### PR TITLE
Fix bugs/issues discovered by claude code during code review

### DIFF
--- a/libs/backtesting/InstrumentPositionManagerException.h
+++ b/libs/backtesting/InstrumentPositionManagerException.h
@@ -4,7 +4,7 @@
 // Written by Michael K. Collison <collison956@gmail.com>, July 2016
 //
 #ifndef __TRADING_POSITION_MANAGER_EXCEPTION_H
-#define __TRADING_POSITION_MANAGER EXCEPTION_H 1
+#define __TRADING_POSITION_MANAGER_EXCEPTION_H 1
 
 #include <exception>
 

--- a/src/palvalidator/filtering/PerformanceFilter.cpp
+++ b/src/palvalidator/filtering/PerformanceFilter.cpp
@@ -138,11 +138,12 @@ namespace palvalidator
        outputStream << "Warning: Failed to evaluate strategy '" << strategy->getStrategyName()
       << "' performance: " << e.what() << "\n";
        outputStream << "Excluding strategy from filtered results.\n";
+       mFilteringSummary.incrementFailBootstrapCount();
      }
  }
 
       // Output statistics about skipped strategies due to insufficient trades
-      unsigned int totalStrategies = survivingStrategies.size();
+      const size_t totalStrategies = survivingStrategies.size();
       outputStream << "Strategy processing summary:\n";
       outputStream << "  Total strategies evaluated: " << totalStrategies << "\n";
       outputStream << "  Strategies skipped due to insufficient trades (<9): " << skippedStrategiesCount << "\n";

--- a/src/palvalidator/filtering/stages/BootstrapAnalysisStage.cpp
+++ b/src/palvalidator/filtering/stages/BootstrapAnalysisStage.cpp
@@ -125,69 +125,6 @@ namespace palvalidator::filtering::stages
     }
 
     // -----------------------------------------------------------------------
-    // StopLossAndProfitTargetPriors
-    //
-    // Encapsulates the stop-loss and profit-target percentages extracted from
-    // a PalStrategy pattern and passed as prior information to the
-    // profit-factor statistic functor.
-    //
-    // Extracted once via extractStopLossAndProfitTargetPriors() and shared by
-    // both the bar-level and trade-level profit-factor bootstrap helpers.
-    // -----------------------------------------------------------------------
-    class StopLossAndProfitTargetPriors
-    {
-    public:
-      StopLossAndProfitTargetPriors(double stopLossPct, double profitTargetPct)
-        : mStopLossPct(stopLossPct)
-        , mProfitTargetPct(profitTargetPct)
-      {}
-
-      double getStopLossPct()     const { return mStopLossPct;     }
-      double getProfitTargetPct() const { return mProfitTargetPct; }
-
-    private:
-      double mStopLossPct;
-      double mProfitTargetPct;
-    };
-
-    // -----------------------------------------------------------------------
-    // extractStopLossAndProfitTargetPriors
-    //
-    // Attempts a dynamic_pointer_cast to PalStrategy<Decimal>. If successful
-    // and a pattern is available, reads the stop-loss and profit-target as
-    // decimal fractions (e.g. 0.0255 for 2.55%).
-    //
-    // Falls back to 0.0 / 0.0 if the strategy is not a PalStrategy, or if
-    // the pattern is unavailable.  Both PF bootstrap paths (bar-level and
-    // trade-level) call this helper to guarantee identical prior extraction.
-    // -----------------------------------------------------------------------
-    template <class Decimal>
-    StopLossAndProfitTargetPriors
-    extractStopLossAndProfitTargetPriors(const StrategyAnalysisContext& ctx)
-    {
-      double stopLossPct    = 0.0;
-      double profitTargetPct = 0.0;
-
-      auto palStrat =
-        std::dynamic_pointer_cast<mkc_timeseries::PalStrategy<Decimal>>(ctx.clonedStrategy);
-      if (palStrat)
-        {
-          auto pattern = palStrat->getPalPattern();
-          if (pattern)
-            {
-              stopLossPct =
-                num::to_double(mkc_timeseries::PercentNumber<Decimal>::createPercentNumber(
-                    pattern->getStopLossAsDecimal()).getAsPercent());
-              profitTargetPct =
-                num::to_double(mkc_timeseries::PercentNumber<Decimal>::createPercentNumber(
-                    pattern->getProfitTargetAsDecimal()).getAsPercent());
-            }
-        }
-
-      return StopLossAndProfitTargetPriors(stopLossPct, profitTargetPct);
-    }
-
-    // -----------------------------------------------------------------------
     // requireClonedStrategy
     //
     // Guards the entry of each auto-bootstrap helper.  Throws
@@ -742,12 +679,12 @@ namespace palvalidator::filtering::stages
         return false;
       }
 
-    // Create a concrete backtester implementation instead of the abstract base class
-    ctx.backtester = std::make_shared<mkc_timeseries::DailyBackTester<Num>>();
-    ctx.backtester->addStrategy(ctx.clonedStrategy);
+    // Use BackTesterFactory to create the correct backtester for the timeframe
     try
       {
-        ctx.backtester->backtest();
+        ctx.backtester =
+          mkc_timeseries::BackTesterFactory<Num>::backTestStrategy(
+            ctx.clonedStrategy, ctx.timeFrame, ctx.oosDates);
       }
     catch (const std::exception& e)
       {
@@ -1388,10 +1325,10 @@ namespace palvalidator::filtering::stages
   // ---------------------------------------------------------------------------
 
   double
-  BootstrapAnalysisStage::getAdjusteConfidenceInterval(const Num& confidenceInterval, size_t returnsSize) const
+  BootstrapAnalysisStage::getAdjustedConfidenceInterval(const Num& confidenceInterval, size_t returnsSize) const
   {
-    static Num adjustedLowerInterval = num::fromString<Num>(std::string("0.90"));
-    static Num typicalLowerInterval = num::fromString<Num>(std::string("0.95"));
+    static const Num adjustedLowerInterval = num::fromString<Num>(std::string("0.90"));
+    static const Num typicalLowerInterval = num::fromString<Num>(std::string("0.95"));
     
     if (isTradeLevelBootStrapping())
       return num::to_double(confidenceInterval);
@@ -1422,10 +1359,21 @@ namespace palvalidator::filtering::stages
 
     os << "\n==================== Bootstrap Analysis Stage ====================\n";
 
-    if (ctx.highResReturns.size() < 2)
+    if (isTradeLevelBootStrapping())
       {
-        os << "   [Bootstrap] Skipping: insufficient highResReturns (n < 2).\n";
-        return result;
+        if (ctx.tradeLevelReturns.size() < 2)
+          {
+            os << "   [Bootstrap] Skipping: insufficient tradeLevelReturns (n < 2).\n";
+            return result;
+          }
+      }
+    else
+      {
+        if (ctx.highResReturns.size() < 2)
+          {
+            os << "   [Bootstrap] Skipping: insufficient highResReturns (n < 2).\n";
+            return result;
+          }
       }
 
     if (!initializeBacktester(ctx, os))
@@ -1450,17 +1398,24 @@ namespace palvalidator::filtering::stages
     double confLevel = 0.0;
     
     if (isTradeLevelBootStrapping())
-      confLevel = getAdjusteConfidenceInterval(mConfidenceLevel, ctx.tradeLevelReturns.size());
+      confLevel = getAdjustedConfidenceInterval(mConfidenceLevel, ctx.tradeLevelReturns.size());
     else
-      confLevel = getAdjusteConfidenceInterval(mConfidenceLevel, ctx.highResReturns.size());
+      confLevel = getAdjustedConfidenceInterval(mConfidenceLevel, ctx.highResReturns.size());
 
     os << "BootstrapAnalysisStage::execute actual confidence interval = " << confLevel << std::endl;
     
-    // 3) Arithmetic mean via BCa
-    const auto bcaMean =
-      runBCaMeanBootstrap(ctx, confLevel, annParams.barsPerYear, blockLength, os);
-    result.lbMeanPeriod             = bcaMean.getLowerBoundPeriod();
-    result.annualizedLowerBoundMean = bcaMean.getLowerBoundAnnualized();
+    // 3) Arithmetic mean via BCa (always uses bar-level highResReturns)
+    if (ctx.highResReturns.size() >= 2)
+      {
+        const auto bcaMean =
+          runBCaMeanBootstrap(ctx, confLevel, annParams.barsPerYear, blockLength, os);
+        result.lbMeanPeriod             = bcaMean.getLowerBoundPeriod();
+        result.annualizedLowerBoundMean = bcaMean.getLowerBoundAnnualized();
+      }
+    else
+      {
+        os << "   [Bootstrap] BCa (Mean): skipped (highResReturns n < 2).\n";
+      }
 
     // 4) Geometric mean (CAGR) via StrategyAutoBootstrap
     try

--- a/src/palvalidator/filtering/stages/BootstrapAnalysisStage.h
+++ b/src/palvalidator/filtering/stages/BootstrapAnalysisStage.h
@@ -245,7 +245,7 @@ namespace palvalidator::filtering::stages
       Num mLowerBoundPeriod;
     };
 
-    double getAdjusteConfidenceInterval(const Num& confidenceInterval, size_t returnsSize) const;
+    double getAdjustedConfidenceInterval(const Num& confidenceInterval, size_t returnsSize) const;
     
     // Core computation methods
     /**

--- a/src/palvalidator/filtering/stages/HurdleAnalysisStage.h
+++ b/src/palvalidator/filtering/stages/HurdleAnalysisStage.h
@@ -32,7 +32,7 @@ namespace palvalidator::filtering::stages
                                  std::ostream& os) const;
 
   private:
-    const TradingHurdleCalculator& mHurdleCalculator;
+    TradingHurdleCalculator mHurdleCalculator;
   };
 
 } // namespace palvalidator::filtering::stages


### PR DESCRIPTION
 ## Summary

  Fix correctness issues identified during code review of the filtering pipeline,
  including a dangling reference, dead-code guards, naming issues, and
  timeframe-incorrect fallback logic.

  ## Changes

  ### Bug Fixes

  **Dangling reference to `TradingHurdleCalculator` (#3)**
  `HurdleAnalysisStage` stored the calculator as a `const&` member, but
  `PerformanceFilter::createPipeline()` passed a stack-local object. The
  pipeline outlived the local, leaving a dangling reference. Fixed by storing
  by value in `HurdleAnalysisStage`.
  - `stages/HurdleAnalysisStage.h`

  **Early return in `execute()` too aggressive for trade-level bootstrapping (#8)**
  The `BootstrapAnalysisStage::execute()` guard `highResReturns.size() < 2`
  applied unconditionally, even in trade-level mode where `tradeLevelReturns`
  is the relevant data source. Fixed by conditioning the check on the
  bootstrapping mode.
  - `stages/BootstrapAnalysisStage.cpp`

  **BCa mean bootstrap not guarded for insufficient bar-level data (#9)**
  `runBCaMeanBootstrap` always runs on `highResReturns`, even in trade-level
  mode. After fixing #8, `execute()` can now proceed with small
  `highResReturns` when `tradeLevelReturns` is sufficient. Added a size guard
  so BCa mean is skipped gracefully rather than failing.
  - `stages/BootstrapAnalysisStage.cpp`

  **Hardcoded `DailyBackTester` in fallback path (#10)**
  `initializeBacktester()` always created a `DailyBackTester` regardless of
  the strategy's timeframe. Replaced with `BackTesterFactory::backTestStrategy()`
  which dispatches to the correct concrete type (Daily, Weekly, Monthly,
  Intraday) based on `ctx.timeFrame`.
  - `stages/BootstrapAnalysisStage.cpp`

  ### Accounting / Observability

  **Uncounted exception-throwing strategies (#4)**
  Strategies that threw exceptions during evaluation were silently excluded
  from results without incrementing any summary counter, causing summary
  statistics to not add up. Added `incrementFailBootstrapCount()` in the
  exception handler.
  - `PerformanceFilter.cpp`

  ### Code Quality

  **Narrowing conversion `size_t` → `unsigned int` (#5)**
  Changed `totalStrategies` from `unsigned int` to `const size_t` to match
  the return type of `vector::size()`.
  - `PerformanceFilter.cpp`

  **Method name typo (#6)**
  Renamed `getAdjusteConfidenceInterval` → `getAdjustedConfidenceInterval`
  in both declaration and definition.
  - `stages/BootstrapAnalysisStage.h`
  - `stages/BootstrapAnalysisStage.cpp`

  **Non-const static locals (#7)**
  Added `const` to two `static Num` variables in
  `getAdjustedConfidenceInterval()` that are initialized once and never
  modified.
  - `stages/BootstrapAnalysisStage.cpp`