### PR TITLE
Time series entry refactor

### DIFF
--- a/libs/backtesting/Security.h
+++ b/libs/backtesting/Security.h
@@ -221,7 +221,7 @@ namespace mkc_timeseries
        * @throws std::out_of_range if the resulting position is outside the time series bounds.
        * @details Delegates to `OHLCTimeSeries::getDateValue`.
        */
-      const boost::gregorian::date&
+      boost::gregorian::date
       getDateValue (const ConstRandomAccessIterator& it, unsigned long offset) const
       {
 	return mSecurityTimeSeries->getDateValue(it, offset); 

--- a/libs/backtesting/TradingPosition.h
+++ b/libs/backtesting/TradingPosition.h
@@ -115,7 +115,7 @@ namespace mkc_timeseries
     ~OpenPositionBar()
       {}
 
-    const boost::gregorian::date& getDate() const
+    boost::gregorian::date getDate() const
     {
       return mEntry.getDateValue();
     }

--- a/libs/timeseries/TimeSeries.h
+++ b/libs/timeseries/TimeSeries.h
@@ -411,7 +411,7 @@ namespace mkc_timeseries
       return (getTimeSeriesEntry (it, offset)->getDate());
     }
 
-    const boost::gregorian::date&
+    boost::gregorian::date
     getDateValue (const ConstRandomAccessIterator& it, unsigned long offset) const
     {
       ValidateVectorOffset(it, offset);      
@@ -795,7 +795,7 @@ namespace mkc_timeseries
     /**
      * @brief Retrieve date value by iterator offset.
      */
-    const boost::gregorian::date& getDateValue(const ConstRandomAccessIterator& it,
+    boost::gregorian::date getDateValue(const ConstRandomAccessIterator& it,
 					       unsigned long offset) const
     {
       return getTimeSeriesEntry(it, offset).getDateValue();

--- a/libs/timeseries/TimeSeriesEntry.h
+++ b/libs/timeseries/TimeSeriesEntry.h
@@ -154,8 +154,6 @@ namespace mkc_timeseries
 			 const Decimal& volumeForEntry,
 			 TimeFrame::Duration timeFrame)
         : mDateTime(entryDateTime),
-	  mDate(entryDateTime.date()),
-	  mTime(entryDateTime.time_of_day()),
           mOpen(open),
           mHigh(high),
           mLow(low),
@@ -218,8 +216,6 @@ namespace mkc_timeseries
 
     OHLCTimeSeriesEntry (const OHLCTimeSeriesEntry<Decimal>& rhs)
       : mDateTime (rhs.mDateTime),
-	mDate(rhs.mDate),
-	mTime(rhs.mTime),
 	mOpen (rhs.mOpen),
 	mHigh (rhs.mHigh),
 	mLow (rhs.mLow),
@@ -235,8 +231,6 @@ namespace mkc_timeseries
 	return *this;
 
       mDateTime = rhs.mDateTime;
-      mDate = rhs.mDate;
-      mTime = rhs.mTime;
       mOpen = rhs.mOpen;
       mHigh = rhs.mHigh;
       mLow = rhs.mLow;
@@ -251,14 +245,14 @@ namespace mkc_timeseries
       return mTimeFrame;
     }
 
-    const boost::gregorian::date& getDateValue() const
+    boost::gregorian::date getDateValue() const
     {
-      return mDate;
+      return mDateTime.date();
     }
 
-    const time_duration& getBarTime() const
+    const time_duration getBarTime() const
     {
-      return mTime;
+      return mDateTime.time_of_day();
     }
 
     const ptime& getDateTime() const
@@ -293,8 +287,6 @@ namespace mkc_timeseries
 
   private:
     ptime mDateTime;
-    boost::gregorian::date mDate;
-    time_duration mTime;
     Decimal mOpen;
     Decimal mHigh;
     Decimal mLow;


### PR DESCRIPTION
Removed unnecessary fields that hold gregorian date and time interval, as they can be retrieved from ptime
Change to OHLCTimeSeriesEntry now requires returning dates by value instead of reference.