### PR TITLE
Cleanup/mcpt policy classes

### DIFF
--- a/libs/statistics/MonteCarloTestPolicy.h
+++ b/libs/statistics/MonteCarloTestPolicy.h
@@ -162,96 +162,82 @@ namespace mkc_timeseries
   };
 
   /**
-   * @class BootStrappedLogProfitFactorPolicy
-   * @brief Permutation test policy using a robust log-profit-factor with stop-loss and profit-target priors.
+ * @class BootStrappedLogProfitFactorPolicy
+ * @brief Permutation test policy returning a symmetric log-profit-factor (log PF).
+ *
+ * Computes log(PF) from high-resolution bar returns using
+ * StatUtils::computeLogProfitFactorRobust_LogPF, which applies ruin-epsilon
+ * clipping, denominator flooring, and Bayesian prior strength via
+ * LegacyNumerPolicy and LegacyDenomPolicy.
+ *
+ * Stop-loss and profit-target are not forwarded because
+ * computeLogProfitFactorRobust_LogPF has no corresponding parameters;
+ * the overloads that previously accepted them are deprecated no-ops.
+ *
+ * @tparam Decimal Numeric type (e.g., num::DefaultNumber).
+ */
+template <class Decimal>
+class BootStrappedLogProfitFactorPolicy
+{
+public:
+  /**
+   * @brief Compute the symmetric log-profit-factor for a single permuted backtester.
    *
-   * Computes a robust log-profit-factor from high-resolution bar returns using
-   * StatUtils::computeLogProfitFactorRobust_LogPF, which incorporates automatic
-   * return-to-log conversion, ruin-epsilon clipping, denominator flooring, and
-   * Bayesian prior strength. The strategy's stop-loss and profit-target percentages
-   * are extracted from the PalPattern and passed through to the robust computation.
-   *
-   * @tparam Decimal Numeric type (e.g., num::DefaultNumber).
+   * @param bt Single-strategy backtester from which high-resolution returns are extracted.
+   * @return log(PF), or zero if trade/bar thresholds are not met.
+   * @throws BackTesterException If bt does not contain exactly one strategy, or if
+   *         the strategy cannot be downcast to PalStrategy.
    */
-  template <class Decimal>
-  class BootStrappedLogProfitFactorPolicy
+  static Decimal
+  getPermutationTestStatistic(std::shared_ptr<BackTester<Decimal>> bt)
   {
-  public:
-    /**
-     * @brief Compute the robust log-profit-factor incorporating stop-loss and profit-target priors.
-     *
-     * @param bt Single-strategy backtester from which high-resolution returns are extracted.
-     * @return The robust log-profit-factor, or zero if trade/bar thresholds are not met.
-     * @throws BackTesterException If bt does not contain exactly one strategy.
-     */
-    static Decimal
-    getPermutationTestStatistic(std::shared_ptr<BackTester<Decimal>> bt)
-    {
-      // Enforce single-strategy invariant
-      if (bt->getNumStrategies() != 1) {
-        throw BackTesterException(
-				  "BootStrappedLogProfitFactorPolicy::getPermutationTestStatistic - expected one strategy");
-      }
-
-      const unsigned int minTradesRequired = getMinStrategyTrades();
-      const unsigned int minBarsRequired   = getMinBarSeriesSize();
-      const uint32_t numTrades = bt->getNumTrades();
-      auto strat = *(bt->beginStrategies());
-
-      std::vector<Decimal> barSeries = bt->getAllHighResReturns(strat.get());
-
-      if (numTrades < minTradesRequired || barSeries.size() < minBarsRequired) {
-        return getMinTradeFailureTestStatistic();
-      }
-
-      // -----------------------------------------------------------------------
-      // Retrieve Strategy Stop Loss and Profit Target (return space)
-      // -----------------------------------------------------------------------
-      double stopLossPct = 0.0;
-      double profitTargetPct = 0.0;
-
-      auto palStrategy = std::dynamic_pointer_cast<PalStrategy<Decimal>>(strat);
-      if (palStrategy)
-	{
-	  auto pattern = palStrategy->getPalPattern();
-	  if (pattern)
-	    {
-	      // Stop Loss
-	      Decimal stopDec = pattern->getStopLossAsDecimal();
-	      auto stopPn = mkc_timeseries::PercentNumber<Decimal>::createPercentNumber(stopDec);
-	      stopLossPct = num::to_double(stopPn.getAsPercent());
-
-	      // Profit Target
-	      Decimal profitTargetDec = pattern->getProfitTargetAsDecimal();
-	      auto profitTargetPn =
-                mkc_timeseries::PercentNumber<Decimal>::createPercentNumber(profitTargetDec);
-	      profitTargetPct = num::to_double(profitTargetPn.getAsPercent());
-	    }
-	}
-
-      // -----------------------------------------------------------------------
-      // Use newer _LogPF interface with automatic return→log conversion
-      // -----------------------------------------------------------------------
-
-      const double prior_strength = 0.01;
-      return StatUtils<Decimal>::computeLogProfitFactorRobust_LogPF(
-								    barSeries,
-								    StatUtils<Decimal>::DefaultRuinEps,
-								    StatUtils<Decimal>::DefaultDenomFloor,
-								    prior_strength,
-								    stopLossPct,
-								    profitTargetPct);
+    // Enforce single-strategy invariant.
+    if (bt->getNumStrategies() != 1) {
+      throw BackTesterException(
+        "BootStrappedLogProfitFactorPolicy::getPermutationTestStatistic - "
+        "expected exactly one strategy");
     }
 
-    /// Minimum number of trades required to attempt this test
-    static unsigned int getMinStrategyTrades() { return 9; }
+    auto strat = *(bt->beginStrategies());
 
-    /// Minimum bar-series length required for statistical stability.
-    static unsigned int getMinBarSeriesSize() { return 10; }
+    // This policy is inherently PalStrategy-specific; a failed cast is a
+    // programming contract violation, not a recoverable runtime condition.
+    if (!std::dynamic_pointer_cast<PalStrategy<Decimal>>(strat)) {
+      throw BackTesterException(
+        "BootStrappedLogProfitFactorPolicy::getPermutationTestStatistic - "
+        "strategy is not a PalStrategy");
+    }
 
-    /// Neutral value returned when minimum trade or bar thresholds are not met.
-    static Decimal getMinTradeFailureTestStatistic()
-    {
+    const uint32_t numTrades = bt->getNumTrades();
+    std::vector<Decimal> barSeries = bt->getAllHighResReturns(strat.get());
+
+    if (numTrades < getMinStrategyTrades() ||
+        barSeries.size() < getMinBarSeriesSize()) {
+      return getMinTradeFailureTestStatistic();
+    }
+
+    // prior_strength = 0.01: intentionally weaker than DefaultPriorStrength (0.5)
+    // so the statistic remains sensitive to the permuted data rather than being
+    // pulled toward the prior. Bounds the effective PF ratio to [0.01, 100].
+    static constexpr double prior_strength = 0.01;
+
+    return StatUtils<Decimal>::computeLogProfitFactorRobust_LogPF(
+      barSeries,
+      StatUtils<Decimal>::DefaultRuinEps,
+      StatUtils<Decimal>::DefaultDenomFloor,
+      prior_strength);
+  }
+
+  /// Minimum number of completed trades required to attempt the test.
+  static unsigned int getMinStrategyTrades() { return 9; }
+
+  /// Minimum bar-series length required for statistical stability.
+  static unsigned int getMinBarSeriesSize() { return 10; }
+
+  /// Neutral value returned when minimum trade or bar thresholds are not met.
+  /// Zero is correct: log(PF = 1) = 0 means break-even / no edge.
+  static Decimal getMinTradeFailureTestStatistic()
+  {
     return DecimalConstants<Decimal>::DecimalZero;
   }
 };
@@ -402,113 +388,71 @@ namespace mkc_timeseries
   };
 
   /**
-   * @class BootStrappedSharpeRatioPolicy
-   * @brief Permutation test policy using a BCa-bootstrapped Sharpe ratio over log returns.
+ * @class BootStrappedSharpeRatioPolicy
+ * @brief Permutation test policy returning a Sharpe ratio computed over log returns.
+ *
+ * Converts bar-by-bar percent returns to log space via log(1 + r), then
+ * computes a Sharpe ratio using StatUtils::sharpeFromReturns. The result is
+ * used directly as the permutation test statistic — no bootstrapping is
+ * performed here; the permutation loop in the caller provides the null
+ * distribution.
+ *
+ * @tparam Decimal Numeric type (e.g., num::DefaultNumber).
+ */
+template <class Decimal>
+class BootStrappedSharpeRatioPolicy
+{
+public:
+  /**
+   * @brief Compute the Sharpe ratio over log returns for a single permuted backtester.
    *
-   * Converts bar-by-bar returns to log space, then computes a Sharpe ratio using
-   * stationary-block BCa bootstrap with a block length equal to the median holding
-   * period. Returns the lower BCa confidence bound as a conservative scalar for
-   * permutation testing, taming the right tail per Masters.
-   *
-   * @tparam Decimal Numeric type (e.g., num::DefaultNumber).
+   * @param bt Single-strategy backtester from which high-resolution returns are extracted.
+   * @return Sharpe ratio over log(1+r) bars, or zero if trade/bar thresholds are not met.
+   * @throws BackTesterException If bt does not contain exactly one strategy.
    */
-  template <class Decimal>
-  class BootStrappedSharpeRatioPolicy
+  static Decimal
+  getPermutationTestStatistic(std::shared_ptr<BackTester<Decimal>> bt)
   {
-  public:
-    /**
-     * @brief Computes a Sharpe Ratio while taming the tails.
-     *
-     * The statistic is then bootstrapped to generate a p-value, providing a robust
-     * assessment of strategy viability.
-     */
-    static Decimal
-    getPermutationTestStatistic(std::shared_ptr<BackTester<Decimal>> bt)
-    {
-      if (bt->getNumStrategies() != 1) {
-	throw BackTesterException(
-				  "BootStrappedSharpeRatioPolicy::getPermutationTestStatistic - expected one strategy, got "
-				  + std::to_string(bt->getNumStrategies()));
-      }
-
-      // ---- Basic sanity thresholds (same spirit as existing policies)
-      const unsigned int minTradesRequired = getMinStrategyTrades();
-      const unsigned int minBarsRequired   = getMinBarSeriesSize();
-
-      const uint32_t numTrades = bt->getNumTrades();
-      auto strat = *(bt->beginStrategies());
-
-      // Pull every bar-by-bar return (entry→exit and any still-open)
-      std::vector<Decimal> barSeries = bt->getAllHighResReturns(strat.get());
-
-      // Convert percent bars → log bars (r_log = log(1 + r_pct)):
-      std::vector<Decimal> logBars;
-      logBars.reserve(barSeries.size());
-      for (const auto& r : barSeries)
-	{
-	  // Use your Decimal math: Decimal one(DecimalConstants<Decimal>::DecimalOne);
-	  logBars.push_back(std::log(DecimalConstants<Decimal>::DecimalOne + r));
-	}
-
-      const uint32_t nBars = static_cast<uint32_t>(barSeries.size());
-
-      if (numTrades < minTradesRequired || nBars < minBarsRequired) {
-	return getMinTradeFailureTestStatistic();
-      }
-
-      const unsigned B     = 1000;   // Number of bootstrap replications
-      const double   alpha = 0.05;   // 95% Confidence interval
-      const double   eps   = 1e-8;   // ε-floor for Sharpe denominator
-
-      auto computeSharpeScore = [&](const std::vector<Decimal>& r) -> Decimal
-      {
-        return StatUtils<Decimal>::sharpeFromReturns(r, eps);
-      };
-
-      // ---- Stationary-block resampler with L = median holding period (min 2)
-      size_t L = 2;
-      {
-	auto& closedPositions = strat->getStrategyBroker().getClosedPositionHistory();
-	const unsigned medHold = closedPositions.getMedianHoldingPeriod();
-	L = std::max<size_t>(2, static_cast<size_t>(medHold));
-      }
-
-      // BCa over stationary blocks
-      mkc_timeseries::StationaryBlockResampler<Decimal> sampler(L);
-
-      struct CompositeScoreFn {
-	decltype(computeSharpeScore)& f;
-	Decimal operator()(const std::vector<Decimal>& v) const { return f(v); }
-      } score{computeSharpeScore};
-
-      using BlockBCA = mkc_timeseries::BCaBootStrap<Decimal, mkc_timeseries::StationaryBlockResampler<Decimal>>;
-      BlockBCA bca(logBars, B, /*confidence=*/1.0 - alpha, score, sampler);
-
-      // Conservative scalar for permutation testing (tames right tail per Masters)
-      const Decimal lowerBound = bca.getLowerBound();
-      return lowerBound;
+    if (bt->getNumStrategies() != 1) {
+      throw BackTesterException(
+        "BootStrappedSharpeRatioPolicy::getPermutationTestStatistic - "
+        "expected exactly one strategy, got "
+        + std::to_string(bt->getNumStrategies()));
     }
 
-    /// Minimum number of trades required to even attempt this test
-    static unsigned int getMinStrategyTrades()
-    {
-      return 5;
+    auto strat = *(bt->beginStrategies());
+    const uint32_t numTrades = bt->getNumTrades();
+    std::vector<Decimal> barSeries = bt->getAllHighResReturns(strat.get());
+
+    // Guard before any computation.
+    if (numTrades < getMinStrategyTrades() ||
+        barSeries.size() < getMinBarSeriesSize()) {
+      return getMinTradeFailureTestStatistic();
     }
 
-    /// Minimum bar-series length required for statistical stability of the Sharpe estimate.
-    static unsigned int getMinBarSeriesSize()
-    {
-      return 20;
-    }
+    // Convert percent bars → log bars: r_log = log(1 + r_pct).
+    std::vector<Decimal> logBars;
+    logBars.reserve(barSeries.size());
+    for (const auto& r : barSeries)
+      logBars.push_back(std::log(DecimalConstants<Decimal>::DecimalOne + r));
 
-    /// Neutral value returned when minimum trade or bar thresholds are not met.
-    static Decimal getMinTradeFailureTestStatistic()
-    {
-        return DecimalConstants<Decimal>::DecimalZero;
-    }
+    static constexpr double eps = 1e-8;  // ε-floor for the Sharpe denominator.
+    return StatUtils<Decimal>::sharpeFromReturns(logBars, eps);
+  }
 
-  private:
-  };
+  /// Minimum number of completed trades required to attempt the test.
+  static unsigned int getMinStrategyTrades() { return 9; }
+
+  /// Minimum bar-series length required for statistical stability of the Sharpe estimate.
+  static unsigned int getMinBarSeriesSize() { return 20; }
+
+  /// Neutral value returned when minimum trade or bar thresholds are not met.
+  /// Zero is correct: a Sharpe of zero means no risk-adjusted edge.
+  static Decimal getMinTradeFailureTestStatistic()
+  {
+    return DecimalConstants<Decimal>::DecimalZero;
+  }
+};
 
   /**
    * @class NonGranularProfitFactorPolicy

--- a/libs/statistics/StatUtils.h
+++ b/libs/statistics/StatUtils.h
@@ -923,14 +923,29 @@ namespace mkc_timeseries
     // Policy 3: smooth + count-fading with k0 computed from N (best small-sample)
     struct SmoothAdditiveWinCountFadingDenomPolicy
     {
-      static int computeK0FromN(int N)
+      // computeK0FromNAndLossCount: computes virtual prior-loss count for the fade formula.
+      //
+      // k0 represents imaginary prior losses in the Bayesian pseudo-count formula:
+      //   fade = k0 / (k0 + loss_count)
+      //
+      // expected_losses is estimated as round(0.20 * N), matching the original
+      // computeK0FromN scaling.  The factor 0.20 is not a loss-rate estimate; it
+      // is calibrated so that k0 lands in the mid-range of [3, 10] for the typical
+      // N window of [20, 30] (e.g., N=25 → expected_losses=5).
+      //
+      // k0 = min(expected_losses, max(loss_count, 1)), clamped to [3, 10].
+      // Taking the minimum ensures k0 never exceeds what either N or the observed
+      // loss count would suggest independently, preventing over-regularisation in
+      // the rare large-N / sparse-loss case (N~50-60, loss_count~4-8).
+      static int computeK0FromNAndLossCount(int N, int loss_count)
       {
-	// Your preference: k0 ~ 5 for N~20–27
-	// Use k0 = round(0.2*N), clamped.
-	if (N <= 0) return 5;
-
-	const xdouble raw = static_cast<xdouble>(N) * 0.20L;
-	int k0 = static_cast<int>(std::llround(raw));
+	// Use the smaller of N-based expected losses and actual loss_count
+	// to avoid over-estimating k0 when win rate is unusually high.
+	const int expected_losses = static_cast<int>(std::llround(0.20 * N));
+	const int reference       = std::min(expected_losses,
+					     std::max(loss_count, 1));
+	
+	int k0 = reference;
 	if (k0 < 3)  k0 = 3;
 	if (k0 > 10) k0 = 10;
 	return k0;
@@ -946,7 +961,7 @@ namespace mkc_timeseries
 	if (loss_count < 0) loss_count = 0;
 	if (N < 0) N = 0;
 
-	const int k0_int = computeK0FromN(N);
+	const int k0_int = computeK0FromNAndLossCount(N, loss_count);;
 
 	const xdouble k0   = static_cast<xdouble>(k0_int);
 	const xdouble lc   = static_cast<xdouble>(loss_count);
@@ -1009,12 +1024,22 @@ namespace mkc_timeseries
     struct ResultLogPFPolicy
     {
       // Returns log(PF) = log(numer) - log(denom).
-      // This matches the LogPF family behavior. :contentReference[oaicite:3]{index=3}
+    //
+    // Precondition: both numer and denom must be strictly positive.
+    // This is guaranteed by NumeratorFloorPolicy (numer >= floor_d > 0)
+    // and any compliant DenomPolicy (denom >= floor_d > 0).
+    // Throws std::logic_error if violated, since a non-positive value
+    // indicates a policy contract violation, not bad input data.
       static Decimal finalizeFromRatio(const Decimal& numer, const Decimal& denom)
       {
 	// Use long double logs to avoid relying on std::log(Decimal) overloads.
 	const long double n = num::to_long_double(numer);
 	const long double d = num::to_long_double(denom);
+
+	if (n <= 0.0L || d <= 0.0L)
+	  throw std::logic_error(
+				 "ResultLogPFPolicy: numer and denom must be strictly positive; "
+				 "check that NumerPolicy and DenomPolicy honour the floor contract");
 	return Decimal(std::log(n) - std::log(d));
       }
     };

--- a/libs/statistics/test/StatUtilsPermutationTest.cpp
+++ b/libs/statistics/test/StatUtilsPermutationTest.cpp
@@ -1,0 +1,420 @@
+// StatUtilsPermutationTest.cpp
+//
+// Regression tests for computeLogProfitFactorRobust_LogPF in the permutation
+// testing context (LegacyNumerPolicy + HardMaxWinAnchorDenomPolicy,
+// prior_strength = 0.01).
+//
+// BACKGROUND
+// ----------
+// The permutation testing path uses the legacy (hard-max) denominator policy:
+//
+//   prior_loss_mag = max(floor_d, prior_strength × sum_log_wins)
+//   denom          = max(sum_loss_mag, prior_loss_mag)
+//
+// The prior is therefore completely inert whenever:
+//
+//   sum_loss_mag >= prior_strength × sum_log_wins
+//
+// which holds for the vast majority of permutations of a real series.  The
+// prior only activates for the sparse-loss tail, capping log(PF) at
+// log(1/prior_strength) = log(100) ≈ 4.605.
+//
+// After reviewing the code, the recommendation was to run an empirical check:
+// construct the 10,000-permutation null distribution and verify no pileup
+// occurs near log(100).  These tests convert that check into deterministic,
+// reproducible unit tests by sweeping representative win-rate scenarios.
+//
+// THREE CONCERNS ADDRESSED
+// ------------------------
+// Section 1 — Structural: HardMaxWinAnchorDenomPolicy is inert for typical
+//   permutation inputs and only activates below a well-defined threshold.
+//
+// Section 2 — End-to-end: Specific permutation-like scenarios produce the
+//   expected log(PF) values through the full call path.
+//
+// Section 3 — Distribution: A deterministic win-rate sweep proves the cap
+//   binds only for the pure no-loss case (prior=0.01), and a control test
+//   proves the tests are sensitive — prior=0.5 (the default) would cause
+//   7 out of 20 sweep cases to pile up, and these tests would catch it.
+//
+// FILE PLACEMENT
+// --------------
+// These tests are in a separate file from StatUtilsPolicyTest.cpp because:
+//   • They operate at distribution level, not policy-unit level.
+//   • The control test deliberately validates failure behavior (prior=0.5
+//     causes pileup), which is an unusual pattern among unit tests.
+//   • They can be run in isolation via the [Permutation] tag.
+//
+// Run just these tests:
+//   ./test_runner [Permutation]
+//
+// ============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <vector>
+#include <cmath>
+#include <limits>
+
+#include "StatUtils.h"
+#include "TestUtils.h"
+#include "DecimalConstants.h"
+#include "number.h"
+
+using namespace mkc_timeseries;
+
+using D    = DecimalType;
+using DC   = DecimalConstants<D>;
+using Stat = StatUtils<D>;
+
+// Tolerance for log-domain comparisons
+static constexpr double kLogTol    = 1e-7;
+
+// The prior_strength used by the production permutation testing path.
+static constexpr double kPermPrior = 0.01;
+
+// The resulting cap on log(PF): log(1 / kPermPrior) = log(100) ≈ 4.605.
+// Computed at runtime because std::log is not constexpr in C++17.
+static const double kCapValue = std::log(1.0 / kPermPrior);
+
+// Build a return series of n_wins wins and n_losses losses at the given
+// per-bar return sizes.  Order does not matter for the accumulation policies.
+static std::vector<D> makePermSeries(int n_wins, int n_losses,
+                                      const char* win_ret,
+                                      const char* loss_ret)
+{
+    std::vector<D> bars;
+    bars.reserve(n_wins + n_losses);
+    for (int i = 0; i < n_wins;   ++i) bars.push_back(D(win_ret));
+    for (int i = 0; i < n_losses; ++i) bars.push_back(D(loss_ret));
+    return bars;
+}
+
+// ============================================================================
+// SECTION 1: HardMaxWinAnchorDenomPolicy — permutation disengagement
+//
+// Verifies the structural property that makes this policy suitable for
+// permutation testing: the prior is inert when losses are adequate, and
+// only activates below a clear threshold.
+// ============================================================================
+
+TEST_CASE("HardMaxWinAnchorDenomPolicy: prior is inert for typical permutation input",
+          "[StatUtils][Permutation][HardMaxDenom][Disengagement]")
+{
+    // A permutation with ~12% loss bars (typical for many strategies):
+    //   sum_log_wins  = 0.40
+    //   sum_loss_mag  = 0.05
+    //   threshold     = 0.01 × 0.40 = 0.004
+    //   0.05 >> 0.004 → prior completely inert
+    //   denom must equal sum_loss_mag exactly, not perturbed by the prior.
+
+    const D wins(0.40), loss_mag(0.05), floor_d(D(Stat::DefaultDenomFloor));
+
+    D denom = Stat::HardMaxWinAnchorDenomPolicy::computeDenom(
+        wins, loss_mag, floor_d, kPermPrior, -1, -1);
+
+    REQUIRE(num::to_double(denom) == Catch::Approx(0.05).margin(kLogTol));
+}
+
+TEST_CASE("HardMaxWinAnchorDenomPolicy: prior activates only below the threshold",
+          "[StatUtils][Permutation][HardMaxDenom][Activation]")
+{
+    // Sparse-loss permutation: sum_loss_mag = 0.001, threshold = 0.004.
+    // sum_loss_mag < threshold → prior takes over.
+    // denom = max(0.001, max(floor_d, 0.004)) = 0.004.
+
+    const D wins(0.40), loss_mag(0.001), floor_d(D(Stat::DefaultDenomFloor));
+    const double expected_threshold = kPermPrior * 0.40; // 0.004
+
+    D denom = Stat::HardMaxWinAnchorDenomPolicy::computeDenom(
+        wins, loss_mag, floor_d, kPermPrior, -1, -1);
+
+    REQUIRE(num::to_double(denom) == Catch::Approx(expected_threshold).margin(kLogTol));
+}
+
+TEST_CASE("HardMaxWinAnchorDenomPolicy: default prior_strength=0.5 clips typical permutation",
+          "[StatUtils][Permutation][HardMaxDenom][DefaultPriorWrong]")
+{
+    // Documents WHY prior_strength=0.01 was chosen over the default 0.5.
+    //
+    // With prior_strength=0.5 and the same input (wins=0.40, loss_mag=0.05):
+    //   threshold = 0.5 × 0.40 = 0.20
+    //   loss_mag (0.05) < threshold (0.20) → prior IS active
+    //   denom = 0.20 instead of 0.05
+    //
+    // This inflates the denominator 4× and silently clips log(PF) from
+    // log(8) ≈ 2.08 down to log(2) ≈ 0.69 — a 3× error on a perfectly
+    // typical profitable permutation.  The null distribution is distorted.
+    //
+    // With prior_strength=0.01: denom = 0.05 (correct, prior inert).
+
+    const D wins(0.40), loss_mag(0.05), floor_d(D(Stat::DefaultDenomFloor));
+
+    D denom_correct = Stat::HardMaxWinAnchorDenomPolicy::computeDenom(
+        wins, loss_mag, floor_d, /*prior=*/0.01, -1, -1);
+
+    D denom_default = Stat::HardMaxWinAnchorDenomPolicy::computeDenom(
+        wins, loss_mag, floor_d, /*prior=*/0.5, -1, -1);
+
+    // With 0.01: prior inert, denominator equals actual losses
+    REQUIRE(num::to_double(denom_correct) == Catch::Approx(0.05).margin(kLogTol));
+
+    // With 0.5: prior active, denominator inflated to 0.20
+    REQUIRE(num::to_double(denom_default) == Catch::Approx(0.20).margin(kLogTol));
+
+    // The distortion is severe: denominator is 4× larger with the default prior
+    REQUIRE(num::to_double(denom_default) > num::to_double(denom_correct) * 3.5);
+}
+
+// ============================================================================
+// SECTION 2: computeLogProfitFactorRobust_LogPF — end-to-end permutation path
+// ============================================================================
+
+TEST_CASE("computeLogProfitFactorRobust_LogPF: all-wins series caps at log(100)",
+          "[StatUtils][Permutation][FullPath][Cap]")
+{
+    // A permutation that draws no losing bars produces:
+    //   denom = prior_strength × sum_log_wins
+    //   log(PF) = log(sum_log_wins / (prior × sum_log_wins)) = log(1/prior) = log(100)
+    //
+    // This is the intended upper bound: a finite, large-but-specific value
+    // rather than an unbounded result that would corrupt the null distribution.
+
+    const std::vector<D> all_wins(20, D("0.01"));
+
+    D result = Stat::computeLogProfitFactorRobust_LogPF(
+        all_wins, Stat::DefaultRuinEps, Stat::DefaultDenomFloor, kPermPrior);
+
+    REQUIRE(std::isfinite(num::to_double(result)));
+    REQUIRE(num::to_double(result) == Catch::Approx(kCapValue).margin(kLogTol));
+}
+
+TEST_CASE("computeLogProfitFactorRobust_LogPF: balanced permutation returns raw log(PF)",
+          "[StatUtils][Permutation][FullPath][Balanced]")
+{
+    // 50 wins and 50 losses of equal return magnitude.
+    // sum_loss_mag (≈0.2506) >> threshold (0.01 × 0.2494 ≈ 0.0025) → prior inert.
+    // Result must equal the analytically computed raw log(PF).
+    //
+    // Note: log(1+r) ≠ -log(1-r), so with equal returns the result is very
+    // slightly negative (~-0.005), not exactly zero.
+
+    const double r       = 0.005;
+    const int    n       = 50;
+    const double raw_w   = static_cast<double>(n) * std::log(1.0 + r);
+    const double raw_l   = static_cast<double>(n) * (-std::log(1.0 - r));
+    const double expected = std::log(raw_w) - std::log(raw_l);
+
+    std::vector<D> bars;
+    for (int i = 0; i < n; ++i) bars.push_back(D("0.005"));
+    for (int i = 0; i < n; ++i) bars.push_back(D("-0.005"));
+
+    D result = Stat::computeLogProfitFactorRobust_LogPF(
+        bars, Stat::DefaultRuinEps, Stat::DefaultDenomFloor, kPermPrior);
+
+    REQUIRE(std::isfinite(num::to_double(result)));
+    // Prior is inert: result equals the unregularized raw log(PF)
+    REQUIRE(num::to_double(result) == Catch::Approx(expected).margin(kLogTol));
+    // Approximately zero, well below the cap
+    REQUIRE(std::abs(num::to_double(result)) < 0.01);
+}
+
+TEST_CASE("computeLogProfitFactorRobust_LogPF: profitable permutation is unregularized",
+          "[StatUtils][Permutation][FullPath][Profitable]")
+{
+    // 60 wins and 40 losses of equal return magnitude (+/-1%).
+    // sum_loss_mag (≈0.402) >> threshold (0.01 × 0.597 ≈ 0.006) → prior inert.
+    // Result must equal the analytically computed raw log(PF) exactly.
+    // Prior must contribute nothing.
+
+    const double r        = 0.01;
+    const int    n_wins   = 60;
+    const int    n_losses = 40;
+    const double raw_w    = static_cast<double>(n_wins)   * std::log(1.0 + r);
+    const double raw_l    = static_cast<double>(n_losses) * (-std::log(1.0 - r));
+    const double expected = std::log(raw_w) - std::log(raw_l);
+
+    std::vector<D> bars;
+    for (int i = 0; i < n_wins;   ++i) bars.push_back(D("0.01"));
+    for (int i = 0; i < n_losses; ++i) bars.push_back(D("-0.01"));
+
+    D result = Stat::computeLogProfitFactorRobust_LogPF(
+        bars, Stat::DefaultRuinEps, Stat::DefaultDenomFloor, kPermPrior);
+
+    REQUIRE(std::isfinite(num::to_double(result)));
+    REQUIRE(num::to_double(result) == Catch::Approx(expected).margin(kLogTol));
+    // Must be well below the cap — prior did not interfere
+    REQUIRE(num::to_double(result) < kCapValue - 1.0);
+}
+
+TEST_CASE("computeLogProfitFactorRobust_LogPF: all-losses series has large negative log(PF)",
+          "[StatUtils][Permutation][FullPath][AllLoss]")
+{
+    // Permutation with no wins: numer = max(0, floor_d) = 1e-6 (tiny).
+    // Large denominator → very negative log(PF).
+    // Verifies the lower tail of the null distribution is correctly
+    // unbounded — necessary so that losing permutations are clearly
+    // distinguishable from the observed strategy result.
+
+    const std::vector<D> all_losses(20, D("-0.01"));
+
+    D result = Stat::computeLogProfitFactorRobust_LogPF(
+        all_losses, Stat::DefaultRuinEps, Stat::DefaultDenomFloor, kPermPrior);
+
+    REQUIRE(std::isfinite(num::to_double(result)));
+    REQUIRE(num::to_double(result) < -5.0);
+}
+
+// ============================================================================
+// SECTION 3: Null distribution — pileup regression tests
+//
+// These are the unit-test equivalent of the recommended empirical check.
+//
+// A sweep of 20 win-rate scenarios (n_wins = 5, 10, ..., 100 out of 100 bars,
+// equal win/loss magnitudes) is used to verify that:
+//
+//   1. The cap at log(100) binds ONLY for the pure no-loss case (n_wins=100).
+//      For all other cases the prior is inert and the result is the raw log(PF).
+//
+//   2. A control test with prior_strength=0.5 (the default) confirms that 7
+//      out of 20 cases pile up at log(2) ≈ 0.693, proving the pileup test is
+//      genuinely sensitive to the key regression.
+//
+//   3. The null distribution is strictly monotone in win rate, confirming
+//      there are no discontinuities or anomalies in the distribution shape.
+//
+// MATH VERIFICATION
+// -----------------
+// With r = 0.005 and 100 bars, the prior disengages when:
+//   n_losses × (-log(0.995)) >= 0.01 × n_wins × log(1.005)
+//   n_losses/n_wins >= 0.01 × (log(1.005) / (-log(0.995))) ≈ 0.00995
+//
+// For n_wins=99, n_losses=1: 1/99 ≈ 0.01010 > 0.00995 → inert.
+// Therefore, prior is inert for ALL cases with n_losses >= 1 in a 100-bar
+// equal-magnitude series.  Only n_wins=100 triggers the cap.
+// ============================================================================
+
+TEST_CASE("Null distribution: equal-magnitude sweep — cap binds only at 100% wins",
+          "[StatUtils][Permutation][NullDist][PileupAbsence]")
+{
+    // Sweep n_wins = 5, 10, ..., 100 with equal win/loss magnitudes (r=0.005).
+    // For each case with losses: verify result equals the analytically computed
+    // raw log(PF) — confirming the prior is completely inert.
+    // Count results near the cap (within 0.01): must be at most 1.
+
+    const int    n_bars = 100;
+    const double r      = 0.005;
+    const double eps    = 0.01;
+
+    int near_cap_count = 0;
+
+    for (int n_wins = 5; n_wins <= 100; n_wins += 5)
+    {
+        const int n_losses = n_bars - n_wins;
+        auto bars = makePermSeries(n_wins, n_losses, "0.005", "-0.005");
+
+        D result = Stat::computeLogProfitFactorRobust_LogPF(
+            bars, Stat::DefaultRuinEps, Stat::DefaultDenomFloor, kPermPrior);
+
+        const double rv = num::to_double(result);
+        INFO("n_wins=" << n_wins << " n_losses=" << n_losses
+                       << " → log(PF)=" << rv
+                       << " cap=" << kCapValue);
+
+        REQUIRE(std::isfinite(rv));
+        REQUIRE(rv <= kCapValue + eps);
+
+        if (n_losses > 0)
+        {
+            // Prior must be completely inert: result equals the raw log(PF)
+            const double raw_w    = static_cast<double>(n_wins)   * std::log(1.0 + r);
+            const double raw_l    = static_cast<double>(n_losses) * (-std::log(1.0 - r));
+            const double expected = std::log(raw_w) - std::log(raw_l);
+            REQUIRE(rv == Catch::Approx(expected).margin(kLogTol));
+        }
+
+        if (rv >= kCapValue - eps)
+            ++near_cap_count;
+    }
+
+    // Only the pure no-loss case (n_wins=100) should reach the cap.
+    // Any value > 1 indicates the prior is incorrectly activating for
+    // permutations that contain real loss data.
+    REQUIRE(near_cap_count <= 1);
+}
+
+TEST_CASE("Null distribution: prior_strength=0.5 causes pileup — regression sensitivity proof",
+          "[StatUtils][Permutation][NullDist][DefaultPriorPileup]")
+{
+    // CONTROL TEST: proves the pileup test above is a meaningful regression guard.
+    //
+    // With prior_strength=0.5 and equal magnitudes (r=0.005), the prior is
+    // active when:
+    //   n_losses × (-log(0.995)) < 0.5 × n_wins × log(1.005)
+    //   n_losses / n_wins < 0.5 × (log(1.005) / (-log(0.995))) ≈ 0.4975
+    //
+    // In the sweep, this activates for n_wins = 70, 75, 80, 85, 90, 95, 100
+    // (7 cases), all of which are pulled to exactly log(2) ≈ 0.693.
+    //
+    // If this test passes (count >= 6), the prior_strength=0.01 test above is
+    // confirmed as a genuine regression detector — not a vacuous assertion.
+
+    const int    n_bars  = 100;
+    const double cap_0_5 = std::log(1.0 / 0.5); // log(2) ≈ 0.693
+    const double eps     = 0.05;
+
+    int near_cap_count = 0;
+
+    for (int n_wins = 5; n_wins <= 100; n_wins += 5)
+    {
+        const int n_losses = n_bars - n_wins;
+        auto bars = makePermSeries(n_wins, n_losses, "0.005", "-0.005");
+
+        D result = Stat::computeLogProfitFactorRobust_LogPF(
+            bars, Stat::DefaultRuinEps, Stat::DefaultDenomFloor,
+            /*prior_strength=*/0.5);  // DEFAULT — wrong for permutation testing
+
+        const double rv = num::to_double(result);
+        INFO("n_wins=" << n_wins << " (prior=0.5) → log(PF)=" << rv);
+
+        REQUIRE(std::isfinite(rv));
+
+        if (rv >= cap_0_5 - eps)
+            ++near_cap_count;
+    }
+
+    // With prior_strength=0.5, 7 permutation outcomes pile up at log(2).
+    // The assertion below will FAIL if prior_strength is correctly set to 0.01,
+    // so this test must be run only with prior=0.5 as written above.
+    REQUIRE(near_cap_count >= 6);
+}
+
+TEST_CASE("Null distribution: log(PF) is strictly monotone in win rate",
+          "[StatUtils][Permutation][NullDist][Monotone]")
+{
+    // When the prior is inert, log(PF) = log(raw_wins / raw_losses) which is
+    // strictly increasing in win rate.  Monotonicity across the sweep confirms
+    // there are no discontinuities or anomalies in the null distribution shape
+    // — a necessary (though not sufficient) condition for distributional smoothness.
+    //
+    // Sweep n_wins = 5 to 95 (all cases where prior is inert).
+
+    const int n_bars = 100;
+    double prev = -std::numeric_limits<double>::infinity();
+
+    for (int n_wins = 5; n_wins <= 95; n_wins += 5)
+    {
+        const int n_losses = n_bars - n_wins;
+        auto bars = makePermSeries(n_wins, n_losses, "0.005", "-0.005");
+
+        D result = Stat::computeLogProfitFactorRobust_LogPF(
+            bars, Stat::DefaultRuinEps, Stat::DefaultDenomFloor, kPermPrior);
+
+        const double rv = num::to_double(result);
+        INFO("n_wins=" << n_wins << " → log(PF)=" << rv << " (prev=" << prev << ")");
+
+        REQUIRE(rv > prev);
+        prev = rv;
+    }
+}

--- a/libs/statistics/test/StatUtilsPolicyTest.cpp
+++ b/libs/statistics/test/StatUtilsPolicyTest.cpp
@@ -367,43 +367,6 @@ TEST_CASE("SmoothAdditiveWinDenomPolicy: denom = max(loss + alpha*wins, floor)",
     }
 }
 
-TEST_CASE("SmoothAdditiveWinCountFadingDenomPolicy: computeK0FromN",
-          "[StatUtils][Policy][CountFadingDenom][K0]")
-{
-    using P = Stat::SmoothAdditiveWinCountFadingDenomPolicy;
-
-    // k0 = round(0.20 * N), clamped to [3, 10]
-    SECTION("N <= 0 → fallback k0 = 5")
-    {
-        REQUIRE(P::computeK0FromN(0)  == 5);
-        REQUIRE(P::computeK0FromN(-1) == 5);
-    }
-
-    SECTION("Very small N → clamped to 3")
-    {
-        // round(0.20 * 5) = round(1.0) = 1 → clamped to 3
-        REQUIRE(P::computeK0FromN(5)  == 3);
-        REQUIRE(P::computeK0FromN(10) == 3); // round(2.0) = 2 → clamped to 3
-    }
-
-    SECTION("Mid-range N → formula applies")
-    {
-        // round(0.20 * 20) = round(4.0) = 4
-        REQUIRE(P::computeK0FromN(20) == 4);
-        // round(0.20 * 25) = round(5.0) = 5
-        REQUIRE(P::computeK0FromN(25) == 5);
-        // round(0.20 * 27) = round(5.4) = 5
-        REQUIRE(P::computeK0FromN(27) == 5);
-    }
-
-    SECTION("Large N → clamped to 10")
-    {
-        // round(0.20 * 100) = 20 → clamped to 10
-        REQUIRE(P::computeK0FromN(100) == 10);
-        REQUIRE(P::computeK0FromN(200) == 10);
-    }
-}
-
 TEST_CASE("SmoothAdditiveWinCountFadingDenomPolicy: count fading reduces prior as losses accumulate",
           "[StatUtils][Policy][CountFadingDenom][Fade]")
 {
@@ -511,6 +474,20 @@ TEST_CASE("ResultLogPFPolicy: finalizeFromRatio returns log(numer) - log(denom)"
         D log1p_pf = Stat::ResultLog1pPFPolicy::finalizeFromRatio(numer, denom);  // log(4)
         REQUIRE(num::to_double(raw_pf) != Catch::Approx(num::to_double(log1p_pf)).margin(0.01));
     }
+
+    SECTION("non-positive numer throws logic_error")
+      {
+	REQUIRE_THROWS_AS(
+			  Stat::ResultLogPFPolicy::finalizeFromRatio(DC::DecimalZero, D(0.10)),
+			  std::logic_error);
+      }
+
+    SECTION("non-positive denom throws logic_error")
+      {
+	REQUIRE_THROWS_AS(
+			  Stat::ResultLogPFPolicy::finalizeFromRatio(D(0.30), DC::DecimalZero),
+			  std::logic_error);
+      }
 }
 
 // ============================================================================
@@ -1047,4 +1024,373 @@ TEST_CASE("Policy ordering: higher prior_strength always produces >= denominator
 
     // larger prior_strength → larger prior_loss_mag → potentially larger denom
     REQUIRE(num::to_double(denom_hi) >= num::to_double(denom_lo));
+}
+
+// StatUtilsK0Tests.cpp
+//
+// Unit tests for SmoothAdditiveWinCountFadingDenomPolicy::computeK0FromNAndLossCount.
+//
+// The new function replaces computeK0FromN to fix a semantic mismatch:
+// k0 represents virtual prior losses in the Bayesian fade formula
+//   fade = k0 / (k0 + loss_count)
+// and must therefore be in loss units, not bar units.  The fix uses
+//   reference = min(round(0.20 * N), max(loss_count, 1))
+// clamped to [3, 10], so k0 tracks the smaller of "expected losses from N"
+// and "observed losses", preventing over-regularisation in the large-N /
+// sparse-loss case that occurs in 1-2% of bootstrap call sites.
+//
+// Test organisation mirrors StatUtilsPolicyTest.cpp (Catch2, same aliases).
+//
+// ============================================================================
+// DEPRECATION NOTE ON computeK0FromN
+// ============================================================================
+// computeK0FromN is no longer called by computeDenom after this change.
+// It is an internal static of SmoothAdditiveWinCountFadingDenomPolicy and
+// carries no ABI or public-API commitment.  Recommendation: REMOVE it along
+// with its tests in StatUtilsPolicyTest.cpp rather than leave it in a
+// "backward-compatible" state that is no longer exercised by production code.
+// Rationale is in the comment block at the bottom of this file.
+// ============================================================================
+
+using P    = Stat::SmoothAdditiveWinCountFadingDenomPolicy;
+
+// ============================================================================
+// SECTION A: computeK0FromNAndLossCount — unit tests on the helper itself
+// ============================================================================
+
+TEST_CASE("computeK0FromNAndLossCount: lower clamp enforced for small inputs",
+          "[StatUtils][Policy][K0][LowerClamp]")
+{
+    // reference = min(round(0.20*N), max(loss_count,1))
+    // Both paths can push reference below 3; clamp must fire in all cases.
+
+    SECTION("N=0, loss_count=0 → expected_losses=0, reference=min(0,1)=0 → clamped to 3")
+    {
+        REQUIRE(P::computeK0FromNAndLossCount(0, 0) == 3);
+    }
+
+    SECTION("N=5, loss_count=1 → expected_losses=1, reference=min(1,1)=1 → clamped to 3")
+    {
+        REQUIRE(P::computeK0FromNAndLossCount(5, 1) == 3);
+    }
+
+    SECTION("N=10, loss_count=2 → expected_losses=2, reference=min(2,2)=2 → clamped to 3")
+    {
+        REQUIRE(P::computeK0FromNAndLossCount(10, 2) == 3);
+    }
+
+    SECTION("N=10, loss_count=0 → expected_losses=2, reference=min(2,1)=1 → clamped to 3")
+    {
+        // max(loss_count,1)=1 prevents k0 collapsing when there are no losses
+        REQUIRE(P::computeK0FromNAndLossCount(10, 0) == 3);
+    }
+}
+
+TEST_CASE("computeK0FromNAndLossCount: upper clamp enforced",
+          "[StatUtils][Policy][K0][UpperClamp]")
+{
+    SECTION("N=200, loss_count=200 → expected_losses=40, reference=min(40,200)=40 → clamped to 10")
+    {
+        REQUIRE(P::computeK0FromNAndLossCount(200, 200) == 10);
+    }
+
+    SECTION("N=100, loss_count=50 → expected_losses=20, reference=min(20,50)=20 → clamped to 10")
+    {
+        REQUIRE(P::computeK0FromNAndLossCount(100, 50) == 10);
+    }
+}
+
+TEST_CASE("computeK0FromNAndLossCount: common N range [20, 30] — regression vs old computeK0FromN",
+          "[StatUtils][Policy][K0][CommonRange]")
+{
+    // In this range loss_count typically correlates with N (normal win rate ~50-70%).
+    // Expected losses = round(0.20 * N) and typical loss_count should be >= that,
+    // so reference = expected_losses and the two functions should agree closely.
+
+    SECTION("N=20, loss_count=8 (typical 40% loss rate)")
+    {
+        // expected_losses = round(0.20*20) = 4
+        // reference = min(4, max(8,1)) = min(4,8) = 4
+        REQUIRE(P::computeK0FromNAndLossCount(20, 8) == 4);
+        // Old function: computeK0FromN(20) == 4 — identical
+    }
+
+    SECTION("N=25, loss_count=10")
+    {
+        // expected_losses = round(0.20*25) = 5; reference = min(5,10) = 5
+        REQUIRE(P::computeK0FromNAndLossCount(25, 10) == 5);
+        // Old: computeK0FromN(25) == 5 — identical
+    }
+
+    SECTION("N=27, loss_count=11")
+    {
+        // expected_losses = round(0.20*27) = round(5.4) = 5; reference = min(5,11) = 5
+        REQUIRE(P::computeK0FromNAndLossCount(27, 11) == 5);
+        // Old: computeK0FromN(27) == 5 — identical
+    }
+
+    SECTION("N=30, loss_count=12")
+    {
+        // expected_losses = round(0.20*30) = 6; reference = min(6,12) = 6
+        REQUIRE(P::computeK0FromNAndLossCount(30, 12) == 6);
+        // Old: computeK0FromN(30) == 6 — identical
+    }
+}
+
+TEST_CASE("computeK0FromNAndLossCount: sparse-loss case in normal N range — prior still meaningful",
+          "[StatUtils][Policy][K0][SparseLoss][NormalN]")
+{
+    // A high-win-rate strategy: N=25, only 2 losses.
+    // Old function: computeK0FromN(25) = 5 → fade = 5/(5+2) = 0.71 (strong prior)
+    // New function: expected=5, reference = min(5, max(2,1)) = min(5,2) = 2 → k0=3 (clamped)
+    //              → fade = 3/(3+2) = 0.60 (still meaningful but correctly weaker)
+    // The new function recognises that 2 observed losses carry real information.
+    REQUIRE(P::computeK0FromNAndLossCount(25, 2) == 3);
+}
+
+TEST_CASE("computeK0FromNAndLossCount: large N / sparse losses — the key improvement case",
+          "[StatUtils][Policy][K0][LargeN][SparseLoss]")
+{
+    // This is the 1-2% scenario that motivated the change.
+    // Old: computeK0FromN(55) = round(0.20*55)=11 → clamped to 10
+    //      fade = 10/(10+5) = 0.667 — nearly full prior after 5 real observations
+    // New: expected=11→10 (clamped first), reference = min(10, max(5,1)) = min(10,5) = 5
+    //      → k0=5, fade = 5/(5+5) = 0.50 — meaningfully weaker, respecting observed data
+
+    SECTION("N=55, loss_count=5")
+    {
+        REQUIRE(P::computeK0FromNAndLossCount(55, 5) == 5);
+    }
+
+    SECTION("N=60, loss_count=4")
+    {
+        // expected = round(0.20*60)=12 → clamped to 10; reference = min(10, max(4,1)) = 4
+        // clamped to 3 (lower clamp)
+        REQUIRE(P::computeK0FromNAndLossCount(60, 4) == 4);
+    }
+
+    SECTION("N=50, loss_count=8")
+    {
+        // expected = round(0.20*50)=10; reference = min(10, max(8,1)) = 8
+        REQUIRE(P::computeK0FromNAndLossCount(50, 8) == 8);
+    }
+}
+
+TEST_CASE("computeK0FromNAndLossCount: loss_count=0 does not collapse k0",
+          "[StatUtils][Policy][K0][ZeroLoss]")
+{
+    // max(loss_count, 1) = 1 prevents reference from reaching 0.
+    // Without this, any N < 15 would send reference to 0 and trigger the lower clamp;
+    // we verify the lower clamp still fires correctly regardless.
+
+    SECTION("N=20, loss_count=0 → reference=min(4,1)=1 → clamped to 3")
+    {
+        REQUIRE(P::computeK0FromNAndLossCount(20, 0) == 3);
+    }
+
+    SECTION("N=50, loss_count=0 → reference=min(10,1)=1 → clamped to 3")
+    {
+        REQUIRE(P::computeK0FromNAndLossCount(50, 0) == 3);
+    }
+
+    SECTION("N=100, loss_count=0 → reference=min(10,1)=1 → clamped to 3")
+    {
+        REQUIRE(P::computeK0FromNAndLossCount(100, 0) == 3);
+    }
+}
+
+TEST_CASE("computeK0FromNAndLossCount: negative inputs are safe",
+          "[StatUtils][Policy][K0][NegativeInputs]")
+{
+    // Negative N and loss_count can arrive via the nullopt path (sentinel -1).
+    // The function must not crash and must return a value in [3, 10].
+
+    SECTION("N=-1, loss_count=-1")
+    {
+        const int k0 = P::computeK0FromNAndLossCount(-1, -1);
+        REQUIRE(k0 >= 3);
+        REQUIRE(k0 <= 10);
+    }
+
+    SECTION("N=0, loss_count=-5")
+    {
+        const int k0 = P::computeK0FromNAndLossCount(0, -5);
+        REQUIRE(k0 >= 3);
+        REQUIRE(k0 <= 10);
+    }
+}
+
+TEST_CASE("computeK0FromNAndLossCount: loss_count >= expected_losses — loss_count is not the binding constraint",
+          "[StatUtils][Policy][K0][LossCountDominates]")
+{
+    // When loss_count > expected_losses, min() selects expected_losses,
+    // matching the old computeK0FromN behavior exactly.
+
+    SECTION("N=25, loss_count=15 → expected=5, min(5,15)=5")
+    {
+        REQUIRE(P::computeK0FromNAndLossCount(25, 15) == 5);
+    }
+
+    SECTION("N=27, loss_count=20 → expected=5, min(5,20)=5")
+    {
+        REQUIRE(P::computeK0FromNAndLossCount(27, 20) == 5);
+    }
+}
+
+TEST_CASE("computeK0FromNAndLossCount: result always in [3, 10]",
+          "[StatUtils][Policy][K0][AlwaysClamped]")
+{
+    // Exhaustive sweep over representative (N, loss_count) pairs.
+    const std::vector<int> ns     = {0, 1, 5, 10, 15, 20, 25, 27, 30, 50, 55, 60, 100, 200};
+    const std::vector<int> losses = {0, 1, 2, 3,  5,  10, 15, 20, 50, 100};
+
+    for (int n : ns)
+    {
+        for (int lc : losses)
+        {
+            const int k0 = P::computeK0FromNAndLossCount(n, lc);
+            INFO("N=" << n << ", loss_count=" << lc << " → k0=" << k0);
+            REQUIRE(k0 >= 3);
+            REQUIRE(k0 <= 10);
+        }
+    }
+}
+
+// ============================================================================
+// SECTION B: End-to-end fade behaviour through computeDenom
+//
+// These tests verify that computeK0FromNAndLossCount produces the correct
+// downstream effect on the fade formula and therefore on the denominator.
+// ============================================================================
+
+TEST_CASE("computeDenom: large-N sparse-loss case produces weaker prior than old k0-from-N logic",
+          "[StatUtils][Policy][K0][EndToEnd][LargeN]")
+{
+    // Simulate what the old computeK0FromN path would have produced for N=55, lc=5,
+    // by calling SmoothAdditiveWinDenomPolicy directly with the old effective_prior.
+    //
+    // Old path: k0=10, fade=10/15=0.667, effective_prior = 0.01 * 0.667 = 0.00667
+    // New path: k0=5,  fade=5/10=0.500,  effective_prior = 0.01 * 0.500 = 0.00500
+    //
+    // With wins=0.40, loss_mag=0.05:
+    //   Old denom = 0.05 + 0.00667 * 0.40 = 0.05267
+    //   New denom = 0.05 + 0.00500 * 0.40 = 0.05200
+    //
+    // New denom is smaller (weaker prior), meaning the 5 observed losses are
+    // given more weight relative to the prior.
+
+    const D wins(0.40), loss_mag(0.05), floor_d(1e-6);
+    const double prior_strength = 0.01;
+    const int N = 55, lc = 5;
+
+    // New path (uses computeK0FromNAndLossCount internally)
+    D new_denom = P::computeDenom(wins, loss_mag, floor_d, prior_strength, lc, N);
+
+    // Old-path reconstruction: k0=10, fade=10/(10+5)
+    const double old_fade             = 10.0 / (10.0 + 5.0);
+    const double old_effective_prior  = prior_strength * old_fade;
+    D old_denom = Stat::SmoothAdditiveWinDenomPolicy::computeDenom(
+        wins, loss_mag, floor_d, old_effective_prior, -1, -1);
+
+    // New denom must be strictly less than old denom (weaker prior)
+    REQUIRE(num::to_double(new_denom) < num::to_double(old_denom));
+
+    // Both must remain finite and above the floor
+    REQUIRE(std::isfinite(num::to_double(new_denom)));
+    REQUIRE(num::to_double(new_denom) >= 1e-6);
+}
+
+TEST_CASE("computeDenom: normal N range [20,30] is unaffected by the change",
+          "[StatUtils][Policy][K0][EndToEnd][NormalN]")
+{
+    // For N=25, loss_count=10 (typical), expected_losses=5 < loss_count,
+    // so reference=min(5,10)=5 and k0=5 — same as old computeK0FromN(25)=5.
+    // Both paths must produce identical denominators.
+
+    const D wins(0.40), loss_mag(0.20), floor_d(1e-6);
+    const double prior_strength = 0.01;
+    const int N = 25, lc = 10;
+
+    D new_denom = P::computeDenom(wins, loss_mag, floor_d, prior_strength, lc, N);
+
+    // Old-path reconstruction: k0=5, fade=5/(5+10)
+    const double old_fade            = 5.0 / (5.0 + 10.0);
+    const double old_effective_prior = prior_strength * old_fade;
+    D old_denom = Stat::SmoothAdditiveWinDenomPolicy::computeDenom(
+        wins, loss_mag, floor_d, old_effective_prior, -1, -1);
+
+    REQUIRE(num::to_double(new_denom) ==
+            Catch::Approx(num::to_double(old_denom)).margin(kLogTol));
+}
+
+TEST_CASE("computeDenom: prior fades correctly as loss_count grows (new k0 path)",
+          "[StatUtils][Policy][K0][EndToEnd][FadeMonotone]")
+{
+    // Monotonicity: more observed losses → smaller k0 (via min) → smaller fade
+    // → smaller additive prior → smaller denominator (loss_mag held constant).
+    // This verifies the Bayesian intent: accumulating evidence weakens the prior.
+
+    const D wins(0.40), floor_d(1e-6);
+    const double prior_strength = 0.5;
+    const int N = 50;   // large-N case where old and new diverge
+
+    // loss_mag held constant to isolate the prior effect
+    const D loss_mag(0.10);
+
+    D d0  = P::computeDenom(wins, loss_mag, floor_d, prior_strength, /*lc=*/0,  N);
+    D d5  = P::computeDenom(wins, loss_mag, floor_d, prior_strength, /*lc=*/5,  N);
+    D d15 = P::computeDenom(wins, loss_mag, floor_d, prior_strength, /*lc=*/15, N);
+    D d40 = P::computeDenom(wins, loss_mag, floor_d, prior_strength, /*lc=*/40, N);
+
+    REQUIRE(num::to_double(d0)  > num::to_double(d5));
+    REQUIRE(num::to_double(d5)  > num::to_double(d15));
+    REQUIRE(num::to_double(d15) > num::to_double(d40));
+}
+
+TEST_CASE("computeDenom: zero loss_count does not produce degenerate denominator",
+          "[StatUtils][Policy][K0][EndToEnd][ZeroLoss]")
+{
+    // Even with no observed losses (wins-only bootstrap resample), the denominator
+    // must be finite and positive — the max(loss_count,1) guard inside
+    // computeK0FromNAndLossCount ensures k0 doesn't collapse.
+
+    const D wins(0.30), loss_mag(0.0), floor_d(1e-6);
+    const double prior_strength = 0.01;
+
+    for (int N : {20, 25, 27, 30, 55, 60})
+    {
+        D denom = P::computeDenom(wins, loss_mag, floor_d, prior_strength, /*lc=*/0, N);
+        INFO("N=" << N << " → denom=" << num::to_double(denom));
+        REQUIRE(std::isfinite(num::to_double(denom)));
+        REQUIRE(num::to_double(denom) > 0.0);
+    }
+}
+
+TEST_CASE("LogProfitFactorFromLogBarsStat_LogPF_Custom: large-N sparse-loss yields finite result",
+          "[StatUtils][Policy][K0][EndToEnd][Functor]")
+{
+    // Smoke test: confirm the full functor path (accumulate → k0 → fade → denom → log(PF))
+    // produces a finite, bounded result for a large-N bootstrap resample that
+    // has only a handful of losses — the motivating call-site scenario.
+
+    using PFSampler = Stat::LogProfitFactorFromLogBarsStat_LogPF_Custom<
+        Stat::SmallSampleNumerPolicy,
+        Stat::SmallSampleDenomPolicy>;
+
+    constexpr double kBootstrapPrior = 0.01;
+    PFSampler stat(Stat::DefaultRuinEps, Stat::DefaultDenomFloor, kBootstrapPrior);
+
+    // Construct a 55-bar log-bar series: 50 wins, 5 losses
+    std::vector<D> logBars;
+    logBars.reserve(55);
+    for (int i = 0; i < 50; ++i) logBars.push_back(D("0.008"));   // small log-wins
+    for (int i = 0; i < 5;  ++i) logBars.push_back(D("-0.012"));  // small log-losses
+
+    D result = stat(logBars);
+
+    REQUIRE(std::isfinite(num::to_double(result)));
+    // With 50 wins vs 5 losses the strategy is profitable: log(PF) > 0
+    REQUIRE(num::to_double(result) > 0.0);
+    // No-loss cap at log(1/kBootstrapPrior) = log(100) ≈ 4.6; well below that
+    REQUIRE(num::to_double(result) < std::log(1.0 / kBootstrapPrior) + 0.01);
 }

--- a/src/palvalidator/filtering/stages/BootstrapAnalysisStage.cpp
+++ b/src/palvalidator/filtering/stages/BootstrapAnalysisStage.cpp
@@ -1276,9 +1276,6 @@ namespace palvalidator::filtering::stages
     const std::vector<Decimal> logBars =
       Stat::makeLogGrowthSeries(ctx.highResReturns, Stat::DefaultRuinEps);
 
-    const StopLossAndProfitTargetPriors priors =
-      extractStopLossAndProfitTargetPriors<Decimal>(ctx);
-
     const BootstrapConfiguration cfg =
       makeBarLevelBootstrapConfiguration(
         mNumResamples, blockLength, confidenceLevel,
@@ -1287,14 +1284,9 @@ namespace palvalidator::filtering::stages
     const BootstrapAlgorithmsConfiguration algoConfig =
       makeBootstrapAlgorithmsConfiguration(/*tradeLevelBootstrapping=*/false);
 
-    os << "   [Bootstrap] AutoCI (PF): passing stop loss of "
-       << priors.getStopLossPct() << " to PFSampler\n";
-
     PFSampler stat(Stat::DefaultRuinEps,
                    Stat::DefaultDenomFloor,
-                   kPFBootstrapPriorStrength,
-                   priors.getStopLossPct(),
-                   priors.getProfitTargetPct());
+                   kPFBootstrapPriorStrength);
 
     StrategyAutoBootstrap<Decimal, PFSampler, Resampler> autoPF(
       mBootstrapFactory,
@@ -1303,10 +1295,6 @@ namespace palvalidator::filtering::stages
       algoConfig,
       stat,
       IntervalType::ONE_SIDED_LOWER);
-
-    os << "   [Bootstrap] AutoCI (PF): running composite bootstrap engines"
-       << " on precomputed log-bars"
-       << " (StopLoss assumption=" << (priors.getStopLossPct() * 100.0) << "%)...\n";
 
     try
       {
@@ -1355,9 +1343,6 @@ namespace palvalidator::filtering::stages
 	return std::nullopt;
       }
 
-    const StopLossAndProfitTargetPriors priors =
-      extractStopLossAndProfitTargetPriors<Decimal>(ctx);
-
     // Pre-compute log(max(1+r, ruin_eps)) for every bar in every trade.
     // LogProfitFactorFromLogBarsStat_LogPF_Custom's Trade overload assumes
     // getDailyReturns() holds pre-computed log-bars, not raw returns.
@@ -1372,14 +1357,9 @@ namespace palvalidator::filtering::stages
     const BootstrapAlgorithmsConfiguration algoConfig =
       makeBootstrapAlgorithmsConfiguration(/*tradeLevelBootstrapping=*/true);
 
-    os << "   [Bootstrap] AutoCI trade-level (PF): passing stop loss of "
-       << priors.getStopLossPct() << " to PFSampler\n";
-
     PFSampler stat(Stat::DefaultRuinEps,
                    Stat::DefaultDenomFloor,
-                   kPFBootstrapPriorStrength,
-                   priors.getStopLossPct(),
-                   priors.getProfitTargetPct());
+                   kPFBootstrapPriorStrength);
 
     StrategyAutoBootstrap<Decimal, PFSampler, Resampler, TradeType> autoPF(
       mBootstrapFactory,
@@ -1388,11 +1368,6 @@ namespace palvalidator::filtering::stages
       algoConfig,
       stat,
       IntervalType::ONE_SIDED_LOWER);
-
-    os << "   [Bootstrap] AutoCI trade-level (PF): running bootstrap engines"
-       << " on " << ctx.tradeLevelReturns.size()
-       << " trades (log-bars pre-computed)"
-       << " (StopLoss assumption=" << (priors.getStopLossPct() * 100.0) << "%)...\n";
 
     try
       {


### PR DESCRIPTION
# Small-Sample Log Profit Factor Regularization and Permutation Policy Fixes
 
## Summary
 
This PR corrects several issues across the policy-based log profit factor
computation, the permutation test policy classes, and the bootstrap analysis
stage. The most impactful change fixes a semantic error in the Bayesian fade
formula that caused over-regularization in the 1–2% of bootstrap call sites
that produce larger-than-typical bar samples (N ~ 50–60). Additional changes
remove dead code and a latent NaN bug from `BootStrappedLogProfitFactorPolicy`,
replace architecturally incorrect BCa bootstrap machinery in
`BootStrappedSharpeRatioPolicy` with a direct statistic computation, harden
two silent failure modes into exceptions, remove dead calling-code arguments
that were silently discarded, and add two new test files that convert empirical
distribution checks into deterministic regression tests.
 
---
 
## Changes by File
 
### `StatUtils.h`
 
#### 1. Replace `computeK0FromN` with `computeK0FromNAndLossCount`
 
**Problem.** `SmoothAdditiveWinCountFadingDenomPolicy` implements a Bayesian
pseudo-count fade:
 
```
fade = k0 / (k0 + loss_count)
```
 
`k0` represents virtual prior losses. The old helper `computeK0FromN` derived it
solely from total bar count `N`:
 
```cpp
// OLD
static int computeK0FromN(int N) {
    const xdouble raw = static_cast<xdouble>(N) * 0.20L;
    int k0 = static_cast<int>(std::llround(raw));
    if (k0 < 3)  k0 = 3;
    if (k0 > 10) k0 = 10;
    return k0;
}
```
 
For the common N range of [20, 30] this worked by correlation — small N implies
few losses. But for the rare large-N / sparse-loss case (N = 55, loss_count = 5)
the old function returned k0 = 10 and produced `fade = 10/15 = 0.667`, applying
a near-full prior after five real observations of the denominator. This
over-regularized log(PF) in exactly the bootstrap resamples where sparse losses
already inflate it.
 
**Fix.** The new function takes both `N` and `loss_count` and uses the minimum of
the two estimates, keeping k0 in loss units throughout:
 
```cpp
// NEW
static int computeK0FromNAndLossCount(int N, int loss_count) {
    const int expected_losses = static_cast<int>(std::llround(0.20 * N));
    const int reference       = std::min(expected_losses,
                                         std::max(loss_count, 1));
    int k0 = reference;
    if (k0 < 3)  k0 = 3;
    if (k0 > 10) k0 = 10;
    return k0;
}
```
 
`computeDenom` is updated to call the new helper. `computeK0FromN` is removed
(see change 5 below).
 
**Behavioral impact by N regime:**
 
| N | loss_count | k0 old | fade old | k0 new | fade new | Effect |
|---|---|---|---|---|---|---|
| 20–30 | typical | 4–6 | unchanged | 4–6 | unchanged | No regression |
| 25 | 2 (sparse) | 5 | 0.71 | 3 | 0.60 | Weaker prior, correct |
| 55 | 5 (rare) | 10 | **0.67** | 5 | **0.50** | Fix: prior weakened |
| 55 | 20 | 10 | 0.33 | 10 | 0.33 | Unchanged |
 
#### 2. Add exception guard to `ResultLogPFPolicy::finalizeFromRatio`
 
Without a guard, a non-positive `numer` or `denom` reaching `std::log` produces
`-inf` or `NaN` that propagates silently into bootstrap confidence interval
calculations — potentially producing a wrong result that passes all downstream
validation. An assert was considered but rejected because asserts are stripped
in production builds, leaving the silent propagation failure intact where it
matters most. A `std::logic_error` is thrown instead, since a non-positive value
indicates a policy contract violation (a programming error) rather than bad
input data:
 
```cpp
static Decimal finalizeFromRatio(const Decimal& numer, const Decimal& denom)
{
    const long double n = num::to_long_double(numer);
    const long double d = num::to_long_double(denom);
 
    if (n <= 0.0L || d <= 0.0L)
        throw std::logic_error(
            "ResultLogPFPolicy: numer and denom must be strictly positive; "
            "check that NumerPolicy and DenomPolicy honour the floor contract");
 
    return Decimal(std::log(n) - std::log(d));
}
```
 
The error message names both the violated policy and the corrective action,
so the source of the violation is immediately actionable when it surfaces.
 
#### 3. Fix `prior_strength` docstring in `computeLogProfitFactorRobust_LogPF`
 
The parameter description gave "a value of 0.01 ensures the denominator is never
less than 1% of the numerator" as an example, but the function's default is 0.5,
which caps log(PF) at log(2) ≈ 0.69 for no-loss samples — a dramatically
different and undocumented behavior. The docstring now documents the cap formula
and explains why bootstrap callers should use a weaker prior such as 0.01.
 
#### 4. Fix comment in `computeK0FromNAndLossCount`
 
The header comment incorrectly described the `0.20` scaling factor as
"approx 0.4 × N for typical strategies." The factor 0.20 is not a loss-rate
estimate; it is a calibration constant that places k0 in the mid-range of [3, 10]
for the typical N window of [20, 30]. The comment is corrected accordingly.
 
#### 5. Remove `computeK0FromN`
 
`computeK0FromN` is an internal static of `SmoothAdditiveWinCountFadingDenomPolicy`
with no external callers and no ABI commitment. Now that `computeDenom` calls
`computeK0FromNAndLossCount`, the old function is dead code. Leaving it alongside
the new function would create a maintenance hazard — a future author seeing two
similar k0 functions could incorrectly restore the old call, re-introducing the
over-regularization this PR fixes. The function and its unit tests are removed.
 
---
 
### `BootstrapAnalysisStage.h` / `.cpp`
 
#### 6. Remove dead `stop_loss_pct` and `profit_target_pct` arguments from `PFSampler` construction
 
`runBarLevelAutoProfitFactorBootstrap` and `runTradeLevelAutoProfitFactorBootstrap`
were constructing `LogProfitFactorFromLogBarsStat_LogPF_Custom` via the 5-parameter
backward-compatible `SymmetricPFStat` constructor and passing live values from
`priors.getStopLossPct()` and `priors.getProfitTargetPct()`. Those parameters are
commented out in `SymmetricPFStat` and silently discarded:
 
```cpp
// BEFORE — priors values passed but silently ignored
PFSampler stat(Stat::DefaultRuinEps,
               Stat::DefaultDenomFloor,
               kPFBootstrapPriorStrength,
               priors.getStopLossPct(),      // silently discarded
               priors.getProfitTargetPct()); // silently discarded
 
// AFTER — canonical 3-parameter form
PFSampler stat(Stat::DefaultRuinEps,
               Stat::DefaultDenomFloor,
               kPFBootstrapPriorStrength);
```
 
This makes the construction self-documenting: the three values that actually
configure the statistic are the only values passed.
 
---
 
### `MonteCarloTestPolicy.h`
 
#### 7. `BootStrappedLogProfitFactorPolicy` — four corrections
 
**7a. Dead code removed: stop-loss and profit-target extraction.**
The previous implementation extracted `stopLossPct` and `profitTargetPct` from
the `PalPattern` via `PercentNumber::getAsPercent()` and forwarded them as the
5th and 6th arguments to `computeLogProfitFactorRobust_LogPF`. Those overloads
are deprecated no-ops that silently discard both parameters and delegate to the
4-parameter canonical overload. The extraction block was therefore pure dead code
and has been removed. The call site now invokes the 4-parameter overload directly:
 
```cpp
return StatUtils<Decimal>::computeLogProfitFactorRobust_LogPF(
    barSeries,
    StatUtils<Decimal>::DefaultRuinEps,
    StatUtils<Decimal>::DefaultDenomFloor,
    prior_strength);
```
 
**7b. Latent NaN bug eliminated.**
`PercentNumber::getAsPercent()` returns the percentage form of the value (e.g.
`2.0` for a 2% stop-loss). Had those values ever been plumbed into a function
expecting a decimal fraction — such as `RobustPFStat`, which computes
`std::log(1.0 - stop_loss_pct)` — the result would have been
`std::log(1.0 - 2.0) = std::log(-1.0)` → **NaN**, silently corrupting every
downstream permutation test statistic. Removing the extraction block eliminates
this bug entirely.
 
**7c. Silent `dynamic_pointer_cast` failure now throws.**
Previously, if the strategy could not be downcast to `PalStrategy<Decimal>`,
the cast failed silently, `stopLossPct` and `profitTargetPct` remained `0.0`,
and execution continued without any diagnostic. Because this policy is inherently
`PalStrategy`-specific, a failed cast is a programming contract violation. It
now throws `BackTesterException`:
 
```cpp
if (!std::dynamic_pointer_cast<PalStrategy<Decimal>>(strat)) {
    throw BackTesterException(
        "BootStrappedLogProfitFactorPolicy::getPermutationTestStatistic - "
        "strategy is not a PalStrategy");
}
```
 
**7d. `prior_strength` promoted to named constant with rationale.**
The magic literal `0.01` is now a `static constexpr` with a comment explaining
the deliberate deviation from `StatUtils::DefaultPriorStrength` (0.5):
 
```cpp
// prior_strength = 0.01: intentionally weaker than DefaultPriorStrength (0.5)
// so the statistic remains sensitive to the permuted data rather than being
// pulled toward the prior. Bounds the effective PF ratio to [0.01, 100].
static constexpr double prior_strength = 0.01;
```
 
#### 8. `BootStrappedSharpeRatioPolicy` — architectural correction
 
**8a. BCa bootstrap machinery removed.**
The previous implementation performed a full stationary-block BCa bootstrap
(1000 replications, median holding-period block length) inside
`getPermutationTestStatistic` and returned the lower confidence bound. This is
architecturally incorrect for a permutation test policy: the permutation loop in
the caller is responsible for generating the null distribution; the policy's only
job is to return a scalar statistic for each permuted backtester. Bootstrapping
inside the statistic inflated runtime by ~1000× per permutation and biased the
test. The following were removed:
 
- `StationaryBlockResampler` construction and block-length lookup
- `BCaBootStrap` instantiation and confidence interval computation
- `CompositeScoreFn` wrapper struct
- `B` and `alpha` constants
- Median holding period lookup via `getClosedPositionHistory()`
 
**8b. Replaced with a direct Sharpe ratio computation.**
The policy now converts percent bars to log bars and calls
`StatUtils::sharpeFromReturns` directly, matching the structural simplicity of
`BootStrappedLogProfitFactorPolicy`:
 
```cpp
for (const auto& r : barSeries)
    logBars.push_back(std::log(DecimalConstants<Decimal>::DecimalOne + r));
 
static constexpr double eps = 1e-8;
return StatUtils<Decimal>::sharpeFromReturns(logBars, eps);
```
 
**8c. Threshold guard moved before log conversion.**
The `numTrades` / `barSeries.size()` guard now runs immediately after fetching
`barSeries`, before the log conversion loop. Previously the loop ran
unconditionally and its output was discarded if the thresholds were not met.
 
**8d. `makeLogGrowthSeries` intentionally not used.**
The log conversion is an explicit inline loop rather than a call to
`StatUtils::makeLogGrowthSeries`. The latter clips growth at `ruin_eps` for
ruin-safety, which is appropriate for profit-factor computation but not for a
Sharpe ratio, where severe losses should influence the mean and variance honestly.
 
---
 
### `StatUtilsPolicyTest.cpp`
 
#### 9. Remove `computeK0FromN` tests, add `computeK0FromNAndLossCount` tests, add `ResultLogPFPolicy` exception tests
 
Three changes are made to the existing test file:
 
**9a. Remove `computeK0FromN` tests.**
The three test cases covering the now-deleted `computeK0FromN` are removed.
Keeping green tests for dead code gives false confidence in coverage.
 
**9b. Add seventeen `computeK0FromNAndLossCount` tests.**
Organized into two sections in place of the removed tests:
 
*Section A — unit tests on the helper itself*
 
| Test | What it verifies |
|---|---|
| Lower clamp | Result ≥ 3 for all inputs that underflow, including zero-loss |
| Upper clamp | Result ≤ 10 for large N and large loss_count |
| Common N range [20–30] regression | New results match old `computeK0FromN` output exactly for typical loss rates — no regression |
| Sparse losses in normal N | N=25, loss_count=2 → k0 correctly reduced to 3 |
| Large-N sparse-loss (the fix) | N=55/60, loss_count=4–8 → k0 no longer inflated to 10 |
| Zero loss_count safety | `max(loss_count, 1)` guard prevents collapse at all N |
| Negative inputs | Sentinel −1 path produces value in [3, 10], does not crash |
| loss_count ≥ expected_losses | `min()` selects expected_losses; matches old function |
| Exhaustive clamp sweep | 140 (N, loss_count) pairs all return value in [3, 10] |
 
*Section B — end-to-end through `computeDenom` and the full functor*
 
| Test | What it verifies |
|---|---|
| Large-N prior weakening | New denominator is strictly less than old-path denominator for N=55, loss_count=5 |
| Normal N unchanged | Old and new paths produce identical denominators for N=25, loss_count=10 |
| Fade monotonicity | Denominator decreases as loss_count grows (prior fades correctly) |
| Zero loss_count non-degeneracy | Finite positive denominator at all tested N values |
| Full functor smoke test | `LogProfitFactorFromLogBarsStat_LogPF_Custom` with `SmallSampleDenomPolicy` on a 55-bar/5-loss series produces finite, positive, bounded log(PF) |
 
**9c. Add two `ResultLogPFPolicy` exception tests.**
Two new sections are added to the existing `ResultLogPFPolicy` test case,
verifying that `finalizeFromRatio` throws `std::logic_error` for each of
the two invalid-argument cases — non-positive numer and non-positive denom:
 
```cpp
SECTION("non-positive numer throws logic_error")
{
    REQUIRE_THROWS_AS(
        Stat::ResultLogPFPolicy::finalizeFromRatio(DC::DecimalZero, D(0.10)),
        std::logic_error);
}
 
SECTION("non-positive denom throws logic_error")
{
    REQUIRE_THROWS_AS(
        Stat::ResultLogPFPolicy::finalizeFromRatio(D(0.30), DC::DecimalZero),
        std::logic_error);
}
```
 
---
 
### `StatUtilsPermutationTest.cpp` *(new file)*
 
#### 10. Empirical pileup check converted to deterministic regression tests
 
During review, the permutation testing path (`computeLogProfitFactorRobust_LogPF`
with `LegacyDenomPolicy` and `prior_strength = 0.01`) was assessed as correct
and requiring no behavioral changes. However, the recommendation was made to run
an empirical check on the 10,000-permutation null distribution to confirm no
pileup occurs near the cap at `log(100) ≈ 4.605`. These 10 tests convert that
check into deterministic, reproducible unit tests that pass today and will catch
any future regression in the permutation path.
 
The key structural property exploited: with equal win/loss magnitudes (r = 0.005)
and 100 bars, the prior disengages as soon as `n_losses ≥ 0.00995 × n_wins`.
For n_wins=99, n_losses=1: 1/99 ≈ 0.0101 > 0.00995 — the prior is already inert
with just one loss from 99 bars. This is verified analytically by a Python
simulation used to design the tests, and encoded as exact assertions.
 
The file is kept separate from `StatUtilsPolicyTest.cpp` because the tests operate
at distribution level rather than policy-unit level, and because the control test
deliberately validates failure behavior — an unusual pattern that is clearer in
isolation. Tests can be run independently via the `[Permutation]` tag.
 
**Section 1 — `HardMaxWinAnchorDenomPolicy` structural properties (3 tests)**
 
| Test | What it verifies |
|---|---|
| Prior inert for typical input | wins=0.40, loss_mag=0.05: threshold=0.004, loss_mag >> threshold, denom = loss_mag exactly |
| Prior activates only below threshold | loss_mag=0.001 < threshold=0.004: denom = threshold |
| Default prior=0.5 clips typical permutation | Same input with prior=0.5: threshold=0.20 inflates denom 4×; documents why 0.01 was chosen |
 
**Section 2 — `computeLogProfitFactorRobust_LogPF` end-to-end (4 tests)**
 
| Test | What it verifies |
|---|---|
| All-wins → cap at log(100) | No-loss permutation produces exactly log(100), not an unbounded value |
| Balanced permutation → raw log(PF) | 50/50 split: prior inert, result equals analytically computed raw log(PF) ≈ 0 |
| Profitable permutation → unregularized | 60/40 split: result equals raw log(PF), well below cap |
| All-losses → large negative log(PF) | Lower tail is correctly unbounded; result < −5 |
 
**Section 3 — Null distribution pileup regression (3 tests)**
 
| Test | What it verifies |
|---|---|
| Equal-magnitude sweep: cap binds only at 100% wins | 20 scenarios (n_wins=5..100, step 5): for all cases with losses, result equals raw log(PF); near-cap count ≤ 1 |
| Default prior=0.5 causes pileup — control test | Same 20 scenarios with prior=0.5: exactly 7 cases pile up at log(2), proving the sweep test is a genuine regression guard and not a vacuous assertion |
| log(PF) is strictly monotone in win rate | Sweep n_wins=5..95: each step strictly greater than the previous, confirming no distributional discontinuities |
 
The control test is the critical sensitivity proof. If `prior_strength` were
accidentally reverted to the default 0.5, the sweep test would find near-cap
count = 7 (failing the `≤ 1` assertion). If someone questioned whether the
sweep test was meaningful, the control test confirms it would catch exactly
that regression.
 
---
 
## Files Changed
 
| File | Net change | Description |
|---|---|---|
| `StatUtils.h` | Modified | Changes 1–5 |
| `BootstrapAnalysisStage.h` / `.cpp` | Modified | Change 6 |
| `MonteCarloTestPolicy.h` | Modified | Changes 7–8 |
| `StatUtilsPolicyTest.cpp` | Modified | Change 9 |
| `StatUtilsPermutationTest.cpp` | New | Change 10 |
 
---
 
## What Was Not Changed
 
- The `SmoothAdditiveWinCountFadingDenomPolicy` fade formula itself is correct.
- `kPFBootstrapPriorStrength = 0.01` is the right value for the bootstrap context;
  its comment accurately describes the no-loss cap behavior at that value.
- The full accumulation path through `LogBarsAccumPolicy` correctly propagates
  `loss_count` and `N` so the fade formula always has real data.
- The permutation testing path (`HardMaxWinAnchorDenomPolicy` + `prior_strength=0.01`)
  requires no behavioral changes — only regression tests are added.
- All existing `LogProfitFactorFromLogBarsStat_LogPF_Custom` call sites not
  passing dead `priors` arguments are unaffected.
- The `LegacyNumerPolicy` / `LegacyDenomPolicy` path and the `RobustPFStat`
  family are untouched.