### PR TITLE
Support decimalization

### DIFF
--- a/libs/backtesting/BacktesterStrategy.h
+++ b/libs/backtesting/BacktesterStrategy.h
@@ -82,6 +82,11 @@ namespace mkc_timeseries
       static boost::uuids::random_generator sUuidGenerator;
       
     public:
+      using Broker = StrategyBroker<Decimal,
+                                    NysePre2001Fractions,                // simulate 1/8 → 1/16 → decimals
+                                    Rule612SubPenny,                     // type name…
+                                    /*PricesAreSplitAdjusted=*/true>;    // …but sub-penny under $1 is OFF
+
       typedef typename Portfolio<Decimal>::ConstPortfolioIterator PortfolioIterator;
 
       /**
@@ -752,7 +757,7 @@ namespace mkc_timeseries
  return aSecurity.isDateFound(processingDateTime);
       }
 
-      const StrategyBroker<Decimal>& getStrategyBroker() const
+      const Broker& getStrategyBroker() const
       {
 	return mBroker;
       }
@@ -795,7 +800,7 @@ namespace mkc_timeseries
 
     private:
       std::string mStrategyName;
-      StrategyBroker<Decimal> mBroker;
+      Broker mBroker;
       std::shared_ptr<Portfolio<Decimal>> mPortfolio;
       SecurityBacktestPropertiesManager mSecuritiesProperties;
       StrategyOptions mStrategyOptions;

--- a/libs/backtesting/test/BackTesterTest.cpp
+++ b/libs/backtesting/test/BackTesterTest.cpp
@@ -281,7 +281,7 @@ SECTION ("PalStrategy testing for all long trades - pattern 1")
     REQUIRE (it != palLongBacktester1.endStrategies());
     std::shared_ptr<BacktesterStrategy<DecimalType>> aStrategy1 = (*it);
 
-    StrategyBroker<DecimalType> aBroker = aStrategy1->getStrategyBroker();
+    auto aBroker = aStrategy1->getStrategyBroker();
     REQUIRE (aBroker.getTotalTrades() == 24);
     REQUIRE (aBroker.getOpenTrades() == 0);
     REQUIRE (aBroker.getClosedTrades() == 24);
@@ -316,7 +316,7 @@ SECTION ("PalStrategy testing for all long trades - pattern 2")
     REQUIRE (it != palLongBacktester2.endStrategies());
     std::shared_ptr<BacktesterStrategy<DecimalType>> aStrategy2 = (*it);
 
-    StrategyBroker<DecimalType> aBroker2 = aStrategy2->getStrategyBroker();
+    auto aBroker2 = aStrategy2->getStrategyBroker();
     REQUIRE (aBroker2.getTotalTrades() == 46);
     REQUIRE (aBroker2.getOpenTrades() == 0);
     REQUIRE (aBroker2.getClosedTrades() == 46);

--- a/libs/backtesting/test/ClosedPositionHistoryTest.cpp
+++ b/libs/backtesting/test/ClosedPositionHistoryTest.cpp
@@ -370,12 +370,12 @@ TEST_CASE ("ClosedPositionHistory operations", "[ClosedPositionHistory]")
   REQUIRE (longCumReturn == closedLongPositions.getCumulativeReturn());
   REQUIRE (closedLongPositions.getNumPositions() == 24);
   REQUIRE (closedLongPositions.getProfitFactor() >= createDecimal("2.99"));
-  REQUIRE (closedLongPositions.getPercentWinners() == createDecimal("58.3333300"));
+  REQUIRE (closedLongPositions.getPercentWinners() == createDecimal("58.33333300"));
   REQUIRE (closedLongPositions.getPercentLosers() == (createDecimal ("100.00") - closedLongPositions.getPercentWinners()));
   REQUIRE (closedLongPositions.getNumWinningPositions() == 14);
   REQUIRE (closedLongPositions.getNumLosingPositions() == 10);
-  REQUIRE (closedLongPositions.getPayoffRatio() == createDecimal("2.1407415"));
-  REQUIRE (closedLongPositions.getPALProfitability() == createDecimal("58.3333300"));
+  REQUIRE (closedLongPositions.getPayoffRatio() == createDecimal("2.14074081"));
+  REQUIRE (closedLongPositions.getPALProfitability() == createDecimal("58.33333300"));
 
 
   auto shortEntryDate1 = TimeSeriesDate (1986, May, 28);

--- a/libs/backtesting/test/OpenPositionTest.cpp
+++ b/libs/backtesting/test/OpenPositionTest.cpp
@@ -66,21 +66,21 @@ TEST_CASE ("OpenPosition operations", "[OpenPosition]")
 
   SECTION ("OpenPosition getPercentReturn()")
   {
-    REQUIRE (longPosition1.getPercentReturn() == DecimalType (dec::fromString<DecimalType>("-2.6584700")));
+    REQUIRE (longPosition1.getPercentReturn() == DecimalType (dec::fromString<DecimalType>("-2.65846700")));
     REQUIRE_FALSE (longPosition1.isWinningPosition());
     REQUIRE (longPosition1.isLosingPosition());
-    REQUIRE (shortPosition1.getPercentReturn() == DecimalType (dec::fromString<DecimalType>("2.6584700")));
+    REQUIRE (shortPosition1.getPercentReturn() == DecimalType (dec::fromString<DecimalType>("2.65846700")));
     REQUIRE (shortPosition1.isWinningPosition());
     REQUIRE_FALSE (shortPosition1.isLosingPosition());
   }
 
   SECTION ("OpenPosition getTradeReturn()")
   {
-    DecimalType longReturn(dec::fromString<DecimalType>("-2.6584700")/DecimalConstants<DecimalType>::DecimalOneHundred);
+    DecimalType longReturn(dec::fromString<DecimalType>("-2.65846700")/DecimalConstants<DecimalType>::DecimalOneHundred);
 
       REQUIRE (longPosition1.getTradeReturn() == longReturn);
 
-      DecimalType shortReturn(dec::fromString<DecimalType>("2.6584700")/DecimalConstants<DecimalType>::DecimalOneHundred);
+      DecimalType shortReturn(dec::fromString<DecimalType>("2.65846700")/DecimalConstants<DecimalType>::DecimalOneHundred);
       REQUIRE (shortPosition1.getTradeReturn() == shortReturn);
   }
 

--- a/libs/backtesting/test/PalStrategyTest.cpp
+++ b/libs/backtesting/test/PalStrategyTest.cpp
@@ -337,7 +337,7 @@ TEST_CASE ("PalStrategy operations", "[PalStrategy]")
     longStrategy1.eventProcessPendingOrders(orderDate);
     REQUIRE ( longStrategy1.isLongPosition (futuresSymbol));
 
-    StrategyBroker<DecimalType> aBroker = longStrategy1.getStrategyBroker();
+    auto aBroker = longStrategy1.getStrategyBroker();
     REQUIRE (aBroker.getTotalTrades() == 1);
     REQUIRE (aBroker.getOpenTrades() == 1);
     REQUIRE (aBroker.getClosedTrades() == 0);
@@ -372,7 +372,7 @@ TEST_CASE ("PalStrategy operations", "[PalStrategy]")
     orderDate = boost_next_weekday(orderDate);
     shortStrategy1.eventProcessPendingOrders(orderDate);
     REQUIRE ( shortStrategy1.isShortPosition (futuresSymbol));
-    StrategyBroker<DecimalType> aBroker = shortStrategy1.getStrategyBroker();
+    auto aBroker = shortStrategy1.getStrategyBroker();
     REQUIRE (aBroker.getTotalTrades() == 1);
     REQUIRE (aBroker.getOpenTrades() == 1);
     REQUIRE (aBroker.getClosedTrades() == 0);
@@ -424,13 +424,12 @@ TEST_CASE ("PalStrategy operations", "[PalStrategy]")
 	  }
       }
 
-    StrategyBroker<DecimalType> aBroker = longStrategy1.getStrategyBroker();
+    auto aBroker = longStrategy1.getStrategyBroker();
     REQUIRE (aBroker.getTotalTrades() == 1);
     REQUIRE (aBroker.getOpenTrades() == 0);
     REQUIRE (aBroker.getClosedTrades() == 1);
 
-    StrategyBroker<DecimalType>::StrategyTransactionIterator it = 
-      aBroker.beginStrategyTransactions();
+    auto it = aBroker.beginStrategyTransactions();
 
     REQUIRE (it !=aBroker.endStrategyTransactions()); 
     auto trans = it->second;
@@ -492,13 +491,12 @@ TEST_CASE ("PalStrategy operations", "[PalStrategy]")
 	  }
       }
 
-    StrategyBroker<DecimalType> aBroker = shortStrategy1.getStrategyBroker();
+    auto aBroker = shortStrategy1.getStrategyBroker();
     REQUIRE (aBroker.getTotalTrades() == 1);
     REQUIRE (aBroker.getOpenTrades() == 0);
     REQUIRE (aBroker.getClosedTrades() == 1);
 
-    StrategyBroker<DecimalType>::StrategyTransactionIterator it = 
-      aBroker.beginStrategyTransactions();
+    auto it = aBroker.beginStrategyTransactions();
 
     REQUIRE (it !=aBroker.endStrategyTransactions()); 
     auto trans = it->second;
@@ -538,7 +536,7 @@ SECTION ("PalStrategy testing for all long trades - pattern 1")
 	longStrategy1.eventProcessPendingOrders (backTesterDate);
       }
 
-    StrategyBroker<DecimalType> aBroker = longStrategy1.getStrategyBroker();
+    auto aBroker = longStrategy1.getStrategyBroker();
     REQUIRE (aBroker.getTotalTrades() == 24);
     REQUIRE (aBroker.getOpenTrades() == 0);
     REQUIRE (aBroker.getClosedTrades() == 24); 
@@ -575,7 +573,7 @@ SECTION ("PalStrategy testing for all long trades - MetaStrategy1 1")
 	metaStrategy1.eventProcessPendingOrders (backTesterDate);
       }
 
-    StrategyBroker<DecimalType> aBroker = metaStrategy1.getStrategyBroker();
+    auto aBroker = metaStrategy1.getStrategyBroker();
     REQUIRE (aBroker.getTotalTrades() == 24);
     REQUIRE (aBroker.getOpenTrades() == 0);
     REQUIRE (aBroker.getClosedTrades() == 24); 
@@ -612,7 +610,7 @@ SECTION ("PalStrategy testing for all long trades with pyramiding - pattern 1")
 	longStrategyPyramid1.eventProcessPendingOrders (backTesterDate);
       }
 
-    StrategyBroker<DecimalType> aBroker = longStrategyPyramid1.getStrategyBroker();
+    auto aBroker = longStrategyPyramid1.getStrategyBroker();
     REQUIRE (aBroker.getTotalTrades() > 546);
     REQUIRE (aBroker.getOpenTrades() == 0);
     REQUIRE (aBroker.getClosedTrades() > 546); 
@@ -651,7 +649,7 @@ SECTION ("PalStrategy testing for all long trades - pattern 2")
 	longStrategy2.eventProcessPendingOrders (backTesterDate);
       }
 
-    StrategyBroker<DecimalType> aBroker = longStrategy2.getStrategyBroker();
+    auto aBroker = longStrategy2.getStrategyBroker();
     REQUIRE (aBroker.getTotalTrades() == 46);
     REQUIRE (aBroker.getOpenTrades() == 0);
     REQUIRE (aBroker.getClosedTrades() == 46); 
@@ -692,7 +690,7 @@ SECTION ("PalStrategy testing for all short trades")
       }
 
     //std::cout << "Backtester end date = " << backTesterDate << std::endl; 
-    StrategyBroker<DecimalType> aBroker2 = shortStrategy1.getStrategyBroker();
+    auto aBroker2 = shortStrategy1.getStrategyBroker();
     ClosedPositionHistory<DecimalType> history2 = aBroker2.getClosedPositionHistory();
     //std::cout << "Calling printPositionHistory for short strategy" << std::endl << std::endl;
     //printPositionHistory (history2);
@@ -732,7 +730,7 @@ SECTION ("PalStrategy testing for all short trades - MetaStrategy2")
 	metaStrategy2.eventProcessPendingOrders (backTesterDate);
       }
 
-    StrategyBroker<DecimalType> aBroker = metaStrategy2.getStrategyBroker();
+    auto aBroker = metaStrategy2.getStrategyBroker();
     REQUIRE (aBroker.getTotalTrades() == 21);
     REQUIRE (aBroker.getOpenTrades() == 0);
     REQUIRE (aBroker.getClosedTrades() == 21); 
@@ -752,7 +750,7 @@ SECTION ("PalStrategy testing for all trades - MetaStrategy3")
 
     backTestLoop (corn, metaStrategy3, backTestStartDate, backTestEndDate);
 
-    StrategyBroker<DecimalType> aBroker = metaStrategy3.getStrategyBroker();
+    auto aBroker = metaStrategy3.getStrategyBroker();
     ClosedPositionHistory<DecimalType> history = aBroker.getClosedPositionHistory();
     //printPositionHistory (history);
 
@@ -776,7 +774,7 @@ SECTION ("PalStrategy testing for all trades - MetaStrategy3")
  
     backTestLoop (corn, metaStrategy4, backTestStartDate, backTestEndDate);
  
-    StrategyBroker<DecimalType> aBroker2 = metaStrategy4.getStrategyBroker();
+    auto aBroker2 = metaStrategy4.getStrategyBroker();
     ClosedPositionHistory<DecimalType> history2 = aBroker2.getClosedPositionHistory();
     //printPositionHistory (history2);
 
@@ -791,7 +789,7 @@ SECTION ("PalStrategy testing for all trades - MetaStrategy3")
     metaStrategy5.addPricePattern(createShortPattern1());
 
     backTestLoop (corn, metaStrategy5, backTestStartDate, backTestEndDate);
-    StrategyBroker<DecimalType> aBroker3 = metaStrategy5.getStrategyBroker();
+    auto aBroker3 = metaStrategy5.getStrategyBroker();
     ClosedPositionHistory<DecimalType> history3 = aBroker3.getClosedPositionHistory();
     //printPositionHistory (history3);
 

--- a/libs/patterndiscovery/README.md
+++ b/libs/patterndiscovery/README.md
@@ -58,7 +58,7 @@ SearchLine<Decimal> searchLine(1, tradeParams, perfCriteria, "Extended Search");
 
 ### Decimal Type Integration
 - Seamless integration with `dec::decimal<Prec>` system
-- Uses `num::DefaultNumber` (`dec::decimal<7>`) by default
+- Uses `num::DefaultNumber` (`dec::decimal<8>`) by default
 - Template design supports any decimal precision
 
 ### Delay Pattern Support
@@ -161,7 +161,7 @@ SearchLine<Decimal> deepSearch(100, tradeParams, perfCriteria, "Deep Search with
 
 ### Time Series Library
 - Uses `dec::decimal<Prec>` for all financial calculations
-- Compatible with `num::DefaultNumber` (`dec::decimal<7>`)
+- Compatible with `num::DefaultNumber` (`dec::decimal<8>`)
 - Integrates with `OHLCTimeSeries` data structures
 
 ## Testing

--- a/libs/statistics/test/PALMastersMonteCarloIntegrationTest.cpp
+++ b/libs/statistics/test/PALMastersMonteCarloIntegrationTest.cpp
@@ -7,13 +7,14 @@
 #include "Security.h"
 #include "MonteCarloTestPolicy.h"
 #include "TradingVolume.h"
+#include "number.h"
 #include <memory>
 #include <vector>
 #include <algorithm>
 #include <random>
 
 using namespace mkc_timeseries;
-using DecimalType = dec::decimal<7>;
+using DecimalType = num::DefaultNumber;
 using StatPolicy = AllHighResLogPFPolicy<DecimalType>;
 
 // Create a test policy with no minimum trade requirement for debugging

--- a/libs/testinfra/TestUtils.h
+++ b/libs/testinfra/TestUtils.h
@@ -7,7 +7,7 @@
 #include "TimeSeriesEntry.h"
 #include "TradingVolume.h"
 
-typedef dec::decimal<7> DecimalType;
+typedef num::DefaultNumber DecimalType;
 
 typedef mkc_timeseries::OHLCTimeSeriesEntry<DecimalType> EntryType;
 

--- a/libs/timeseries/RoundingPolicies.h
+++ b/libs/timeseries/RoundingPolicies.h
@@ -1,0 +1,36 @@
+#ifndef __ROUNDING_POLICIES_H
+#define __ROUNDING_POLICIES_H 1
+
+// Copyright (C) MKC Associates, LLC - All Rights Reserved
+// Unauthorized copying of this file, via any medium is strictly prohibited
+// Proprietary and confidential
+// Written by Michael K. Collison <collison956@gmail.com>, July 2016
+
+#include "number.h"
+
+namespace mkc_timeseries
+{
+  template <class Decimal>
+  struct NoRounding
+  {
+    static Decimal round(const Decimal& price,
+			 const Decimal& /*tick*/,
+			 const Decimal& /*tickDiv2*/)
+    {
+      return price;
+    }
+  };
+
+  template <class Decimal>
+  struct TickRounding {
+    static Decimal round(const Decimal& price,
+			 const Decimal& tick,
+			 const Decimal& tickDiv2)
+    {
+      return num::Round2Tick(price, tick, tickDiv2);
+    }
+  };
+
+} // namespace mkc_timeseries
+
+#endif // __ROUNDING_POLICIES_H

--- a/libs/timeseries/SyntheticTimeSeriesCreator.h
+++ b/libs/timeseries/SyntheticTimeSeriesCreator.h
@@ -27,7 +27,7 @@ namespace mkc_timeseries
      * (user-defined) to a shared pointer of the new OHLCTimeSeries.
      * You can then write each synthetic series out to CSV.
      * 
-     * @tparam Decimal  Numeric type for price values (e.g., dec::decimal<7>, double).
+     * @tparam Decimal  Numeric type for price values (e.g., num::DefaultNumber, double).
      */
     template <class Decimal>
     class SyntheticTimeSeriesCreator

--- a/libs/timeseries/TimeSeriesCsvReader.h
+++ b/libs/timeseries/TimeSeriesCsvReader.h
@@ -13,14 +13,16 @@
 #include <boost/date_time.hpp>
 #include "DecimalConstants.h"
 #include "csv.h"
+#include "RoundingPolicies.h"
 
 namespace mkc_timeseries
 {
   using boost::posix_time::ptime;
   using boost::posix_time::time_duration;
   using boost::posix_time::duration_from_string;
-
-  template <class Decimal>
+  
+  template <class Decimal,
+	    template<class> class RoundingPolicy = NoRounding>
   class TimeSeriesCsvReader
   {
   public:
@@ -93,8 +95,8 @@ namespace mkc_timeseries
   protected:
     Decimal DecimalRound (const Decimal& price)
     {
-      //return price;
-      return num::Round2Tick (price, getTick(), mMinimumTickDiv2);
+      // Policy decides what to do; default is no rounding.
+      return RoundingPolicy<Decimal>::round(price, getTick(), mMinimumTickDiv2);
     }
     
     bool checkForErrors (boost::gregorian::date entryDate,
@@ -145,8 +147,9 @@ namespace mkc_timeseries
 
   // Reader for Price Action Lab CSV Formatted Files
 
-  template <class Decimal>
-  class PALFormatCsvReader : public TimeSeriesCsvReader<Decimal>
+  template <class Decimal,
+	    template<class> class RoundingPolicy = NoRounding>
+  class PALFormatCsvReader : public TimeSeriesCsvReader<Decimal, RoundingPolicy>
   {
   public:
     PALFormatCsvReader (const std::string& fileName, TimeFrame::Duration timeFrame = TimeFrame::DAILY, 
@@ -218,8 +221,9 @@ namespace mkc_timeseries
   // Date, Open, High, Low, Close, Volume, Open Interest, Rollover date, Unadjusted Close
   //
 
-  template <class Decimal>
-  class CSIExtendedFuturesCsvReader : public TimeSeriesCsvReader<Decimal>
+  template <class Decimal,
+	    template<class> class RoundingPolicy = NoRounding>
+  class CSIExtendedFuturesCsvReader : public TimeSeriesCsvReader<Decimal, RoundingPolicy>
   {
   public:
     CSIExtendedFuturesCsvReader (const std::string& fileName, TimeFrame::Duration timeFrame, 
@@ -291,8 +295,9 @@ namespace mkc_timeseries
   // Date, Open, High, Low, Close, Volume, Open Interest, Rollover date, Unadjusted Close
   //
 
-  template <class Decimal>
-  class CSIErrorCheckingExtendedFuturesCsvReader : public TimeSeriesCsvReader<Decimal>
+  template <class Decimal,
+	    template<class> class RoundingPolicy = NoRounding>
+  class CSIErrorCheckingExtendedFuturesCsvReader : public TimeSeriesCsvReader<Decimal, RoundingPolicy>
   {
   public:
     CSIErrorCheckingExtendedFuturesCsvReader (const std::string& fileName,
@@ -368,8 +373,9 @@ namespace mkc_timeseries
   // Date, Open, High, Low, Close, Volume, Open Interest
   //
 
-  template <class Decimal>
-  class CSIFuturesCsvReader : public TimeSeriesCsvReader<Decimal>
+  template <class Decimal,
+	    template<class> class RoundingPolicy = NoRounding>
+  class CSIFuturesCsvReader : public TimeSeriesCsvReader<Decimal, RoundingPolicy>
   {
   public:
     CSIFuturesCsvReader (const std::string& fileName, TimeFrame::Duration timeFrame, 
@@ -439,8 +445,9 @@ namespace mkc_timeseries
   // Date, Open, High, Low, Close, Volume, Open Interest
   //
 
-  template <class Decimal>
-  class CSIErrorCheckingFuturesCsvReader : public TimeSeriesCsvReader<Decimal>
+  template <class Decimal,
+	    template<class> class RoundingPolicy = NoRounding>
+  class CSIErrorCheckingFuturesCsvReader : public TimeSeriesCsvReader<Decimal, RoundingPolicy>
   {
   public:
     CSIErrorCheckingFuturesCsvReader (const std::string& fileName,
@@ -513,8 +520,9 @@ namespace mkc_timeseries
   //
 
 
-  template <class Decimal>
-  class TradeStationFormatCsvReader : public TimeSeriesCsvReader<Decimal>
+  template <class Decimal,
+	    template<class> class RoundingPolicy = NoRounding>
+  class TradeStationFormatCsvReader : public TimeSeriesCsvReader<Decimal, RoundingPolicy>
   {
   public:
     TradeStationFormatCsvReader (const std::string& fileName,
@@ -601,8 +609,9 @@ namespace mkc_timeseries
 
   ///////
 
-  template <class Decimal>
-  class TradeStationErrorCheckingFormatCsvReader : public TimeSeriesCsvReader<Decimal>
+  template <class Decimal,
+	    template<class> class RoundingPolicy = NoRounding>
+  class TradeStationErrorCheckingFormatCsvReader : public TimeSeriesCsvReader<Decimal, RoundingPolicy>
   {
   public:
     TradeStationErrorCheckingFormatCsvReader (const std::string& fileName,
@@ -692,8 +701,9 @@ namespace mkc_timeseries
   //
 
 
-  template <class Decimal>
-  class TradeStationIndicator1CsvReader : public TimeSeriesCsvReader<Decimal>
+  template <class Decimal,
+	    template<class> class RoundingPolicy = NoRounding>
+  class TradeStationIndicator1CsvReader : public TimeSeriesCsvReader<Decimal, RoundingPolicy>
   {
   public:
     TradeStationIndicator1CsvReader (const std::string& fileName,
@@ -788,8 +798,9 @@ namespace mkc_timeseries
   //   the reader uses the date-only constructor (00:00) like other readers.
   // - For intraday (if enabled by caller) and when a time is present, we parse it.
 
-  template <class Decimal>
-  class WealthLabCsvReader : public TimeSeriesCsvReader<Decimal>
+  template <class Decimal,
+	    template<class> class RoundingPolicy = NoRounding>
+  class WealthLabCsvReader : public TimeSeriesCsvReader<Decimal, RoundingPolicy>
   {
   public:
     WealthLabCsvReader(const std::string& fileName,
@@ -870,8 +881,9 @@ namespace mkc_timeseries
   ////
 ///////
 
-  template <class Decimal>
-  class PinnacleErrorCheckingFormatCsvReader : public TimeSeriesCsvReader<Decimal>
+  template <class Decimal,
+	    template<class> class RoundingPolicy = NoRounding>
+  class PinnacleErrorCheckingFormatCsvReader : public TimeSeriesCsvReader<Decimal, RoundingPolicy>
   {
   public:
     PinnacleErrorCheckingFormatCsvReader (const std::string& fileName,

--- a/libs/timeseries/number.h
+++ b/libs/timeseries/number.h
@@ -16,10 +16,10 @@
 namespace num
 {
   /**
-   * @brief Default decimal type with 7 decimal places using the default rounding policy.
+   * @brief Default decimal type with 8 decimal places using the default rounding policy.
    * @see dec::decimal
    */
-  using DefaultNumber  = dec::decimal<7>;
+  using DefaultNumber  = dec::decimal<8>;
 
   /**
    * @brief Converts a DefaultNumber to its string representation.

--- a/libs/timeseries/test/NumberTest.cpp
+++ b/libs/timeseries/test/NumberTest.cpp
@@ -24,7 +24,7 @@ TEST_CASE("operator% returns correct remainder for positive and negative values"
 
 TEST_CASE("toString produces the expected string representation", "[number]") {
     DefaultNumber d = createDecimal("12.345");
-    REQUIRE(num::toString(d) == std::string("12.3450000"));
+    REQUIRE(num::toString(d) == std::string("12.34500000"));
 }
 
 TEST_CASE("abs returns the absolute value of a decimal", "[number]") {

--- a/libs/timeseries/test/SyntheticTimeSeriesTest.cpp
+++ b/libs/timeseries/test/SyntheticTimeSeriesTest.cpp
@@ -467,7 +467,10 @@ TEST_CASE ("SyntheticTimeSeriesTest", "[SyntheticTimeSeries]")
       auto originalClosingSeries = sampleSeries.CloseTimeSeries();
       std::vector<DecimalType> originalClosingVector = originalClosingSeries.getTimeSeriesAsVector();
       DecimalType lastClosePrice = originalClosingVector.back();
-      REQUIRE (lastClosePrice == syntheticLastClosePrice);
+      // With NoRounding policy, allow for small precision differences
+      DecimalType tolerance = DecimalConstants<DecimalType>::EquityTick;
+      DecimalType diff = num::abs(lastClosePrice - syntheticLastClosePrice);
+      REQUIRE (diff <= tolerance);
       std::vector<DecimalType> shuffledRelativeOpen = syntheticSeries.getRelativeOpen();
       std::vector<DecimalType> shuffledRelativeHigh = syntheticSeries.getRelativeHigh();
       std::vector<DecimalType> shuffledRelativeLow = syntheticSeries.getRelativeLow();

--- a/libs/timeseries/test/TimeSeriesCsvReaderTest2.cpp
+++ b/libs/timeseries/test/TimeSeriesCsvReaderTest2.cpp
@@ -42,7 +42,7 @@ auto decimalApprox(const Decimal& expected, const Decimal& tolerance) {
     return DecimalApprox<Decimal>(expected, tolerance);
 }
 
-// Tolerance for decimal comparisons (e.g. 0.00001 in decimal<7>)
+// Tolerance for decimal comparisons (e.g. 0.00001 in decimal<8>)
 static const DecimalType DEC_TOL = createDecimal("0.00001");
 
 TEST_CASE("PALFormatCsvReader reads QQQ end-of-day file with known anchors", "[csv][PAL]") {
@@ -138,11 +138,11 @@ TEST_CASE("TradeStationFormatCsvReader throws on too‐few‐columns", "[csv][er
         out << "04/01/2021,15:00,100.0,101.0,99.0\n";
     }
 
-    TradeStationFormatCsvReader<dec::decimal<7>> reader(
+    TradeStationFormatCsvReader<DecimalType> reader(
         badPath,
         TimeFrame::INTRADAY,
         TradingVolume::SHARES,
-        DecimalConstants<dec::decimal<7>>::EquityTick
+        DecimalConstants<DecimalType>::EquityTick
     );
 
     // 3) assert that the CSV library's "too few columns" error bubbles up
@@ -177,11 +177,11 @@ TEST_CASE("TradeStationFormatCsvReader throws if INTRADAY but file is daily form
     }
 
     // 2) Construct reader asking for INTRADAY
-    TradeStationFormatCsvReader<dec::decimal<7>> reader(
+    TradeStationFormatCsvReader<DecimalType> reader(
         path,
         TimeFrame::INTRADAY,
         TradingVolume::SHARES,
-        DecimalConstants<dec::decimal<7>>::EquityTick
+        DecimalConstants<DecimalType>::EquityTick
     );
 
     // 3) Expect the CSV-library to complain about missing "Up"/"Down" columns
@@ -225,23 +225,23 @@ TEST_CASE("WealthLabCsvReader reads Wealth-Lab daily CSV", "[csv][WealthLab][Dai
     REQUIRE(series.getFirstDateTime() == ptime(date(2000, 5, 30), getDefaultBarTime()));
     REQUIRE(series.getLastDateTime()  == ptime(date(2000, 6, 12), getDefaultBarTime()));
 
-    // First bar (rounded to equity tick)
+    // First bar (raw values from CSV, no rounding)
     {
         auto first = *series.beginSortedAccess();
-        REQUIRE(first.getOpenValue()   == decimalApprox(createDecimal("0.23"), DEC_TOL));
-        REQUIRE(first.getHighValue()   == decimalApprox(createDecimal("0.23"), DEC_TOL));
-        REQUIRE(first.getLowValue()    == decimalApprox(createDecimal("0.22"), DEC_TOL));
-        REQUIRE(first.getCloseValue()  == decimalApprox(createDecimal("0.23"), DEC_TOL));
+        REQUIRE(first.getOpenValue()   == decimalApprox(createDecimal("0.22578125"), DEC_TOL));
+        REQUIRE(first.getHighValue()   == decimalApprox(createDecimal("0.23463542"), DEC_TOL));
+        REQUIRE(first.getLowValue()    == decimalApprox(createDecimal("0.22473957"), DEC_TOL));
+        REQUIRE(first.getCloseValue()  == decimalApprox(createDecimal("0.22890625"), DEC_TOL));
         REQUIRE(first.getVolumeValue() == decimalApprox(createDecimal("306210240"), DEC_TOL));
     }
 
-    // Last bar (rounded to equity tick)
+    // Last bar (raw values from CSV, no rounding)
     {
         auto last = *std::prev(series.endSortedAccess());
-        REQUIRE(last.getOpenValue()   == decimalApprox(createDecimal("0.26"), DEC_TOL));
-        REQUIRE(last.getHighValue()   == decimalApprox(createDecimal("0.27"), DEC_TOL));
-        REQUIRE(last.getLowValue()    == decimalApprox(createDecimal("0.25"), DEC_TOL));
-        REQUIRE(last.getCloseValue()  == decimalApprox(createDecimal("0.26"), DEC_TOL));
+        REQUIRE(last.getOpenValue()   == decimalApprox(createDecimal("0.2645825"), DEC_TOL));
+        REQUIRE(last.getHighValue()   == decimalApprox(createDecimal("0.2667975"), DEC_TOL));
+        REQUIRE(last.getLowValue()    == decimalApprox(createDecimal("0.25052"), DEC_TOL));
+        REQUIRE(last.getCloseValue()  == decimalApprox(createDecimal("0.25638"), DEC_TOL));
         REQUIRE(last.getVolumeValue() == decimalApprox(createDecimal("382571040"), DEC_TOL));
     }
 

--- a/libs/timeseries/test/TimeSeriesIndicatorsTest.cpp
+++ b/libs/timeseries/test/TimeSeriesIndicatorsTest.cpp
@@ -18,7 +18,7 @@
 
 // Using directives
 using namespace mkc_timeseries;
-// DecimalType is defined in TestUtils.h as typedef dec::decimal<7> DecimalType;
+// DecimalType is defined in TestUtils.h as typedef num::DefaultNumber DecimalType;
 using num::fromString; // bring fromString<DecimalType> into scope
 using namespace Catch;
 

--- a/src/patterndiscovery/test/SyntheticTimeSeriesCreatorTest.cpp
+++ b/src/patterndiscovery/test/SyntheticTimeSeriesCreatorTest.cpp
@@ -4,9 +4,10 @@
 #include "SyntheticTimeSeriesCreator.h"
 #include "DecimalConstants.h"
 #include "TimeFrameDiscovery.h"
+#include "number.h"
 #include <map>
 
-typedef dec::decimal<7> DecimalType;
+typedef num::DefaultNumber DecimalType;
 
 using namespace mkc_timeseries;
 using namespace boost::gregorian;


### PR DESCRIPTION
- Don't round when reading csv files
- Don't round when creating synthetic time series
- Expand default number of decimal digits from 7 to 8