### PR TITLE
Bump version number to 2.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(PalValidator VERSION 2.4.0 LANGUAGES CXX)
+project(PalValidator VERSION 2.5.0 LANGUAGES CXX)
 
 # Extract Git information for version header
 find_package(Git QUIET)


### PR DESCRIPTION
# palvalidator v2.5 Release Notes
 
**Release Date:** April 8, 2026
**Milestone:** 2.4 → 2.5
 
---
 
## Overview
 
Version 2.5 delivers a focused set of correctness, thread-safety, and statistical
accuracy improvements to the BCa bootstrap infrastructure. All changes are concentrated
in the resampling and block-length selection subsystems. No API-breaking changes were
introduced.
 
---
 
## What's Changed
 
### PR #299 — BCa Bootstrap Resampler Correctness and Cleanup
 
**Branch:** `bootstrap_resampler_bug_fixes` → `master`
**Commits:** 2
**Merged:** April 7, 2026
 
#### Bug Fixes
 
**Critical: Thread-safety fix in `StationaryBlockResampler`**
`std::geometric_distribution<size_t>` was stored as a `mutable` member and mutated
inside the `const` `operator()`. Under the BCa bootstrap parallel loop, multiple threads
calling `operator()` on the same resampler instance concurrently produced a data race
and undefined behaviour. The distribution is now constructed as a local variable inside
`operator()`, eliminating all shared mutable state. The `mutable` qualifier and `m_geo`
member have been removed.
 
**Redundant RNG draw eliminated in `StationaryBlockResampler`**
The original loop drew a new random starting index after copying the final block,
wasting one RNG call per invocation. The index draw has been moved to the top of the
loop so it is only evaluated when it will actually be used.
 
**Jackknife correctness: `n-1` clamp replaced with `n-minKeep` clamp**
The original code clamped `L_eff = min(m_L, n - 1)`, which for large block lengths left
single-observation replicates on which statistics such as variance or Sharpe ratio are
undefined. The clamp is now `L_eff = min(m_L, n - minKeep)` where `minKeep = 2`,
guaranteeing every replicate contains at least 2 observations.
 
**Jackknife correctness: defensive `numBlocks == 0` guard**
An explicit guard was added to throw `std::invalid_argument` when no replicates can be
formed, ensuring future refactors that break this invariant fail loudly rather than
silently.
 
**No silent IID fallback in `StationaryBlockResampler::jackknife()`**
The jackknife no longer silently falls back to a delete-one IID jackknife when
`numBlocks` is small. For serially dependent data, switching the jackknife dependence
model to delete-one IID distorts the influence structure that BCa acceleration is meant
to estimate. The small-blocks condition is instead surfaced as a diagnostic.
 
#### Code Quality
 
**`size_t` → `std::size_t` in `IIDResampler`**
All public method signatures, return types, and loop counters now use `std::size_t`
explicitly rather than the unqualified `size_t`, consistent with the style used
throughout the codebase.
 
**Variable renaming in `IIDResampler::jackknife()`**
Internal variable names have been updated for clarity: `jk` → `jackknifeValues`,
`tmp` → `leaveOneOutSample`.
 
**Default bootstrap samples changed from 25,000 to 15,000**
The default number of bootstrap samples has been reduced to improve runtime performance
without meaningfully impacting statistical accuracy for typical use cases.
 
#### Documentation
 
The `StationaryBlockResampler` class doc comment now documents: thread-safety rationale,
block-length cap behaviour, the non-overlapping circular delete-block jackknife scheme
(Künsch 1989), and the circular assembly ordering of the retained sample.
 
#### New Unit Tests
 
Nine new tests were added across four test files:
 
- **`StationaryBlockResamplerJackknifeTest.cpp`** — two new tests verifying exact
  circular assembly values for all non-overlapping blocks and the `n=2` boundary
  condition.
- **`BiasCorrectedBootstrapTest.cpp`** — two new tests verifying the circular wrap copy
  path with exact values and that geometric block lengths produce the correct mean.
- **`BiasCorrectedBootstrapAdditionalTest.cpp`** — five new tests covering:
  `IIDResampler` empty-input guards on both overloads, the `n=2` minimum-valid-input
  boundary for `jackknife()`, a non-linear statistic (population variance) to detect
  incorrect subset construction, and a `T ≠ R` return-type deduction scenario.
 
---
 
### PR #300 — Fix Block Length Calculation Derived from Autocorrelation
 
**Branch:** `bug/compute_bootstrap_widths` → `master`
**Commits:** 1
**Merged:** April 8, 2026
 
#### Problem
 
The ACF-based block length selection used in `suggestStationaryBlockLengthFromACF` and
`ComputeBootstrappedWidths` contained a statistical bug that caused block lengths to be
driven to the maximum cap (6 or 12) even when the input data was pure white noise. The
root cause was use of the standard pointwise significance band `2/√n`, which controls
the false-positive rate at ~1.2% *per individual lag*. When M lags are tested
simultaneously, the family-wise error rate compounds to approximately 11% for M=10 and
22% for M=20, meaning roughly one run in five incorrectly selected a large block length
on white-noise data. Two real-world cases with `n=2982` and `n=3230` daily ROC series
were both assigned block lengths of 12 — the maximum cap — purely due to noise
exceedances at high lags, producing bootstrap confidence intervals that were wider than
warranted and resulting in conservative profit targets and stop losses.
 
#### Fix
 
Two corrections are applied together in both affected locations:
 
**1. Bonferroni-corrected significance threshold**
The pointwise `2/√n` threshold has been replaced with `z_bonf / √n`, where
`z_bonf = qnorm(1 - α/(2M))` is computed from the actual number of lags tested. This
controls the family-wise error rate at ≤5% regardless of how many lags are tested and
adapts automatically if the caller passes an ACF of a different length. Typical
z-criticals are 2.64 at M=6 (+32% vs old threshold) and 3.02 at M=20 (+51% vs old
threshold).
 
**2. Consecutive-lag rule**
The prior rule updated the block length for any single lag exceeding the threshold. The
new rule requires two *adjacent* lags to both exceed the threshold. An isolated
exceedance at a single lag is treated as Monte Carlo noise. Genuine autocorrelation (AR,
MA, GARCH volatility clustering) always produces a run of significant lags that will
satisfy the consecutive requirement. The false-positive probability for a single pair
drops from ~1.2% to ~0.015%.
 
The two observed failure cases were resolved:
 
| Case | n | Old result | New result |
|------|---|------------|------------|
| Case 1 | 2,982 | L=12 (capped) | L=2 |
| Case 2 | 3,230 | L=12 (capped) | L=2 |
 
On the `n=3230` dataset, correcting the block length from 12 to 2 increased effective
bootstrap blocks ~6×, reduced the long CI spread by 22%, and reduced the short CI spread
by 60%, producing tighter and statistically appropriate confidence intervals.
 
#### Additional Changes
 
**`ComputeBootstrappedWidths` unified with `suggestStationaryBlockLengthFromACF`**
`ComputeBootstrappedWidths` contained its own inline reimplementation of the block-length
logic that used the old pointwise threshold, an additional "practical threshold"
(`min(0.05, 2.5/√n)`), and the single-lag rule. All three divergences have been
corrected. The `prac_thresh` has been removed entirely. Named constants `kMaxACFLag` and
`kBonferroniZ` make the relationship between the two sites explicit.
 
**Portable `erfinv` via Boost**
Computing the exact Bonferroni z-critical requires the inverse error function, which is
not in the C++ standard library. `boost::math::erf_inv` was chosen because Boost is
already a project dependency and is portable across MSVC and GCC. A hand-rolled
`mkc_erfinv` fallback (Winitzki 2008 approximation + 2 Halley iterations, accurate to
<5e-15) remains available for dependency-free builds.
 
**Unit test corrections in `StatUtilsTest.cpp`**
Two existing tests were updated to reflect the corrected algorithm behaviour. Both
failures were caused by the tests reimplementing or depending on the old (incorrect)
threshold and single-lag logic. The updated tests verify the clamping mechanism and the
correct handling of alternating ACF patterns that are structural artifacts of
paired-return data rather than genuine autocorrelation.
 
---
 
## Files Changed
 
| File | Change |
|------|--------|
| `libs/statistics/StatUtils.h` | Bonferroni threshold + consecutive-lag rule in `suggestStationaryBlockLengthFromACF`; Boost `erf_inv` include |
| `libs/backtesting/BootStrapIndicators.h` | Bonferroni threshold + consecutive-lag rule in `ComputeBootstrappedWidths`; removed `prac_thresh`; named constants |
| `libs/statistics/BiasCorrectedBootstrap.h` | Thread-safety fix and RNG draw ordering in `StationaryBlockResampler`; jackknife clamp and guards; `std::size_t` consistency and variable renaming in `IIDResampler`; documentation for both |
| `libs/resampling/test/StationaryBlockResamplerJackknifeTest.cpp` | 2 new tests |
| `libs/statistics/test/BiasCorrectedBootstrapTest.cpp` | 2 new tests |
| `libs/statistics/test/BiasCorrectedBootstrapAdditionalTest.cpp` | 5 new tests (1 replaced) |
| `libs/statistics/test/StatUtilsTest.cpp` | 2 corrected tests |
 
---
 
## References
 
- Politis, D.N., & Romano, J.P. (1994). "The Stationary Bootstrap." *JASA*, 89(428).
- Politis, D.N., & White, H. (2004). "Automatic Block-Length Selection for the Dependent Bootstrap." *Econometric Reviews*, 23(1).
- Efron, B. (1987). "Better Bootstrap Confidence Intervals." *JASA*, 82(397).
- Künsch, H.R. (1989). "The Jackknife and the Bootstrap for General Stationary Observations." *Annals of Statistics*, 17(3).
- Winitzki, S. (2008). "A handy approximation for the error function and its inverse."