### PR TITLE
Palsetup intraday

### DIFF
--- a/libs/backtesting/BackTester.h
+++ b/libs/backtesting/BackTester.h
@@ -13,6 +13,7 @@
 #include <map>
 #include <string>
 #include <boost/date_time.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
 #include "number.h"
 #include "BoostDateHelper.h"
 #include "BacktesterStrategy.h"
@@ -809,7 +810,135 @@ namespace mkc_timeseries
 
     TimeSeriesDate next_period(const TimeSeriesDate& d) const
       {
-	return boost_next_week(d);
+        return boost_next_week(d);
+      }
+  };
+
+  //
+  // class IntradayBackTester (stub implementation for testing)
+  //
+
+  template <class Decimal>
+  class IntradayBackTester : public BackTester<Decimal>
+  {
+  public:
+    explicit IntradayBackTester(boost::gregorian::date startDate,
+                               boost::gregorian::date endDate)
+      : BackTester<Decimal>()
+    {
+      if (isWeekend (startDate))
+        startDate = boost_next_weekday (startDate);
+
+      if (isWeekend (endDate))
+        endDate = boost_previous_weekday (endDate);
+
+      DateRange r(startDate, endDate);
+      this->addDateRange(r);
+    }
+
+    // Constructor that accepts ptime arguments (for intraday functionality)
+    explicit IntradayBackTester(boost::posix_time::ptime startTime,
+                               boost::posix_time::ptime endTime)
+      : BackTester<Decimal>()
+    {
+      boost::gregorian::date startDate = startTime.date();
+      boost::gregorian::date endDate = endTime.date();
+      
+      if (isWeekend (startDate))
+        startDate = boost_next_weekday (startDate);
+
+      if (isWeekend (endDate))
+        endDate = boost_previous_weekday (endDate);
+
+      DateRange r(startDate, endDate);
+      this->addDateRange(r);
+    }
+
+    IntradayBackTester() :
+      BackTester<Decimal>()
+    {}
+
+    ~IntradayBackTester()
+    {}
+
+    IntradayBackTester(const IntradayBackTester<Decimal> &rhs)
+      :  BackTester<Decimal>(rhs)
+    {}
+
+    IntradayBackTester<Decimal>&
+    operator=(const IntradayBackTester<Decimal> &rhs)
+    {
+      if (this == &rhs)
+        return *this;
+
+      BackTester<Decimal>::operator=(rhs);
+      return *this;
+    }
+
+    /**
+     * @brief Clone the IntradayBackTester with date ranges, but without strategies.
+     * @note This is a stub implementation for testing purposes.
+     */
+    std::shared_ptr<BackTester<Decimal>> clone() const
+    {
+      auto back = std::make_shared<IntradayBackTester<Decimal>>();
+      auto it = this->beginBacktestDateRange();
+      for (; it != this->endBacktestDateRange(); it++)
+        back->addDateRange(it->second);
+
+      return back;
+    }
+
+    /**
+     * @brief Determines whether this is a backtester that operates
+     * on the daily time frame.
+     * @return `false`
+     */
+    bool isDailyBackTester() const
+    {
+      return false;
+    }
+
+    /**
+     * @brief Determines whether this is a backtester that operates
+     * on the weekly time frame.
+     * @return `false`.
+     */
+    bool isWeeklyBackTester() const
+    {
+      return false;
+    }
+
+    /**
+     * @brief Determines whether this is a backtester that operates
+     * on the monthly time frame.
+     * @return `false`.
+     */
+    bool isMonthlyBackTester() const
+    {
+      return false;
+    }
+
+    /**
+     * @brief Determines whether this is a backtester that operates
+     * on intraday time frames.
+     * @return `true`.
+     */
+    bool isIntradayBackTester() const
+    {
+      return true;
+    }
+
+  protected:
+    // For stub implementation, use daily logic but could be enhanced for intraday periods
+    TimeSeriesDate previous_period(const TimeSeriesDate& d) const
+      {
+        return boost_previous_weekday(d);
+      }
+
+    TimeSeriesDate next_period(const TimeSeriesDate& d) const
+      {
+        return boost_next_weekday(d);
       }
   };
 
@@ -828,9 +957,12 @@ namespace mkc_timeseries
 						   backtestingDates.getLastDate());
 	else if (theTimeFrame == TimeFrame::MONTHLY)
 	  return std::make_shared<MonthlyBackTester<Decimal>>(backtestingDates.getFirstDate(),
-						    backtestingDates.getLastDate());
+	                                    backtestingDates.getLastDate());
+	else if (theTimeFrame == TimeFrame::INTRADAY)
+	  return std::make_shared<IntradayBackTester<Decimal>>(backtestingDates.getFirstDateTime(),
+	                                    backtestingDates.getLastDateTime());
 	else
-	  throw BackTesterException("BackTesterFactory::getBacktester - cannot create backtester for time frame other than daily, weekly or monthly");
+	  throw BackTesterException("BackTesterFactory::getBacktester - cannot create backtester for time frame other than daily, weekly, monthly or intraday");
       }
 
       static std::shared_ptr<BackTester<Decimal>> getBackTester(TimeFrame::Duration theTimeFrame,
@@ -850,9 +982,7 @@ namespace mkc_timeseries
       }
 
     };
+
 }
-
-
-
 
 #endif

--- a/libs/backtesting/SecurityAttributesFactory.h
+++ b/libs/backtesting/SecurityAttributesFactory.h
@@ -287,7 +287,8 @@ namespace mkc_timeseries
 		      boost::gregorian::from_undelimited_string("19930104"));
       addCommonStock (std::string("COST"), std::string("Costco"),
 		      boost::gregorian::from_undelimited_string("19851205"));
-
+      addCommonStock (std::string("APP"), std::string("AppLovin"),
+		      boost::gregorian::from_undelimited_string("20010415"));
     }
 
     /**

--- a/libs/timeseries/TimeFrameUtility.cpp
+++ b/libs/timeseries/TimeFrameUtility.cpp
@@ -15,6 +15,8 @@ namespace mkc_timeseries
     
     if (upperCaseTimeFrameStr == std::string("DAILY"))
       return TimeFrame::DAILY;
+    else if (upperCaseTimeFrameStr == std::string("INTRADAY"))
+      return TimeFrame::INTRADAY;
     else if (upperCaseTimeFrameStr == std::string("WEEKLY"))
       return TimeFrame::WEEKLY;
     else if (upperCaseTimeFrameStr == std::string("MONTHLY"))

--- a/libs/timeseries/TimeSeries.h
+++ b/libs/timeseries/TimeSeries.h
@@ -314,7 +314,7 @@ namespace mkc_timeseries
       auto result = mSortedTimeSeries.emplace(entry->getDateTime(), entry);
       if (!result.second)
       {
-	throw std::domain_error("NumericTimeSeries:addEntry: entry for time already exists");
+ throw std::domain_error("NumericTimeSeries:addEntry: entry for time already exists: " + boost::posix_time::to_simple_string(entry->getDateTime()));
       }
 
       mMapAndArrayInSync = false;

--- a/libs/timeseries/TimeSeriesIndicators.h
+++ b/libs/timeseries/TimeSeriesIndicators.h
@@ -128,7 +128,7 @@ namespace mkc_timeseries
 
 	rocValue = ((currentValue / prevValue) - DecimalConstants<Decimal>::DecimalOne) *
 	  DecimalConstants<Decimal>::DecimalOneHundred;
-	resultSeries.addEntry(NumericTimeSeriesEntry<Decimal> (p->getDate(),
+	resultSeries.addEntry(NumericTimeSeriesEntry<Decimal> (p->getDateTime(),
 							       rocValue,
 							       series.getTimeFrame()));
       }

--- a/src/palsetup/main.cpp
+++ b/src/palsetup/main.cpp
@@ -7,6 +7,7 @@
 #include <limits>         // for numeric_limits
 #include <cctype>         // for std::toupper
 #include <boost/date_time/gregorian/gregorian.hpp>  // for to_iso_string
+#include <boost/date_time/posix_time/posix_time.hpp>  // for ptime formatting
 
 #include "TimeSeriesCsvReader.h"
 #include "TimeSeriesCsvWriter.h"
@@ -28,36 +29,52 @@ void writeConfigFile(const std::string& outputDir,
                      const OHLCTimeSeries<Num>& outOfSampleSeries,
                      const std::string& timeFrame)
 {
-    std::string configFileName = outputDir + "/" + tickerSymbol + "_config.csv";
-    std::ofstream configFile(configFileName);
-    if (!configFile.is_open()) {
-        std::cerr << "Error: Unable to open config file " << configFileName << std::endl;
-        return;
+  std::string configFileName = outputDir + "/" + tickerSymbol + "_config.csv";
+  std::ofstream configFile(configFileName);
+  if (!configFile.is_open())
+    {
+      std::cerr << "Error: Unable to open config file " << configFileName << std::endl;
+      return;
     }
 
-    std::string irPath     = "./" + tickerSymbol + "_IR.txt";
-    std::string dataPath   = "./" + tickerSymbol + "_Data.txt";
-    std::string fileFormat = "PAL";
+  std::string irPath     = "./" + tickerSymbol + "_IR.txt";
+  std::string dataPath   = "./" + tickerSymbol + "_Data.txt";
+  std::string fileFormat = (timeFrame == "Intraday") ? "INTRADAY::TRADESTATION" : "PAL";
 
-    // Dates in YYYYMMDD format
-    std::string isDateStart  = to_iso_string(insampleSeries.getFirstDate());
-    std::string isDateEnd    = to_iso_string(insampleSeries.getLastDate());
-    std::string oosDateStart = to_iso_string(outOfSampleSeries.getFirstDate());
-    std::string oosDateEnd   = to_iso_string(outOfSampleSeries.getLastDate());
+  // Dates in YYYYMMDD format - use DateTime for intraday to preserve time information
+  std::string isDateStart, isDateEnd, oosDateStart, oosDateEnd;
 
-    // Write CSV line: Symbol,IRPath,DataPath,FileFormat,ISDateStart,ISDateEnd,OOSDateStart,OOSDateEnd,TimeFrame
-    configFile << tickerSymbol << ","
-               << irPath       << ","
-               << dataPath     << ","
-               << fileFormat   << ","
-               << isDateStart  << ","
-               << isDateEnd    << ","
-               << oosDateStart << ","
-               << oosDateEnd   << ","
-               << timeFrame    << std::endl;
+  if (timeFrame == "Intraday")
+    {
+      // For intraday data, use full DateTime to avoid overlapping date ranges
+      // Format as YYYYMMDDTHHMMSS for ptime
+      isDateStart  = boost::posix_time::to_iso_string(insampleSeries.getFirstDateTime());
+      isDateEnd    = boost::posix_time::to_iso_string(insampleSeries.getLastDateTime());
+      oosDateStart = boost::posix_time::to_iso_string(outOfSampleSeries.getFirstDateTime());
+      oosDateEnd   = boost::posix_time::to_iso_string(outOfSampleSeries.getLastDateTime());
+    }
+  else
+    {
+      // For EOD data, use Date methods as before
+      isDateStart  = to_iso_string(insampleSeries.getFirstDate());
+      isDateEnd    = to_iso_string(insampleSeries.getLastDate());
+      oosDateStart = to_iso_string(outOfSampleSeries.getFirstDate());
+      oosDateEnd   = to_iso_string(outOfSampleSeries.getLastDate());
+    }
 
-    configFile.close();
-    std::cout << "Configuration file written: " << configFileName << std::endl;
+  // Write CSV line: Symbol,IRPath,DataPath,FileFormat,ISDateStart,ISDateEnd,OOSDateStart,OOSDateEnd,TimeFrame
+  configFile << tickerSymbol << ","
+	     << irPath       << ","
+	     << dataPath     << ","
+	     << fileFormat   << ","
+	     << isDateStart  << ","
+	     << isDateEnd    << ","
+	     << oosDateStart << ","
+	     << oosDateEnd   << ","
+	     << timeFrame    << std::endl;
+
+  configFile.close();
+  std::cout << "Configuration file written: " << configFileName << std::endl;
 }
 
 // Factory for CSV readers using specified time frame
@@ -67,175 +84,275 @@ createTimeSeriesReader(int fileType,
                        const Num& tick,
                        TimeFrame::Duration timeFrame)
 {
-    switch (fileType) {
+  switch (fileType)
+    {
     case 1:
-        return std::make_shared<CSIErrorCheckingFuturesCsvReader<Num>>(fileName,
-                                                                        timeFrame,
-                                                                        TradingVolume::SHARES,
-                                                                        tick);
+      return std::make_shared<CSIErrorCheckingFuturesCsvReader<Num>>(fileName,
+								     timeFrame,
+								     TradingVolume::SHARES,
+								     tick);
     case 2:
-        return std::make_shared<CSIErrorCheckingExtendedFuturesCsvReader<Num>>(fileName,
-                                                                               timeFrame,
-                                                                               TradingVolume::SHARES,
-                                                                               tick);
+      return std::make_shared<CSIErrorCheckingExtendedFuturesCsvReader<Num>>(fileName,
+									     timeFrame,
+									     TradingVolume::SHARES,
+									     tick);
     case 3:
-        return std::make_shared<TradeStationErrorCheckingFormatCsvReader<Num>>(fileName,
-                                                                                timeFrame,
-                                                                                TradingVolume::SHARES,
-                                                                                tick);
+      // Use TradeStationFormatCsvReader for intraday, TradeStationErrorCheckingFormatCsvReader for others
+      if (timeFrame == TimeFrame::INTRADAY)
+        {
+	  return std::make_shared<TradeStationFormatCsvReader<Num>>(fileName,
+								    timeFrame,
+								    TradingVolume::SHARES,
+								    tick);
+        }
+      else
+        {
+	  return std::make_shared<TradeStationErrorCheckingFormatCsvReader<Num>>(fileName,
+										 timeFrame,
+										 TradingVolume::SHARES,
+										 tick);
+        }
     case 4:
-        return std::make_shared<PinnacleErrorCheckingFormatCsvReader<Num>>(fileName,
-                                                                            timeFrame,
-                                                                            TradingVolume::SHARES,
-                                                                            tick);
+      return std::make_shared<PinnacleErrorCheckingFormatCsvReader<Num>>(fileName,
+									 timeFrame,
+									 TradingVolume::SHARES,
+									 tick);
     case 5:
-        return std::make_shared<PALFormatCsvReader<Num>>(fileName,
-                                                           timeFrame,
-                                                           TradingVolume::SHARES,
-                                                           tick);
+      return std::make_shared<PALFormatCsvReader<Num>>(fileName,
+						       timeFrame,
+						       TradingVolume::SHARES,
+						       tick);
     default:
-        throw std::out_of_range("Invalid file type");
+      throw std::out_of_range("Invalid file type");
     }
 }
 
-int main(int argc, char** argv) {
-    if ((argc == 3) || (argc == 4)) {
-        // Command-line args: datafile, file-type, [securityTick]
-        std::string historicDataFileName = argv[1];
-        int fileType = std::stoi(argv[2]);
-        Num securityTick(DecimalConstants<Num>::EquityTick);
-        if (argc == 4)
-            securityTick = Num(std::stof(argv[3]));
+int main(int argc, char** argv)
+{
+  if ((argc == 3) || (argc == 4))
+    {
+      // Command-line args: datafile, file-type, [securityTick]
+      std::string historicDataFileName = argv[1];
+      int fileType = std::stoi(argv[2]);
+      Num securityTick(DecimalConstants<Num>::EquityTick);
+      if (argc == 4)
+	securityTick = Num(std::stof(argv[3]));
 
-        // 1. Read ticker symbol
-        std::string tickerSymbol;
-        std::cout << "Enter ticker symbol: ";
-        std::cin >> tickerSymbol;
-        std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+      // 1. Extract default ticker symbol from filename and read ticker symbol
+      std::string defaultTicker;
+      fs::path filePath(historicDataFileName);
+      std::string baseName = filePath.stem().string(); // Gets filename without extension
+      size_t dotPos = baseName.find('.');
+      if (dotPos != std::string::npos)
+        {
+	  defaultTicker = baseName.substr(0, dotPos);
+        }
+      else
+        {
+	  defaultTicker = baseName;
+        }
 
-        // 2. Read and parse time frame (default Daily)
-        std::string timeFrameStr;
-        TimeFrame::Duration timeFrame;
-        bool validFrame = false;
-        while (!validFrame) {
-            std::cout << "Enter time frame ([D]aily, [W]eekly, [M]onthly, [I]ntraday) [default D]: ";
-            std::string tfInput;
-            std::getline(std::cin, tfInput);
-            if (tfInput.empty()) tfInput = "D";
-            char c = std::toupper(tfInput[0]);
-            switch (c) {
-                case 'D': timeFrameStr = "Daily"; validFrame = true; break;
-                case 'W': timeFrameStr = "Weekly"; validFrame = true; break;
-                case 'M': timeFrameStr = "Monthly"; validFrame = true; break;
-                case 'I': timeFrameStr = "Intraday"; validFrame = true; break;
-                default:
-                    std::cerr << "Invalid time frame. Please enter D, W, M, or I." << std::endl;
+      std::string tickerSymbol;
+      std::cout << "Enter ticker symbol [default " << defaultTicker << "]: ";
+      std::getline(std::cin, tickerSymbol);
+      if (tickerSymbol.empty())
+        {
+	  tickerSymbol = defaultTicker;
+        }
+
+      // 2. Read and parse time frame (default Daily)
+      std::string timeFrameStr;
+      TimeFrame::Duration timeFrame;
+      bool validFrame = false;
+      while (!validFrame)
+        {
+	  std::cout << "Enter time frame ([D]aily, [W]eekly, [M]onthly, [I]ntraday) [default D]: ";
+	  std::string tfInput;
+	  std::getline(std::cin, tfInput);
+	  if (tfInput.empty()) tfInput = "D";
+	  char c = std::toupper(tfInput[0]);
+	  switch (c)
+            {
+	    case 'D': timeFrameStr = "Daily"; validFrame = true; break;
+	    case 'W': timeFrameStr = "Weekly"; validFrame = true; break;
+	    case 'M': timeFrameStr = "Monthly"; validFrame = true; break;
+	    case 'I': timeFrameStr = "Intraday"; validFrame = true; break;
+	    default:
+	      std::cerr << "Invalid time frame. Please enter D, W, M, or I." << std::endl;
             }
         }
-        timeFrame = getTimeFrameFromString(timeFrameStr);
+      timeFrame = getTimeFrameFromString(timeFrameStr);
 
-        // 3. Read and parse reserve percentage (default 5%)
-        double reservedPercent = 5.0;
-        std::cout << "Enter percent of data to reserve (0-100, default 5): ";
-        std::string reservedPercentStr;
-        std::getline(std::cin, reservedPercentStr);
-        if (!reservedPercentStr.empty()) {
-            try {
-                reservedPercent = std::stod(reservedPercentStr);
-            } catch (...) {
-                std::cerr << "Invalid input for reserved percent. Using default 5%." << std::endl;
-                reservedPercent = 5.0;
+      // 3. Read and parse reserve percentage (default 5%)
+      double reservedPercent = 5.0;
+      std::cout << "Enter percent of data to reserve (0-100, default 5): ";
+      std::string reservedPercentStr;
+      std::getline(std::cin, reservedPercentStr);
+      if (!reservedPercentStr.empty())
+        {
+	  try
+            {
+	      reservedPercent = std::stod(reservedPercentStr);
+            }
+	  catch (...)
+            {
+	      std::cerr << "Invalid input for reserved percent. Using default 5%." << std::endl;
+	      reservedPercent = 5.0;
             }
         }
-        reservedPercent = std::clamp(reservedPercent, 0.0, 100.0);
+      reservedPercent = std::clamp(reservedPercent, 0.0, 100.0);
 
-        // 4. Prepare output directories
-        fs::path baseDir = tickerSymbol + "_Validation";
-        if (fs::exists(baseDir))
-            fs::remove_all(baseDir);
-        fs::path palDir = baseDir / "PAL_Files";
-        fs::path valDir = baseDir / "Validation_Files";
-        fs::create_directories(palDir);
-        fs::create_directories(valDir);
+      // 4. Prepare output directories
+      fs::path baseDir = tickerSymbol + "_Validation";
+      if (fs::exists(baseDir))
+	fs::remove_all(baseDir);
+      fs::path palDir = baseDir / "PAL_Files";
+      fs::path valDir = baseDir / "Validation_Files";
+      fs::create_directories(palDir);
+      fs::create_directories(valDir);
 
-        // 5. Create and read time series
-        shared_ptr<TimeSeriesCsvReader<Num>> reader;
-        if (fileType >= 1 && fileType <= 5) {
-            reader = createTimeSeriesReader(fileType,
-                                            historicDataFileName,
-                                            securityTick,
-                                            timeFrame);
-        } else {
-            throw std::out_of_range("Invalid file type");
+      // 5. Create and read time series
+      shared_ptr<TimeSeriesCsvReader<Num>> reader;
+      if (fileType >= 1 && fileType <= 5)
+        {
+	  reader = createTimeSeriesReader(fileType,
+					  historicDataFileName,
+					  securityTick,
+					  timeFrame);
         }
-        reader->readFile();
-        auto aTimeSeries = reader->getTimeSeries();
-
-        // 6. Split into insample, out-of-sample, and reserved (last)
-        size_t totalSize    = aTimeSeries->getNumEntries();
-        size_t reservedSize = static_cast<size_t>(totalSize * (reservedPercent / 100.0));
-        size_t remaining    = totalSize - reservedSize;
-        size_t insampleSize = static_cast<size_t>(remaining * 0.8);
-        size_t oosSize      = remaining - insampleSize;
-
-        OHLCTimeSeries<Num> reservedSeries(aTimeSeries->getTimeFrame(), aTimeSeries->getVolumeUnits());
-        OHLCTimeSeries<Num> insampleSeries(aTimeSeries->getTimeFrame(), aTimeSeries->getVolumeUnits());
-        OHLCTimeSeries<Num> outOfSampleSeries(aTimeSeries->getTimeFrame(), aTimeSeries->getVolumeUnits());
-
-        size_t count = 0;
-        for (auto it = aTimeSeries->beginSortedAccess(); it != aTimeSeries->endSortedAccess(); ++it, ++count) {
-            const auto& entry = *it;
-            if (count < insampleSize)
-                insampleSeries.addEntry(entry);
-            else if (count < insampleSize + oosSize)
-                outOfSampleSeries.addEntry(entry);
-            else
-                reservedSeries.addEntry(entry);
+      else
+        {
+	  throw std::out_of_range("Invalid file type");
         }
 
-        // 7. Insample stop calculation
-        NumericTimeSeries<Num> closingPrices(insampleSeries.CloseTimeSeries());
-        NumericTimeSeries<Num> rocOfClosingPrices(RocSeries(closingPrices, 1));
-        Num medianOfRoc(Median(rocOfClosingPrices));
-        Num robustQn = RobustQn<Num>(rocOfClosingPrices).getRobustQn();
-        Num MAD(MedianAbsoluteDeviation<Num>(rocOfClosingPrices.getTimeSeriesAsVector()));
-        Num StdDev(StandardDeviation<Num>(rocOfClosingPrices.getTimeSeriesAsVector()));
-        Num stopValue = medianOfRoc + robustQn;
+      try
+        {
+	  reader->readFile();
+        }
+      catch (const TimeSeriesException& e)
+        {
+	  std::cerr << "ERROR: Data file contains duplicate timestamps." << std::endl;
+	  std::cerr << "Details: " << e.what() << std::endl;
+	  std::cerr << "Action: Please clean the data file and remove any duplicate entries." << std::endl;
+	  std::cerr << "Note: Pass the above details to your broker's data cleaning team." << std::endl;
+	  return 1;
+        }
+      catch (const TimeSeriesEntryException& e)
+        {
+	  std::cerr << "ERROR: Data file contains invalid OHLC price relationships." << std::endl;
+	  std::cerr << "Details: " << e.what() << std::endl;
+	  std::cerr << "Action: Please check and correct the data file for invalid price entries." << std::endl;
+	  std::cerr << "Note: Pass the above details to your broker's data cleaning team." << std::endl;
+	  return 1;
+        }
+      auto aTimeSeries = reader->getTimeSeries();
 
-        // 8. Generate target/stop files
-        std::ofstream tsFile1((palDir / (tickerSymbol + "_0_5_.TRS")).string());
-        tsFile1 << (stopValue * Num(0.5)) << std::endl << stopValue << std::endl;
-        tsFile1.close();
+      // 6. Split into insample, out-of-sample, and reserved (last)
+      size_t totalSize    = aTimeSeries->getNumEntries();
+      size_t reservedSize = static_cast<size_t>(totalSize * (reservedPercent / 100.0));
+      size_t remaining    = totalSize - reservedSize;
+      size_t insampleSize = static_cast<size_t>(remaining * 0.8);
+      size_t oosSize      = remaining - insampleSize;
 
-        std::ofstream tsFile2((palDir / (tickerSymbol + "_1_0_.TRS")).string());
-        tsFile2 << stopValue << std::endl << stopValue << std::endl;
-        tsFile2.close();
+      OHLCTimeSeries<Num> reservedSeries(aTimeSeries->getTimeFrame(), aTimeSeries->getVolumeUnits());
+      OHLCTimeSeries<Num> insampleSeries(aTimeSeries->getTimeFrame(), aTimeSeries->getVolumeUnits());
+      OHLCTimeSeries<Num> outOfSampleSeries(aTimeSeries->getTimeFrame(), aTimeSeries->getVolumeUnits());
 
-        // 9. Write data files
-        PalTimeSeriesCsvWriter<Num> insampleWriter((palDir / (tickerSymbol + "_IS.txt")).string(), insampleSeries);
-        insampleWriter.writeFile();
-        PalTimeSeriesCsvWriter<Num> allWriter((valDir / (tickerSymbol + "_ALL.txt")).string(), *aTimeSeries);
-        allWriter.writeFile();
-        PalTimeSeriesCsvWriter<Num> oosWriter((valDir / (tickerSymbol + "_OOS.txt")).string(), outOfSampleSeries);
-        oosWriter.writeFile();
-        if (reservedSize > 0) {
-            PalTimeSeriesCsvWriter<Num> reservedWriter((valDir / (tickerSymbol + "_reserved.txt")).string(), reservedSeries);
-            reservedWriter.writeFile();
+      size_t count = 0;
+      for (auto it = aTimeSeries->beginSortedAccess(); it != aTimeSeries->endSortedAccess(); ++it, ++count)
+        {
+	  const auto& entry = *it;
+	  if (count < insampleSize)
+	    insampleSeries.addEntry(entry);
+	  else if (count < insampleSize + oosSize)
+	    outOfSampleSeries.addEntry(entry);
+	  else
+	    reservedSeries.addEntry(entry);
         }
 
-        // 10. Output statistics
-        std::cout << "Reserved% = " << reservedPercent << "%\n";
-        std::cout << "Median = " << medianOfRoc << std::endl;
-        std::cout << "Qn  = " << robustQn << std::endl;
-        std::cout << "MAD = " << MAD << std::endl;
-        std::cout << "Std = " << StdDev << std::endl;
-        std::cout << "Stop = " << stopValue << std::endl;
+      // 7. Insample stop calculation
+      Num stopValue;
+      Num medianOfRoc;
+      Num robustQn;
+      Num MAD;
+      Num StdDev;
+        
+      try
+        {
+	  NumericTimeSeries<Num> closingPrices(insampleSeries.CloseTimeSeries());
+	  NumericTimeSeries<Num> rocOfClosingPrices(RocSeries(closingPrices, 1));
+	  medianOfRoc = Median(rocOfClosingPrices);
+	  robustQn = RobustQn<Num>(rocOfClosingPrices).getRobustQn();
+	  MAD = MedianAbsoluteDeviation<Num>(rocOfClosingPrices.getTimeSeriesAsVector());
+	  StdDev = StandardDeviation<Num>(rocOfClosingPrices.getTimeSeriesAsVector());
+	  stopValue = medianOfRoc + robustQn;
+        }
+      catch (const std::domain_error& e)
+        {
+	  std::cerr << "ERROR: Intraday data contains duplicate timestamps preventing stop calculation." << std::endl;
+	  std::cerr << "Details: " << e.what() << std::endl;
+	  std::cerr << "Cause: NumericTimeSeries cannot handle multiple intraday bars with identical timestamps." << std::endl;
+	  std::cerr << "Action: Clean the intraday data to ensure unique timestamps for each bar." << std::endl;
+	  std::cerr << "Note: Pass the above details to your broker's data cleaning team." << std::endl;
+	  return 1;
+        }
 
-        // 11. Write configuration file
-        writeConfigFile(valDir.string(), tickerSymbol, insampleSeries, outOfSampleSeries, timeFrameStr);
+      // 8. Generate target/stop files
+      std::ofstream tsFile1((palDir / (tickerSymbol + "_0_5_.TRS")).string());
+      tsFile1 << (stopValue * Num(0.5)) << std::endl << stopValue << std::endl;
+      tsFile1.close();
 
-    } else {
-        std::cout << "Usage (beta):: PalSetup datafile file-type (1=CSI,2=CSI Ext,3=TradeStation,4=Pinnacle,5=PAL) [tick]" << std::endl;
+      std::ofstream tsFile2((palDir / (tickerSymbol + "_1_0_.TRS")).string());
+      tsFile2 << stopValue << std::endl << stopValue << std::endl;
+      tsFile2.close();
+
+      // 9. Write data files
+      if (timeFrameStr == "Intraday")
+        {
+	  // For intraday: insample uses PAL intraday format, validation files use TradeStation intraday format
+	  PalIntradayCsvWriter<Num> insampleWriter((palDir / (tickerSymbol + "_IS.txt")).string(), insampleSeries);
+	  insampleWriter.writeFile();
+	  TradeStationIntradayCsvWriter<Num> allWriter((valDir / (tickerSymbol + "_ALL.txt")).string(), *aTimeSeries);
+	  allWriter.writeFile();
+	  TradeStationIntradayCsvWriter<Num> oosWriter((valDir / (tickerSymbol + "_OOS.txt")).string(), outOfSampleSeries);
+	  oosWriter.writeFile();
+	  if (reservedSize > 0)
+            {
+	      TradeStationIntradayCsvWriter<Num> reservedWriter((valDir / (tickerSymbol + "_reserved.txt")).string(), reservedSeries);
+	      reservedWriter.writeFile();
+            }
+        }
+      else
+        {
+	  // For non-intraday: all files use standard PAL EOD format
+	  PalTimeSeriesCsvWriter<Num> insampleWriter((palDir / (tickerSymbol + "_IS.txt")).string(), insampleSeries);
+	  insampleWriter.writeFile();
+	  PalTimeSeriesCsvWriter<Num> allWriter((valDir / (tickerSymbol + "_ALL.txt")).string(), *aTimeSeries);
+	  allWriter.writeFile();
+	  PalTimeSeriesCsvWriter<Num> oosWriter((valDir / (tickerSymbol + "_OOS.txt")).string(), outOfSampleSeries);
+	  oosWriter.writeFile();
+	  if (reservedSize > 0)
+            {
+	      PalTimeSeriesCsvWriter<Num> reservedWriter((valDir / (tickerSymbol + "_reserved.txt")).string(), reservedSeries);
+	      reservedWriter.writeFile();
+            }
+        }
+
+      // 10. Output statistics
+      std::cout << "Reserved% = " << reservedPercent << "%\n";
+      std::cout << "Median = " << medianOfRoc << std::endl;
+      std::cout << "Qn  = " << robustQn << std::endl;
+      std::cout << "MAD = " << MAD << std::endl;
+      std::cout << "Std = " << StdDev << std::endl;
+      std::cout << "Stop = " << stopValue << std::endl;
+
+      // 11. Write configuration file
+      writeConfigFile(valDir.string(), tickerSymbol, insampleSeries, outOfSampleSeries, timeFrameStr);
+
     }
-    return 0;
+  else
+    {
+      std::cout << "Usage (beta):: PalSetup datafile file-type (1=CSI,2=CSI Ext,3=TradeStation,4=Pinnacle,5=PAL) [tick]" << std::endl;
+    }
+  return 0;
 }

--- a/src/palsetup/main.cpp
+++ b/src/palsetup/main.cpp
@@ -29,7 +29,7 @@ void writeConfigFile(const std::string& outputDir,
                      const OHLCTimeSeries<Num>& outOfSampleSeries,
                      const std::string& timeFrame)
 {
-  std::string configFileName = outputDir + "/" + tickerSymbol + "_config.csv";
+  fs::path configFileName = fs::path(outputDir) / (tickerSymbol + "_config.csv");
   std::ofstream configFile(configFileName);
   if (!configFile.is_open())
     {

--- a/src/palvalidator/ValidatorConfiguration.cpp
+++ b/src/palvalidator/ValidatorConfiguration.cpp
@@ -144,6 +144,9 @@ namespace mkc_timeseries
     else if (upperCaseFormatStr == std::string("TRADESTATION"))
             return std::make_shared<TradeStationFormatCsvReader<Decimal>>(historicDataFilePath, timeFrame,
 									  unitsOfVolume, tickValue);
+    else if (upperCaseFormatStr == std::string("INTRADAY::TRADESTATION"))
+            return std::make_shared<TradeStationFormatCsvReader<Decimal>>(historicDataFilePath, timeFrame,
+									  unitsOfVolume, tickValue);
     else if (upperCaseFormatStr == std::string("CSIEXTENDED"))
             return std::make_shared<CSIExtendedFuturesCsvReader<Decimal>>(historicDataFilePath, timeFrame,
 									  unitsOfVolume, tickValue);

--- a/src/palvalidator/ValidatorConfiguration.cpp
+++ b/src/palvalidator/ValidatorConfiguration.cpp
@@ -6,6 +6,8 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include "csv.h"
 #include "ValidatorConfiguration.h"
 #include "PalParseDriver.h"
 #include "TimeFrameUtility.h"
@@ -42,10 +44,28 @@ namespace mkc_timeseries
 
   std::shared_ptr<ValidatorConfiguration<Decimal>> ValidatorConfigurationFileReader::readConfigurationFile()
   {
+    // Check if the file has a header row by reading the first line
+    io::CSVReader<9> csvConfigFileCheck(mConfigurationFileName.c_str());
+    char* firstLine = csvConfigFileCheck.next_line();
+    bool hasHeader = false;
+    if (firstLine) {
+        std::string firstLineStr(firstLine);
+        // Check if first line contains header keywords
+        hasHeader = (firstLineStr.find("Symbol") != std::string::npos &&
+                    firstLineStr.find("IRPath") != std::string::npos &&
+                    firstLineStr.find("DataPath") != std::string::npos);
+    }
+    
+    // Create the main CSV reader
     io::CSVReader<9> csvConfigFile(mConfigurationFileName.c_str());
-
-    csvConfigFile.set_header("Symbol", "IRPath", "DataPath","FileFormat","ISDateStart",
-			     "ISDateEnd", "OOSDateStart", "OOSDateEnd", "TimeFrame");
+    
+    if (hasHeader) {
+        csvConfigFile.read_header(io::ignore_no_column, "Symbol", "IRPath", "DataPath","FileFormat","ISDateStart",
+                     "ISDateEnd", "OOSDateStart", "OOSDateEnd", "TimeFrame");
+    } else {
+        csvConfigFile.set_header("Symbol", "IRPath", "DataPath","FileFormat","ISDateStart",
+                     "ISDateEnd", "OOSDateStart", "OOSDateEnd", "TimeFrame");
+    }
 
     std::string tickerSymbol, palIRFilePathStr, historicDataFilePathStr, historicDataFormatStr;
     std::string inSampleStartDate, inSampleEndDate, oosStartDate, oosEndDate;
@@ -54,17 +74,54 @@ namespace mkc_timeseries
     boost::gregorian::date insampleDateStart, insampleDateEnd, oosDateStart, oosDateEnd;
 
     csvConfigFile.read_row (tickerSymbol, palIRFilePathStr, historicDataFilePathStr,
-			    historicDataFormatStr, inSampleStartDate, inSampleEndDate,
-			    oosStartDate, oosEndDate, timeFrameStr);
+       historicDataFormatStr, inSampleStartDate, inSampleEndDate,
+       oosStartDate, oosEndDate, timeFrameStr);
 
 
-    insampleDateStart = boost::gregorian::from_undelimited_string(inSampleStartDate);
-    insampleDateEnd = boost::gregorian::from_undelimited_string(inSampleEndDate);
+    // Parse dates - handle both YYYYMMDD (gregorian) and YYYYMMDDTHHMMSS (ptime) formats
+    // Enforce format consistency - all dates must use the same format
+    bool isInSamplePtimeFormat = (inSampleStartDate.length() > 8 || inSampleEndDate.length() > 8);
+    bool isOosPtimeFormat = (oosStartDate.length() > 8 || oosEndDate.length() > 8);
+    
+    // Check for format consistency
+    if (isInSamplePtimeFormat != isOosPtimeFormat) {
+        throw ValidatorConfigurationException("ValidatorConfigurationFileReader::readConfigurationFile - Date format inconsistency: all dates must use either YYYYMMDD or YYYYMMDDTHHMMSS format");
+    }
+    
+    // Check that within each date range, both dates use the same format
+    if ((inSampleStartDate.length() > 8) != (inSampleEndDate.length() > 8)) {
+        throw ValidatorConfigurationException("ValidatorConfigurationFileReader::readConfigurationFile - In-sample date format inconsistency: start and end dates must use the same format");
+    }
+    
+    if ((oosStartDate.length() > 8) != (oosEndDate.length() > 8)) {
+        throw ValidatorConfigurationException("ValidatorConfigurationFileReader::readConfigurationFile - Out-of-sample date format inconsistency: start and end dates must use the same format");
+    }
+    
+    if (isInSamplePtimeFormat) {
+        // ptime format (YYYYMMDDTHHMMSS) - extract date portion for DateRange
+        boost::posix_time::ptime ptimeStart = boost::posix_time::from_iso_string(inSampleStartDate);
+        boost::posix_time::ptime ptimeEnd = boost::posix_time::from_iso_string(inSampleEndDate);
+        insampleDateStart = ptimeStart.date();
+        insampleDateEnd = ptimeEnd.date();
+    } else {
+        // gregorian format (YYYYMMDD)
+        insampleDateStart = boost::gregorian::from_undelimited_string(inSampleStartDate);
+        insampleDateEnd = boost::gregorian::from_undelimited_string(inSampleEndDate);
+    }
 
     DateRange inSampleDates(insampleDateStart, insampleDateEnd);
 
-    oosDateStart = boost::gregorian::from_undelimited_string(oosStartDate);
-    oosDateEnd = boost::gregorian::from_undelimited_string(oosEndDate);
+    if (isOosPtimeFormat) {
+        // ptime format (YYYYMMDDTHHMMSS) - extract date portion for DateRange
+        boost::posix_time::ptime ptimeStart = boost::posix_time::from_iso_string(oosStartDate);
+        boost::posix_time::ptime ptimeEnd = boost::posix_time::from_iso_string(oosEndDate);
+        oosDateStart = ptimeStart.date();
+        oosDateEnd = ptimeEnd.date();
+    } else {
+        // gregorian format (YYYYMMDD)
+        oosDateStart = boost::gregorian::from_undelimited_string(oosStartDate);
+        oosDateEnd = boost::gregorian::from_undelimited_string(oosEndDate);
+    }
 
     DateRange ooSampleDates( oosDateStart, oosDateEnd);
 
@@ -85,9 +142,9 @@ namespace mkc_timeseries
     TimeFrame::Duration backTestingTimeFrame = getTimeFrameFromString(timeFrameStr);
 
     std::shared_ptr<TimeSeriesCsvReader<Decimal>> reader = getHistoricDataFileReader(tickerSymbol,
-										     historicDataFilePathStr,
-										     historicDataFormatStr,
-										     backTestingTimeFrame);
+    						     historicDataFilePathStr,
+    						     historicDataFormatStr,
+    						     backTestingTimeFrame);
 
     reader->readFile();
 

--- a/src/palvalidator/test/ValidatorConfigurationTest.cpp
+++ b/src/palvalidator/test/ValidatorConfigurationTest.cpp
@@ -62,22 +62,22 @@ TEST_CASE("Intraday date parsing - ptime format", "[ValidatorConfiguration][Intr
         
         // Create minimal test files to satisfy file existence checks
         std::ofstream irFile("./test_ir.txt");
-        irFile << "Code For Selected Patterns\n";
-        irFile << "----------------------------------------------------------------------------------------------------------------------------------\n";
-        irFile << "\n";
-        irFile << "{File:test_data.txt  Index:1  Index Date:20210415  PL:80.00%  PS:20%  Trades:10  CL:1}\n";
-        irFile << "\n";
-        irFile << "IF CLOSE OF 0 BARS AGO > OPEN OF 0 BARS AGO\n";
-        irFile << "THEN BUY NEXT BAR ON THE OPEN WITH\n";
-        irFile << "PROFIT TARGET AT ENTRY PRICE + 1.0 %\n";
-        irFile << "AND STOP LOSS AT ENTRY PRICE - 1.0 %\n";
-        irFile << "----------------------------------------------------------------------------------------------------------------------------------\n";
+        irFile << "Code For Selected Patterns" << std::endl;
+        irFile << "----------------------------------------------------------------------------------------------------------------------------------" << std::endl;
+        irFile << "" << std::endl;
+        irFile << "{File:test_data.txt  Index:1  Index Date:20210415  PL:80.00%  PS:20%  Trades:10  CL:1}" << std::endl;
+        irFile << "" << std::endl;
+        irFile << "IF CLOSE OF 0 BARS AGO > OPEN OF 0 BARS AGO" << std::endl;
+        irFile << "THEN BUY NEXT BAR ON THE OPEN WITH" << std::endl;
+        irFile << "PROFIT TARGET AT ENTRY PRICE + 1.0 %" << std::endl;
+        irFile << "AND STOP LOSS AT ENTRY PRICE - 1.0 %" << std::endl;
+        irFile << "----------------------------------------------------------------------------------------------------------------------------------" << std::endl;
         irFile.close();
         
         std::ofstream dataFile("./test_data.txt");
-        dataFile << "Date,Time,Open,High,Low,Close,Up,Down\n";
-        dataFile << "04/15/2021,09:30:00,130.00,131.00,129.50,130.50,1000,500\n";
-        dataFile << "04/15/2021,09:31:00,130.50,131.25,130.00,131.00,1500,800\n";
+        dataFile << "Date,Time,Open,High,Low,Close,Up,Down" << std::endl;
+        dataFile << "04/15/2021,09:30:00,130.00,131.00,129.50,130.50,1000,500" << std::endl;
+        dataFile << "04/15/2021,09:31:00,130.50,131.25,130.00,131.00,1500,800" << std::endl;
         dataFile.close();
         
         ValidatorConfigurationFileReader reader("test_intraday_config.csv");
@@ -126,21 +126,21 @@ TEST_CASE("EOD date parsing - gregorian format", "[ValidatorConfiguration][EOD]"
         
         // Create minimal test files
         std::ofstream irFile("./test_ir.txt");
-        irFile << "Code For Selected Patterns\n";
-        irFile << "----------------------------------------------------------------------------------------------------------------------------------\n";
-        irFile << "\n";
-        irFile << "{File:test_data.txt  Index:1  Index Date:20210415  PL:80.00%  PS:20%  Trades:10  CL:1}\n";
-        irFile << "\n";
-        irFile << "IF CLOSE OF 0 BARS AGO > OPEN OF 0 BARS AGO\n";
-        irFile << "THEN BUY NEXT BAR ON THE OPEN WITH\n";
-        irFile << "PROFIT TARGET AT ENTRY PRICE + 1.0 %\n";
-        irFile << "AND STOP LOSS AT ENTRY PRICE - 1.0 %\n";
-        irFile << "----------------------------------------------------------------------------------------------------------------------------------\n";
+        irFile << "Code For Selected Patterns" << std::endl;
+        irFile << "----------------------------------------------------------------------------------------------------------------------------------" << std::endl;
+        irFile << "" << std::endl;
+        irFile << "{File:test_data.txt  Index:1  Index Date:20210415  PL:80.00%  PS:20%  Trades:10  CL:1}" << std::endl;
+        irFile << "" << std::endl;
+        irFile << "IF CLOSE OF 0 BARS AGO > OPEN OF 0 BARS AGO" << std::endl;
+        irFile << "THEN BUY NEXT BAR ON THE OPEN WITH" << std::endl;
+        irFile << "PROFIT TARGET AT ENTRY PRICE + 1.0 %" << std::endl;
+        irFile << "AND STOP LOSS AT ENTRY PRICE - 1.0 %" << std::endl;
+        irFile << "----------------------------------------------------------------------------------------------------------------------------------" << std::endl;
         irFile.close();
         
         std::ofstream dataFile("./test_data.txt");
-        dataFile << "20210415,400.0000000,401.0000000,399.5000000,400.5000000\n";
-        dataFile << "20210416,400.5000000,402.0000000,400.0000000,401.2500000\n";
+        dataFile << "20210415,400.0000000,401.0000000,399.5000000,400.5000000" << std::endl;
+        dataFile << "20210416,400.5000000,402.0000000,400.0000000,401.2500000" << std::endl;
         dataFile.close();
         
         ValidatorConfigurationFileReader reader("test_eod_config.csv");
@@ -189,22 +189,22 @@ TEST_CASE("Intraday format reader selection", "[ValidatorConfiguration][FormatRe
         
         // Create minimal test files
         std::ofstream irFile("./test_ir.txt");
-        irFile << "Code For Selected Patterns\n";
-        irFile << "----------------------------------------------------------------------------------------------------------------------------------\n";
-        irFile << "\n";
-        irFile << "{File:test_data.txt  Index:1  Index Date:20210415  PL:80.00%  PS:20%  Trades:10  CL:1}\n";
-        irFile << "\n";
-        irFile << "IF CLOSE OF 0 BARS AGO > OPEN OF 0 BARS AGO\n";
-        irFile << "THEN BUY NEXT BAR ON THE OPEN WITH\n";
-        irFile << "PROFIT TARGET AT ENTRY PRICE + 1.0 %\n";
-        irFile << "AND STOP LOSS AT ENTRY PRICE - 1.0 %\n";
-        irFile << "----------------------------------------------------------------------------------------------------------------------------------\n";
+        irFile << "Code For Selected Patterns" << std::endl;
+        irFile << "----------------------------------------------------------------------------------------------------------------------------------" << std::endl;
+        irFile << "" << std::endl;
+        irFile << "{File:test_data.txt  Index:1  Index Date:20210415  PL:80.00%  PS:20%  Trades:10  CL:1}" << std::endl;
+        irFile << "" << std::endl;
+        irFile << "IF CLOSE OF 0 BARS AGO > OPEN OF 0 BARS AGO" << std::endl;
+        irFile << "THEN BUY NEXT BAR ON THE OPEN WITH" << std::endl;
+        irFile << "PROFIT TARGET AT ENTRY PRICE + 1.0 %" << std::endl;
+        irFile << "AND STOP LOSS AT ENTRY PRICE - 1.0 %" << std::endl;
+        irFile << "----------------------------------------------------------------------------------------------------------------------------------" << std::endl;
         irFile.close();
         
         std::ofstream dataFile("./test_data.txt");
-        dataFile << "Date,Time,Open,High,Low,Close,Up,Down\n";
-        dataFile << "04/15/2021,09:30:00,350.00,351.00,349.50,350.50,10000,5000\n";
-        dataFile << "04/15/2021,09:31:00,350.50,351.25,350.00,351.00,15000,8000\n";
+        dataFile << "Date,Time,Open,High,Low,Close,Up,Down" << std::endl;
+        dataFile << "04/15/2021,09:30:00,350.00,351.00,349.50,350.50,10000,5000" << std::endl;
+        dataFile << "04/15/2021,09:31:00,350.50,351.25,350.00,351.00,15000,8000" << std::endl;
         dataFile.close();
         
         ValidatorConfigurationFileReader reader("test_format_config.csv");
@@ -245,21 +245,21 @@ TEST_CASE("Date overlap validation", "[ValidatorConfiguration][Validation]")
         
         // Create minimal test files
         std::ofstream irFile("./test_ir.txt");
-        irFile << "Code For Selected Patterns\n";
-        irFile << "----------------------------------------------------------------------------------------------------------------------------------\n";
-        irFile << "\n";
-        irFile << "{File:test_data.txt  Index:1  Index Date:20210415  PL:80.00%  PS:20%  Trades:10  CL:1}\n";
-        irFile << "\n";
-        irFile << "IF CLOSE OF 0 BARS AGO > OPEN OF 0 BARS AGO\n";
-        irFile << "THEN BUY NEXT BAR ON THE OPEN WITH\n";
-        irFile << "PROFIT TARGET AT ENTRY PRICE + 1.0 %\n";
-        irFile << "AND STOP LOSS AT ENTRY PRICE - 1.0 %\n";
-        irFile << "----------------------------------------------------------------------------------------------------------------------------------\n";
+        irFile << "Code For Selected Patterns" << std::endl;
+        irFile << "----------------------------------------------------------------------------------------------------------------------------------" << std::endl;
+        irFile << "" << std::endl;
+        irFile << "{File:test_data.txt  Index:1  Index Date:20210415  PL:80.00%  PS:20%  Trades:10  CL:1}" << std::endl;
+        irFile << "" << std::endl;
+        irFile << "IF CLOSE OF 0 BARS AGO > OPEN OF 0 BARS AGO" << std::endl;
+        irFile << "THEN BUY NEXT BAR ON THE OPEN WITH" << std::endl;
+        irFile << "PROFIT TARGET AT ENTRY PRICE + 1.0 %" << std::endl;
+        irFile << "AND STOP LOSS AT ENTRY PRICE - 1.0 %" << std::endl;
+        irFile << "----------------------------------------------------------------------------------------------------------------------------------" << std::endl;
         irFile.close();
         
         std::ofstream dataFile("./test_data.txt");
-        dataFile << "Date,Time,Open,High,Low,Close,Up,Down\n";
-        dataFile << "04/15/2021,09:30:00,250.00,251.00,249.50,250.50,5000,2500\n";
+        dataFile << "Date,Time,Open,High,Low,Close,Up,Down" << std::endl;
+        dataFile << "04/15/2021,09:30:00,250.00,251.00,249.50,250.50,5000,2500" << std::endl;
         dataFile.close();
         
         ValidatorConfigurationFileReader reader("test_overlap_config.csv");
@@ -289,21 +289,21 @@ TEST_CASE("Date format consistency validation", "[ValidatorConfiguration][Format
         
         // Create minimal test files
         std::ofstream irFile("./test_ir.txt");
-        irFile << "Code For Selected Patterns\n";
-        irFile << "----------------------------------------------------------------------------------------------------------------------------------\n";
-        irFile << "\n";
-        irFile << "{File:test_data.txt  Index:1  Index Date:20210415  PL:80.00%  PS:20%  Trades:10  CL:1}\n";
-        irFile << "\n";
-        irFile << "IF CLOSE OF 0 BARS AGO > OPEN OF 0 BARS AGO\n";
-        irFile << "THEN BUY NEXT BAR ON THE OPEN WITH\n";
-        irFile << "PROFIT TARGET AT ENTRY PRICE + 1.0 %\n";
-        irFile << "AND STOP LOSS AT ENTRY PRICE - 1.0 %\n";
-        irFile << "----------------------------------------------------------------------------------------------------------------------------------\n";
+        irFile << "Code For Selected Patterns" << std::endl;
+        irFile << "----------------------------------------------------------------------------------------------------------------------------------" << std::endl;
+        irFile << "" << std::endl;
+        irFile << "{File:test_data.txt  Index:1  Index Date:20210415  PL:80.00%  PS:20%  Trades:10  CL:1}" << std::endl;
+        irFile << "" << std::endl;
+        irFile << "IF CLOSE OF 0 BARS AGO > OPEN OF 0 BARS AGO" << std::endl;
+        irFile << "THEN BUY NEXT BAR ON THE OPEN WITH" << std::endl;
+        irFile << "PROFIT TARGET AT ENTRY PRICE + 1.0 %" << std::endl;
+        irFile << "AND STOP LOSS AT ENTRY PRICE - 1.0 %" << std::endl;
+        irFile << "----------------------------------------------------------------------------------------------------------------------------------" << std::endl;
         irFile.close();
         
         std::ofstream dataFile("./test_data.txt");
-        dataFile << "Date,Time,Open,High,Low,Close,Up,Down\n";
-        dataFile << "04/15/2021,09:30:00,700.00,701.00,699.50,700.50,8000,4000\n";
+        dataFile << "Date,Time,Open,High,Low,Close,Up,Down" << std::endl;
+        dataFile << "04/15/2021,09:30:00,700.00,701.00,699.50,700.50,8000,4000" << std::endl;
         dataFile.close();
         
         ValidatorConfigurationFileReader reader("test_inconsistent_config.csv");

--- a/src/palvalidator/test/ValidatorConfigurationTest.cpp
+++ b/src/palvalidator/test/ValidatorConfigurationTest.cpp
@@ -1,9 +1,12 @@
 #include <catch2/catch_test_macros.hpp>
 #include "ValidatorConfiguration.h"
 #include "TestUtils.h"
+#include <fstream>
+#include <boost/date_time/posix_time/posix_time.hpp>
 
 using namespace mkc_timeseries;
 using namespace boost::gregorian;
+using namespace boost::posix_time;
 
 
 TEST_CASE ("Security operations", "[Security]")
@@ -42,4 +45,275 @@ TEST_CASE ("Security operations", "[Security]")
   REQUIRE (oosBackTester->numBackTestRanges() == 1);
   REQUIRE (oosBackTester->getStartDate() == oosFirstDate);
   REQUIRE (oosBackTester->getEndDate() == oosLastDate);
+}
+
+TEST_CASE("Intraday date parsing - ptime format", "[ValidatorConfiguration][Intraday]")
+{
+    SECTION("Parse intraday ptime dates correctly")
+    {
+        // Create a temporary config file with intraday ptime format dates
+        std::string configContent =
+            "Symbol,IRPath,DataPath,FileFormat,ISDateStart,ISDateEnd,OOSDateStart,OOSDateEnd,TimeFrame\n"
+            "AAPL,./test_ir.txt,./test_data.txt,INTRADAY::TRADESTATION,20210415T093000,20240604T160000,20240605T093000,20250320T160000,Intraday\n";
+        
+        std::ofstream configFile("test_intraday_config.csv");
+        configFile << configContent;
+        configFile.close();
+        
+        // Create minimal test files to satisfy file existence checks
+        std::ofstream irFile("./test_ir.txt");
+        irFile << "Code For Selected Patterns\n";
+        irFile << "----------------------------------------------------------------------------------------------------------------------------------\n";
+        irFile << "\n";
+        irFile << "{File:test_data.txt  Index:1  Index Date:20210415  PL:80.00%  PS:20%  Trades:10  CL:1}\n";
+        irFile << "\n";
+        irFile << "IF CLOSE OF 0 BARS AGO > OPEN OF 0 BARS AGO\n";
+        irFile << "THEN BUY NEXT BAR ON THE OPEN WITH\n";
+        irFile << "PROFIT TARGET AT ENTRY PRICE + 1.0 %\n";
+        irFile << "AND STOP LOSS AT ENTRY PRICE - 1.0 %\n";
+        irFile << "----------------------------------------------------------------------------------------------------------------------------------\n";
+        irFile.close();
+        
+        std::ofstream dataFile("./test_data.txt");
+        dataFile << "Date,Time,Open,High,Low,Close,Up,Down\n";
+        dataFile << "04/15/2021,09:30:00,130.00,131.00,129.50,130.50,1000,500\n";
+        dataFile << "04/15/2021,09:31:00,130.50,131.25,130.00,131.00,1500,800\n";
+        dataFile.close();
+        
+        ValidatorConfigurationFileReader reader("test_intraday_config.csv");
+        
+        REQUIRE_NOTHROW([&]() {
+            auto config = reader.readConfigurationFile();
+            
+            // Verify date ranges are parsed correctly from ptime format
+            DateRange inSampleRange = config->getInsampleDateRange();
+            DateRange oosRange = config->getOosDateRange();
+            
+            // Expected dates extracted from ptime strings
+            date expectedISStart = date(2021, 4, 15);  // From 20210415T093000
+            date expectedISEnd = date(2024, 6, 4);     // From 20240604T160000
+            date expectedOOSStart = date(2024, 6, 5);  // From 20240605T093000
+            date expectedOOSEnd = date(2025, 3, 20);   // From 20250320T160000
+            
+            REQUIRE(inSampleRange.getFirstDate() == expectedISStart);
+            REQUIRE(inSampleRange.getLastDate() == expectedISEnd);
+            REQUIRE(oosRange.getFirstDate() == expectedOOSStart);
+            REQUIRE(oosRange.getLastDate() == expectedOOSEnd);
+            
+            // Verify no overlap between in-sample and out-of-sample
+            REQUIRE(oosRange.getFirstDate() > inSampleRange.getLastDate());
+        }());
+        
+        // Cleanup
+        std::remove("test_intraday_config.csv");
+        std::remove("./test_ir.txt");
+        std::remove("./test_data.txt");
+    }
+}
+
+TEST_CASE("EOD date parsing - gregorian format", "[ValidatorConfiguration][EOD]")
+{
+    SECTION("Parse EOD gregorian dates correctly")
+    {
+        // Create a temporary config file with EOD gregorian format dates
+        std::string configContent =
+            "Symbol,IRPath,DataPath,FileFormat,ISDateStart,ISDateEnd,OOSDateStart,OOSDateEnd,TimeFrame\n"
+            "SPY,./test_ir.txt,./test_data.txt,PAL,20210415,20240604,20240605,20250320,Daily\n";
+        
+        std::ofstream configFile("test_eod_config.csv");
+        configFile << configContent;
+        configFile.close();
+        
+        // Create minimal test files
+        std::ofstream irFile("./test_ir.txt");
+        irFile << "Code For Selected Patterns\n";
+        irFile << "----------------------------------------------------------------------------------------------------------------------------------\n";
+        irFile << "\n";
+        irFile << "{File:test_data.txt  Index:1  Index Date:20210415  PL:80.00%  PS:20%  Trades:10  CL:1}\n";
+        irFile << "\n";
+        irFile << "IF CLOSE OF 0 BARS AGO > OPEN OF 0 BARS AGO\n";
+        irFile << "THEN BUY NEXT BAR ON THE OPEN WITH\n";
+        irFile << "PROFIT TARGET AT ENTRY PRICE + 1.0 %\n";
+        irFile << "AND STOP LOSS AT ENTRY PRICE - 1.0 %\n";
+        irFile << "----------------------------------------------------------------------------------------------------------------------------------\n";
+        irFile.close();
+        
+        std::ofstream dataFile("./test_data.txt");
+        dataFile << "20210415,400.0000000,401.0000000,399.5000000,400.5000000\n";
+        dataFile << "20210416,400.5000000,402.0000000,400.0000000,401.2500000\n";
+        dataFile.close();
+        
+        ValidatorConfigurationFileReader reader("test_eod_config.csv");
+        
+        REQUIRE_NOTHROW([&]() {
+            auto config = reader.readConfigurationFile();
+            
+            // Verify date ranges are parsed correctly from gregorian format
+            DateRange inSampleRange = config->getInsampleDateRange();
+            DateRange oosRange = config->getOosDateRange();
+            
+            // Expected dates from gregorian strings
+            date expectedISStart = date(2021, 4, 15);  // From 20210415
+            date expectedISEnd = date(2024, 6, 4);     // From 20240604
+            date expectedOOSStart = date(2024, 6, 5);  // From 20240605
+            date expectedOOSEnd = date(2025, 3, 20);   // From 20250320
+            
+            REQUIRE(inSampleRange.getFirstDate() == expectedISStart);
+            REQUIRE(inSampleRange.getLastDate() == expectedISEnd);
+            REQUIRE(oosRange.getFirstDate() == expectedOOSStart);
+            REQUIRE(oosRange.getLastDate() == expectedOOSEnd);
+            
+            // Verify no overlap between in-sample and out-of-sample
+            REQUIRE(oosRange.getFirstDate() > inSampleRange.getLastDate());
+        }());
+        
+        // Cleanup
+        std::remove("test_eod_config.csv");
+        std::remove("./test_ir.txt");
+        std::remove("./test_data.txt");
+    }
+}
+
+TEST_CASE("Intraday format reader selection", "[ValidatorConfiguration][FormatReader]")
+{
+    SECTION("INTRADAY::TRADESTATION format creates correct reader")
+    {
+        // Create a temporary config file with intraday format
+        std::string configContent =
+            "Symbol,IRPath,DataPath,FileFormat,ISDateStart,ISDateEnd,OOSDateStart,OOSDateEnd,TimeFrame\n"
+            "QQQ,./test_ir.txt,./test_data.txt,INTRADAY::TRADESTATION,20210415T093000,20240604T160000,20240605T093000,20250320T160000,Intraday\n";
+        
+        std::ofstream configFile("test_format_config.csv");
+        configFile << configContent;
+        configFile.close();
+        
+        // Create minimal test files
+        std::ofstream irFile("./test_ir.txt");
+        irFile << "Code For Selected Patterns\n";
+        irFile << "----------------------------------------------------------------------------------------------------------------------------------\n";
+        irFile << "\n";
+        irFile << "{File:test_data.txt  Index:1  Index Date:20210415  PL:80.00%  PS:20%  Trades:10  CL:1}\n";
+        irFile << "\n";
+        irFile << "IF CLOSE OF 0 BARS AGO > OPEN OF 0 BARS AGO\n";
+        irFile << "THEN BUY NEXT BAR ON THE OPEN WITH\n";
+        irFile << "PROFIT TARGET AT ENTRY PRICE + 1.0 %\n";
+        irFile << "AND STOP LOSS AT ENTRY PRICE - 1.0 %\n";
+        irFile << "----------------------------------------------------------------------------------------------------------------------------------\n";
+        irFile.close();
+        
+        std::ofstream dataFile("./test_data.txt");
+        dataFile << "Date,Time,Open,High,Low,Close,Up,Down\n";
+        dataFile << "04/15/2021,09:30:00,350.00,351.00,349.50,350.50,10000,5000\n";
+        dataFile << "04/15/2021,09:31:00,350.50,351.25,350.00,351.00,15000,8000\n";
+        dataFile.close();
+        
+        ValidatorConfigurationFileReader reader("test_format_config.csv");
+        
+        REQUIRE_NOTHROW([&]() {
+            auto config = reader.readConfigurationFile();
+            
+            // Verify the configuration was created successfully
+            REQUIRE(config != nullptr);
+            
+            auto security = config->getSecurity();
+            REQUIRE(security != nullptr);
+            REQUIRE(security->getSymbol() == "QQQ");
+            
+            // Verify time frame is set correctly for intraday
+            REQUIRE(security->getTimeSeries()->getTimeFrame() == TimeFrame::INTRADAY);
+        }());
+        
+        // Cleanup
+        std::remove("test_format_config.csv");
+        std::remove("./test_ir.txt");
+        std::remove("./test_data.txt");
+    }
+}
+
+TEST_CASE("Date overlap validation", "[ValidatorConfiguration][Validation]")
+{
+    SECTION("Throws exception when OOS start date overlaps with in-sample end date")
+    {
+        // Create config with overlapping dates (same date for IS end and OOS start)
+        std::string configContent =
+            "Symbol,IRPath,DataPath,FileFormat,ISDateStart,ISDateEnd,OOSDateStart,OOSDateEnd,TimeFrame\n"
+            "MSFT,./test_ir.txt,./test_data.txt,INTRADAY::TRADESTATION,20210415T093000,20240604T160000,20240604T093000,20250320T160000,Intraday\n";
+        
+        std::ofstream configFile("test_overlap_config.csv");
+        configFile << configContent;
+        configFile.close();
+        
+        // Create minimal test files
+        std::ofstream irFile("./test_ir.txt");
+        irFile << "Code For Selected Patterns\n";
+        irFile << "----------------------------------------------------------------------------------------------------------------------------------\n";
+        irFile << "\n";
+        irFile << "{File:test_data.txt  Index:1  Index Date:20210415  PL:80.00%  PS:20%  Trades:10  CL:1}\n";
+        irFile << "\n";
+        irFile << "IF CLOSE OF 0 BARS AGO > OPEN OF 0 BARS AGO\n";
+        irFile << "THEN BUY NEXT BAR ON THE OPEN WITH\n";
+        irFile << "PROFIT TARGET AT ENTRY PRICE + 1.0 %\n";
+        irFile << "AND STOP LOSS AT ENTRY PRICE - 1.0 %\n";
+        irFile << "----------------------------------------------------------------------------------------------------------------------------------\n";
+        irFile.close();
+        
+        std::ofstream dataFile("./test_data.txt");
+        dataFile << "Date,Time,Open,High,Low,Close,Up,Down\n";
+        dataFile << "04/15/2021,09:30:00,250.00,251.00,249.50,250.50,5000,2500\n";
+        dataFile.close();
+        
+        ValidatorConfigurationFileReader reader("test_overlap_config.csv");
+        
+        // Should throw exception due to overlapping dates
+        REQUIRE_THROWS_AS(reader.readConfigurationFile(), ValidatorConfigurationException);
+        
+        // Cleanup
+        std::remove("test_overlap_config.csv");
+        std::remove("./test_ir.txt");
+        std::remove("./test_data.txt");
+    }
+}
+
+TEST_CASE("Date format consistency validation", "[ValidatorConfiguration][FormatConsistency]")
+{
+    SECTION("Throws exception when date formats are inconsistent")
+    {
+        // Create config with mixed formats (ptime for in-sample, gregorian for out-of-sample)
+        std::string configContent =
+            "Symbol,IRPath,DataPath,FileFormat,ISDateStart,ISDateEnd,OOSDateStart,OOSDateEnd,TimeFrame\n"
+            "TSLA,./test_ir.txt,./test_data.txt,INTRADAY::TRADESTATION,20210415T093000,20240604T160000,20240605,20250320,Intraday\n";
+        
+        std::ofstream configFile("test_inconsistent_config.csv");
+        configFile << configContent;
+        configFile.close();
+        
+        // Create minimal test files
+        std::ofstream irFile("./test_ir.txt");
+        irFile << "Code For Selected Patterns\n";
+        irFile << "----------------------------------------------------------------------------------------------------------------------------------\n";
+        irFile << "\n";
+        irFile << "{File:test_data.txt  Index:1  Index Date:20210415  PL:80.00%  PS:20%  Trades:10  CL:1}\n";
+        irFile << "\n";
+        irFile << "IF CLOSE OF 0 BARS AGO > OPEN OF 0 BARS AGO\n";
+        irFile << "THEN BUY NEXT BAR ON THE OPEN WITH\n";
+        irFile << "PROFIT TARGET AT ENTRY PRICE + 1.0 %\n";
+        irFile << "AND STOP LOSS AT ENTRY PRICE - 1.0 %\n";
+        irFile << "----------------------------------------------------------------------------------------------------------------------------------\n";
+        irFile.close();
+        
+        std::ofstream dataFile("./test_data.txt");
+        dataFile << "Date,Time,Open,High,Low,Close,Up,Down\n";
+        dataFile << "04/15/2021,09:30:00,700.00,701.00,699.50,700.50,8000,4000\n";
+        dataFile.close();
+        
+        ValidatorConfigurationFileReader reader("test_inconsistent_config.csv");
+        
+        // Should throw exception due to inconsistent date formats
+        REQUIRE_THROWS_AS(reader.readConfigurationFile(), ValidatorConfigurationException);
+        
+        // Cleanup
+        std::remove("test_inconsistent_config.csv");
+        std::remove("./test_ir.txt");
+        std::remove("./test_data.txt");
+    }
 }


### PR DESCRIPTION
palsetup - add support for reading, and writing intraday files
ValidatorConfiguraton - add support for intraday dates and files. Also unit tests.
BackTester - add skeleton intraday backtester because ValidatorConfiguraton needs to create one
TimeSeriesIndicators - fix bug on RocSeries where it was using boost gregorian over boost ptime

