### PR TITLE
Correctly set to unrounded close

### DIFF
--- a/libs/timeseries/SyntheticTimeSeries.h
+++ b/libs/timeseries/SyntheticTimeSeries.h
@@ -485,7 +485,7 @@ private:
                 Decimal low   = num::Round2Tick(actualLow,   mMinimumTick, mMinimumTickDiv2);
                 Decimal close = num::Round2Tick(actualClose, mMinimumTick, mMinimumTickDiv2);
 
-                lastUnroundedCloseForThisDay = close;
+                lastUnroundedCloseForThisDay = actualClose;
                 
 #ifdef SYNTHETIC_VOLUME
                 Decimal volume = DecimalConstants<Decimal>::DecimalZero; 


### PR DESCRIPTION
The reason` lastUnroundedCloseForThisDay` should be set to `actualClose` instead of the rounded close is to maintain precision in the inter-day price chaining and preserve the statistical properties of overnight gaps.

Why Use Unrounded Close:
Precision Chain Maintenance: The variable `preciseInterDayChainClose` is used to calculate the next day's opening anchor:

`Decimal preciseDayOpenAnchor = preciseInterDayChainClose * currentGapFactor;`

Using rounded values introduces cumulative rounding errors.

Statistical Integrity: The overnight gaps were calculated from original unrounded prices in `initIntradayDataInternal()`. To preserve their statistical distribution, the chaining should use precise values.

Impact of Using Rounded Close:
Cumulative Rounding Errors: Each day's rounding error gets carried forward and amplified, causing the synthetic series to drift from the intended statistical properties.

Distorted Overnight Gap Distribution: The algorithm specifically emphasizes preserving "the statistical distribution of the inter-bar gaps" as being "much more important than you might realize and easy to get wrong if you are not careful." Using rounded values for chaining violates this principle.

Long-term Price Drift: Over many days, the accumulated rounding errors could cause the synthetic series to have different long-term behavior compared to the original series, potentially affecting backtest results.

Inconsistent Gap Magnitudes: The actual overnight gaps applied would differ from the intended permuted gaps due to the rounding errors in the base prices.