### PR TITLE
Don't reseed in test

### DIFF
--- a/libs/timeseries/test/SyntheticTimeSeriesTest.cpp
+++ b/libs/timeseries/test/SyntheticTimeSeriesTest.cpp
@@ -877,13 +877,11 @@ TEST_CASE("Intraday SyntheticTimeSeries: two runs produce different series",
 
     // Act: run #1
     SyntheticTimeSeries<DecimalType> s1(original, tick, tick2);
-    s1.reseedRNG();
     s1.createSyntheticSeries();
     auto out1 = *s1.getSyntheticTimeSeries();
 
     // Act: run #2
     SyntheticTimeSeries<DecimalType> s2(original, tick, tick2);
-    s2.reseedRNG();
     s2.createSyntheticSeries();
     auto out2 = *s2.getSyntheticTimeSeries();
 


### PR DESCRIPTION
Reseeding here actually increases the odds of the same seed being created due to the stack variables.

void SyntheticTimeSeries::reseedRNG() {
  boost::mutex::scoped_lock lock(mMutex);
  // here you construct a brand-new auto_seed_256 temporary…
  randutils::auto_seed_256{}  
  // …and hand it straight to mRandGen.seed()
  mRandGenerator.seed( randutils::auto_seed_256{} );
}

That one-line temporary lives at exactly the same stack address, and (if the two calls happen within the same high-res-clock tick) sees the same timestamp. Since auto_seed_256 mixes in its own address + timestamp + whatever random_device gives it, you end up feeding seed(...) the very same seed sequence twice. Hence s1 and s2 draw identical PCG streams and the test sees no difference.