### PR TITLE
Add multiple cleanup fixes from claude code review

### DIFF
--- a/libs/statistics/AutoBootstrapConfiguration.h
+++ b/libs/statistics/AutoBootstrapConfiguration.h
@@ -60,6 +60,12 @@ namespace AutoBootstrapConfiguration
   /// Both sites must agree — a single constant here guarantees that.
   constexpr std::size_t kMinEffectiveBAbsolute = 200;
 
+  /// Minimum fraction of requested bootstrap replicates that must be effective
+  /// for BCa (and by default, all methods except PercentileT) to pass the
+  /// effective-B gate. Referenced by passesEffectiveBGate (AutoBootstrapScoring.h)
+  /// and the diagnostic mirror in analyzeBcaRejection (AutoBootstrapSelector.h).
+  constexpr double kBcaMinEffectiveFraction = 0.90;
+
   // ===========================================================================
   // PERCENTILE-T HARD REJECTION LIMITS
   // ===========================================================================

--- a/libs/statistics/AutoBootstrapScoring.h
+++ b/libs/statistics/AutoBootstrapScoring.h
@@ -238,58 +238,68 @@ namespace palvalidator
       {
       public:
         /**
-         * @brief Constructs a BCa rejection analysis with all parameters
+         * @brief Constructs a BCa rejection analysis with all parameters.
          *
-         * @param hasBcaCandidate True if a BCa candidate was present in the tournament
-         * @param bcaChosen True if BCa was ultimately selected as the winner
-         * @param rejectedForInstability True if BCa was rejected due to extreme z0/accel parameters
-         * @param rejectedForLength True if BCa was rejected due to excessive length penalty
-         * @param rejectedForDomain True if BCa was rejected due to domain/support violations
-         * @param rejectedForNonFinite True if BCa was rejected due to non-finite scores
+         * @param hasBcaCandidate True if a BCa candidate was present in the tournament.
+         * @param bcaChosen True if BCa was ultimately selected as the winner.
+         * @param rejectedForInstability True if BCa was rejected due to extreme z0/accel parameters.
+         * @param rejectedForLength True if BCa was rejected due to excessive length penalty.
+         * @param rejectedForDomain True if BCa was rejected due to domain/support violations.
+         * @param rejectedForNonFinite True if BCa was rejected due to non-finite scores.
+         * @param rejectedForScore True if BCa passed all hard gates but was outscored
+         *        by another method in the tournament. This disambiguates the "fairly
+         *        outscored" case from the "all flags false" diagnostic gap (BUG-4).
          */
         BcaRejectionAnalysis(bool hasBcaCandidate,
                            bool bcaChosen,
                            bool rejectedForInstability,
                            bool rejectedForLength,
                            bool rejectedForDomain,
-                           bool rejectedForNonFinite)
+                           bool rejectedForNonFinite,
+                           bool rejectedForScore = false)
           : m_has_bca_candidate(hasBcaCandidate),
             m_bca_chosen(bcaChosen),
             m_rejected_for_instability(rejectedForInstability),
             m_rejected_for_length(rejectedForLength),
             m_rejected_for_domain(rejectedForDomain),
-            m_rejected_for_non_finite(rejectedForNonFinite)
+            m_rejected_for_non_finite(rejectedForNonFinite),
+            m_rejected_for_score(rejectedForScore)
         {}
-        
+
         /**
-         * @brief Gets whether a BCa candidate was present in the tournament
+         * @brief Gets whether a BCa candidate was present in the tournament.
          */
         bool hasBcaCandidate() const { return m_has_bca_candidate; }
-        
+
         /**
-         * @brief Gets whether BCa was selected as the winner
+         * @brief Gets whether BCa was selected as the winner.
          */
         bool bcaChosen() const { return m_bca_chosen; }
-        
+
         /**
-         * @brief Gets whether BCa was rejected due to parameter instability
+         * @brief Gets whether BCa was rejected due to parameter instability.
          */
         bool rejectedForInstability() const { return m_rejected_for_instability; }
-        
+
         /**
-         * @brief Gets whether BCa was rejected due to excessive length penalty
+         * @brief Gets whether BCa was rejected due to excessive length penalty.
          */
         bool rejectedForLength() const { return m_rejected_for_length; }
-        
+
         /**
-         * @brief Gets whether BCa was rejected due to domain violations
+         * @brief Gets whether BCa was rejected due to domain violations.
          */
         bool rejectedForDomain() const { return m_rejected_for_domain; }
-        
+
         /**
-         * @brief Gets whether BCa was rejected due to non-finite scores
+         * @brief Gets whether BCa was rejected due to non-finite scores.
          */
         bool rejectedForNonFinite() const { return m_rejected_for_non_finite; }
+
+        /**
+         * @brief Gets whether BCa passed all hard gates but was outscored by another method.
+         */
+        bool rejectedForScore() const { return m_rejected_for_score; }
 
       private:
         bool m_has_bca_candidate;
@@ -298,6 +308,7 @@ namespace palvalidator
         bool m_rejected_for_length;
         bool m_rejected_for_domain;
         bool m_rejected_for_non_finite;
+        bool m_rejected_for_score;
       };
 
       /**
@@ -432,20 +443,15 @@ namespace palvalidator
 	    AutoBootstrapConfiguration::kMinEffectiveBAbsolute;
         
 	  // Method-specific minimum fraction requirements
-	  double min_frac = 0.90;
-	
+	  double min_frac = AutoBootstrapConfiguration::kBcaMinEffectiveFraction;
+
 	  switch (candidate.getMethod())
 	    {
 	    case MethodId::PercentileT:
 	      min_frac = AutoBootstrapConfiguration::kPercentileTMinEffectiveFraction;
 	      break;
 
-	    case MethodId::BCa:
-	      min_frac = 0.90;
-	      break;
-
 	    default:
-	      min_frac = 0.90;
 	      break;
 	    }
         
@@ -569,7 +575,7 @@ namespace palvalidator
         {
           const Candidate& candidate = m_candidates[index];
           const double score = candidate.getScore();
-          
+
           if (!m_found_any)
           {
             m_found_any = true;
@@ -578,14 +584,14 @@ namespace palvalidator
             m_tie_epsilon_used = relativeEpsilon(score, score);
             return;
           }
-          
+
           const double eps = relativeEpsilon(score, m_best_score);
-          m_tie_epsilon_used = eps;
-          
+
           if (score < m_best_score - eps)
           {
             m_best_score = score;
             m_winner_idx = index;
+            m_tie_epsilon_used = eps;
           }
           else if (std::fabs(score - m_best_score) <= eps)
           {
@@ -596,11 +602,12 @@ namespace palvalidator
               const Candidate& current_winner = m_candidates[m_winner_idx.value()];
               const int pBest = methodPreference(current_winner.getMethod());
               const int pCur  = methodPreference(candidate.getMethod());
-              
+
               if (pCur < pBest)
               {
                 m_best_score = score;
                 m_winner_idx = index;
+                m_tie_epsilon_used = eps;
               }
             }
           }

--- a/libs/statistics/AutoBootstrapSelector.h
+++ b/libs/statistics/AutoBootstrapSelector.h
@@ -774,6 +774,11 @@ namespace palvalidator
 	if (!passes_effective_b_gate)
 	  mask |= CandidateReject::EffectiveBLow;
 
+	// 4) Non-finite interval bounds (hard gate for all methods)
+	if (!std::isfinite(num::to_double(candidate.getLower())) ||
+	    !std::isfinite(num::to_double(candidate.getUpper())))
+	  mask |= CandidateReject::BoundsNonFinite;
+
 	if (candidate.getMethod() == MethodId::BCa)
 	  {
 	    const double z0    = candidate.getZ0();
@@ -787,6 +792,19 @@ namespace palvalidator
 
 	    if (std::isfinite(accel) && std::fabs(accel) > AutoBootstrapConfiguration::kBcaAHardLimit)
 	      mask |= CandidateReject::BcaAccelHardFail;
+
+	    if (candidate.getN() < AutoBootstrapConfiguration::kBcaMinSampleSize)
+	      mask |= CandidateReject::BcaMinSampleSize;
+
+	    if (!candidate.getAccelIsReliable())
+	      mask |= CandidateReject::BcaAccelUnreliable;
+
+	    if (!candidate.getBcaTransformMonotone())
+	      mask |= CandidateReject::BcaTransformNonMonotone;
+
+	    if (std::isfinite(candidate.getSkewBoot()) &&
+		std::fabs(candidate.getSkewBoot()) > AutoBootstrapConfiguration::kBcaSkewHardLimit)
+	      mask |= CandidateReject::BcaSkewHardFail;
 	  }
 
 	if (candidate.getMethod() == MethodId::MOutOfN)
@@ -805,6 +823,9 @@ namespace palvalidator
 
 	if (candidate.getMethod() == MethodId::PercentileT)
 	  {
+	    if (candidate.getN() < AutoBootstrapConfiguration::kPercentileTMinSampleSize)
+	      mask |= CandidateReject::PercentileTMinSampleSize;
+
 	    const double inner_fail_rate = candidate.getInnerFailureRate();
 	    if (std::isfinite(inner_fail_rate) &&
 		inner_fail_rate > AutoBootstrapConfiguration::kPercentileTInnerFailThreshold)
@@ -1728,20 +1749,13 @@ namespace palvalidator
           // Without this, a BCa candidate eliminated solely by low effective_B
           // would leave all four rejection flags false while bca_chosen=false,
           // silently misreporting in SelectionDiagnostics.
-          //
-          // BUG-5 NOTE: kMinEffectiveAbsolute (200) is also defined as a local
-          // constexpr inside CandidateGateKeeper::passesEffectiveBGate in
-          // AutoBootstrapScoring.h. Both values MUST remain in sync. The correct
-          // long-term fix is to promote this constant to
-          // AutoBootstrapConfiguration::kMinEffectiveBAbsolute and reference it
-          // from both sites.
           {
-
             const std::size_t requested_B = bca.getBOuter();
             if (requested_B >= 2)
             {
               const std::size_t required_by_frac = static_cast<std::size_t>(
-                std::ceil(0.90 * static_cast<double>(requested_B)));
+                std::ceil(AutoBootstrapConfiguration::kBcaMinEffectiveFraction
+                          * static_cast<double>(requested_B)));
               const std::size_t required =
                 std::max(AutoBootstrapConfiguration::kMinEffectiveBAbsolute, required_by_frac);
               if (bca.getEffectiveB() < required)
@@ -1758,22 +1772,18 @@ namespace palvalidator
           break; // Only one BCa candidate
         }
 
-        // BUG-4 NOTE: BcaRejectionAnalysis currently has no "rejected_for_score"
-        // field. When BCa passes all hard gates above but is simply outscored by
-        // another method, all four rejection flags remain false while bca_chosen is
-        // also false. Callers can detect this "fairly outscored" state by checking:
-        //   has_bca_candidate=true  &&  bca_chosen=false
-        //   &&  !rejected_for_instability  &&  !rejected_for_length
-        //   &&  !rejected_for_domain       &&  !rejected_for_non_finite
-        // The complete fix is to add a rejected_for_score field to BcaRejectionAnalysis
-        // in AutoBootstrapScoring.h so the tournament result is unambiguously reported.
-        
+        // If BCa passed all hard gates but was not chosen, it was fairly outscored.
+        const bool rejected_for_score =
+          !rejected_for_instability && !rejected_for_length &&
+          !rejected_for_domain && !rejected_for_non_finite;
+
         return detail::BcaRejectionAnalysis(true, // has_bca_candidate
 					    false, // bca_chosen (we already checked this)
 					    rejected_for_instability,
 					    rejected_for_length,
 					    rejected_for_domain,
-					    rejected_for_non_finite
+					    rejected_for_non_finite,
+					    rejected_for_score
 					    );
       }
       
@@ -2008,7 +2018,8 @@ namespace palvalidator
           bca_analysis.rejectedForNonFinite(),
           enriched.size(),
           std::move(breakdowns),
-          tie_epsilon_used);
+          tie_epsilon_used,
+          bca_analysis.rejectedForScore());
         
         return Result(winner.getMethod(), winner, enriched, diagnostics);
       }

--- a/libs/statistics/AutoCIResult.h
+++ b/libs/statistics/AutoCIResult.h
@@ -572,6 +572,8 @@ namespace palvalidator
 	 * @param numCandidates Total number of candidates evaluated (default: 0)
 	 * @param scoreBreakdowns Detailed score decomposition for all candidates (default: empty)
 	 * @param tie_epsilon [V2] Relative tolerance used for tie detection (default: 1e-10)
+	 * @param bcaRejectedForScore True if BCa passed all hard gates but was fairly
+	 *        outscored by another method (default: false).
 	 */
 	SelectionDiagnostics(
 			     MethodId     chosenMethod,
@@ -587,8 +589,8 @@ namespace palvalidator
 			     bool         bcaRejectedForNonFinite   = false,
 			     std::size_t  numCandidates             = 0,
 			     std::vector<ScoreBreakdown> scoreBreakdowns = std::vector<ScoreBreakdown>(),
-			     // NEW V2 PARAMETER (default for backward compatibility)
-			     double       tie_epsilon = 1e-10)
+			     double       tie_epsilon = 1e-10,
+			     bool         bcaRejectedForScore = false)
 	: m_chosen_method(chosenMethod),
 	  m_chosen_method_name(std::move(chosenMethodName)),
 	  m_chosen_score(chosenScore),
@@ -602,7 +604,8 @@ namespace palvalidator
 	  m_bca_rejected_for_non_finite(bcaRejectedForNonFinite),
 	  m_num_candidates(numCandidates),
 	  m_score_breakdowns(std::move(scoreBreakdowns)),
-	  m_tie_epsilon(tie_epsilon)
+	  m_tie_epsilon(tie_epsilon),
+	  m_bca_rejected_for_score(bcaRejectedForScore)
 	{}
 
 	// -- Existing Getters (unchanged) --
@@ -617,6 +620,10 @@ namespace palvalidator
 	bool wasBCaRejectedForLength() const { return m_bca_rejected_for_length; }
 	bool wasBCaRejectedForDomain() const { return m_bca_rejected_for_domain; }
 	bool wasBCaRejectedForNonFiniteParameters() const { return m_bca_rejected_for_non_finite; }
+	/**
+	 * @brief Returns true if BCa passed all hard gates but was fairly outscored.
+	 */
+	bool wasBCaRejectedForScore() const { return m_bca_rejected_for_score; }
 	std::size_t getNumCandidates() const { return m_num_candidates; }
 	bool hasScoreBreakdowns() const { return !m_score_breakdowns.empty(); }
 	const std::vector<ScoreBreakdown>& getScoreBreakdowns() const { return m_score_breakdowns; }
@@ -640,10 +647,9 @@ namespace palvalidator
 	bool        m_bca_rejected_for_length;
 	bool        m_bca_rejected_for_domain;
 	bool        m_bca_rejected_for_non_finite;
+	bool        m_bca_rejected_for_score;
 	std::size_t m_num_candidates;
 	std::vector<ScoreBreakdown> m_score_breakdowns;
-    
-	// NEW V2 field
 	double m_tie_epsilon;
       };
 

--- a/libs/statistics/BiasCorrectedBootstrap.h
+++ b/libs/statistics/BiasCorrectedBootstrap.h
@@ -44,8 +44,8 @@
 //     - StdAsyncExecutor      : portable; good for small numbers of long tasks
 //     - BoostRunnerExecutor   : integrates with an existing Boost runner thread pool
 
-#ifndef __BCA_BOOTSTRAP_H
-#define __BCA_BOOTSTRAP_H
+#ifndef MKC_BCA_BOOTSTRAP_H
+#define MKC_BCA_BOOTSTRAP_H
 
 #include <vector>
 #include <numeric>
@@ -1330,7 +1330,9 @@ struct IIDResampler
     StatFn                         m_statistic;
     Sampler                        m_sampler;
 
-    // Provider storage: zero-size when Provider = void (no overhead).
+    // Provider storage: minimal (1 byte + padding) when Provider = void.
+    // char is not an empty class, so [[no_unique_address]] cannot elide it.
+    // The overhead is negligible; an empty struct could eliminate it entirely.
     [[no_unique_address]]
     std::conditional_t<std::is_void_v<Provider>, char, Provider> m_provider{};
 
@@ -1958,4 +1960,4 @@ struct IIDResampler
 
 } // namespace mkc_timeseries
 
-#endif // __BCA_BOOTSTRAP_H
+#endif // MKC_BCA_BOOTSTRAP_H

--- a/libs/statistics/CandidateReject.h
+++ b/libs/statistics/CandidateReject.h
@@ -33,8 +33,14 @@ namespace palvalidator::diagnostics
       BcaAccelHardFail        = 1u << 5,  // |accel| exceeds hard limit
       PercentileTInnerFails   = 1u << 6,  // Percentile-T inner fail rate too high (diagnostic)
       PercentileTLowEffB      = 1u << 7,  // Percentile-T effective B fraction too low (diagnostic)
-      MOutOfNHardFailure      = (1 << 8)  // distribution_degenerate or insufficient_spread
-      // bits 8..31 reserved
+      MOutOfNHardFailure      = 1u << 8,  // distribution_degenerate or insufficient_spread
+      BcaSkewHardFail         = 1u << 9,  // |skew_boot| exceeds kBcaSkewHardLimit
+      BcaAccelUnreliable      = 1u << 10, // Jackknife acceleration dominated by single outlier
+      BcaTransformNonMonotone = 1u << 11, // BCa percentile-transform mapping inverted (α₁ > α₂)
+      BcaMinSampleSize        = 1u << 12, // n < kBcaMinSampleSize (jackknife unreliable)
+      PercentileTMinSampleSize = 1u << 13, // n < kPercentileTMinSampleSize (inner SE* unreliable)
+      BoundsNonFinite         = 1u << 14  // Interval lower or upper bound is NaN/Inf
+      // bits 15..31 reserved
     };
 
   enum class CandidateFlag : std::uint32_t
@@ -117,6 +123,13 @@ namespace palvalidator::diagnostics
     append(CandidateReject::BcaAccelHardFail,      "BCA_ACCEL_EXCEEDED");
     append(CandidateReject::PercentileTInnerFails, "PCTT_INNER_FAILURES");
     append(CandidateReject::PercentileTLowEffB,    "PCTT_LOW_EFFECTIVE_B");
+    append(CandidateReject::MOutOfNHardFailure,    "MOUTN_HARD_FAILURE");
+    append(CandidateReject::BcaSkewHardFail,       "BCA_SKEW_EXCEEDED");
+    append(CandidateReject::BcaAccelUnreliable,    "BCA_ACCEL_UNRELIABLE");
+    append(CandidateReject::BcaTransformNonMonotone, "BCA_TRANSFORM_NON_MONOTONE");
+    append(CandidateReject::BcaMinSampleSize,      "BCA_MIN_SAMPLE_SIZE");
+    append(CandidateReject::PercentileTMinSampleSize, "PCTT_MIN_SAMPLE_SIZE");
+    append(CandidateReject::BoundsNonFinite,       "BOUNDS_NON_FINITE");
 
     return oss.str();
   }

--- a/libs/statistics/MOutOfNPercentileBootstrap.h
+++ b/libs/statistics/MOutOfNPercentileBootstrap.h
@@ -240,14 +240,14 @@ namespace palvalidator
        */
       MOutOfNPercentileBootstrap(std::size_t B,
                                  double      confidence_level,
-                                 double      m_ratio,
+                                 double      ratio,
                                  const Resampler& resampler,
                                  bool        rescale_to_n = false,
 				 IntervalType interval_type = IntervalType::TWO_SIDED,
                                  std::shared_ptr<Executor> exec = nullptr)
         : m_B(B)
         , m_CL(confidence_level)
-        , m_ratio(m_ratio)
+        , m_ratio(ratio)
         , m_resampler(resampler)
         , m_rescale_to_n(rescale_to_n)
         , m_exec(exec ? std::move(exec) : std::make_shared<Executor>())
@@ -400,13 +400,13 @@ namespace palvalidator
       static MOutOfNPercentileBootstrap
       createFixedRatio(std::size_t B,
                        double      confidence_level,
-                       double      m_ratio,
+                       double      ratio,
                        const Resampler& resampler,
                        bool        rescale_to_n = false,
 		       IntervalType interval_type = IntervalType::TWO_SIDED,
                        std::shared_ptr<Executor> exec = nullptr)
       {
-        return MOutOfNPercentileBootstrap(B, confidence_level, m_ratio, resampler,
+        return MOutOfNPercentileBootstrap(B, confidence_level, ratio, resampler,
 					  rescale_to_n, interval_type, std::move(exec));
       }
 
@@ -617,18 +617,8 @@ namespace palvalidator
         {
           auto policy = std::static_pointer_cast<
             IAdaptiveRatioPolicy<Decimal, BootstrapStatistic>>(m_ratioPolicy);
-
-          if (policy)
-          {
-            actual_ratio = policy->computeRatioWithRefinement(
-              x, ctx, m_CL, m_B, probeMaker, diagnosticLog);
-          }
-          else
-          {
-            TailVolatilityAdaptivePolicy<Decimal, BootstrapStatistic> defaultPolicy;
-            actual_ratio = defaultPolicy.computeRatioWithRefinement(
-              x, ctx, m_CL, m_B, probeMaker, diagnosticLog);
-          }
+          actual_ratio = policy->computeRatioWithRefinement(
+            x, ctx, m_CL, m_B, probeMaker, diagnosticLog);
         }
 
         // 4. Compute m_sub and clamp to valid range
@@ -1416,16 +1406,15 @@ namespace palvalidator
           "MOutOfNPercentileBootstrap::computeAdaptiveRatio() is not supported for "
           "trade-level bootstrapping (SampleType != Decimal). "
           "Use the fixed-ratio run() overload with IIDResampler<Trade<Decimal>> instead.");
-        auto policy = std::static_pointer_cast<
-          IAdaptiveRatioPolicy<Decimal, BootstrapStatistic>>(m_ratioPolicy);
-
-        if (policy)
+        if (!m_ratioPolicy)
         {
-          return policy->computeRatio(x, ctx, m_CL, m_B, diagnosticLog);
+          TailVolatilityAdaptivePolicy<Decimal, BootstrapStatistic> defaultPolicy;
+          return defaultPolicy.computeRatio(x, ctx, m_CL, m_B, diagnosticLog);
         }
 
-        TailVolatilityAdaptivePolicy<Decimal, BootstrapStatistic> defaultPolicy;
-        return defaultPolicy.computeRatio(x, ctx, m_CL, m_B, diagnosticLog);
+        auto policy = std::static_pointer_cast<
+          IAdaptiveRatioPolicy<Decimal, BootstrapStatistic>>(m_ratioPolicy);
+        return policy->computeRatio(x, ctx, m_CL, m_B, diagnosticLog);
       }
 
     private:
@@ -1436,7 +1425,11 @@ namespace palvalidator
       bool         m_rescale_to_n; /**< If true, rescale CI from m to n. */
       mutable std::shared_ptr<Executor> m_exec;   /**< Parallel executor. */
       mutable uint32_t           m_chunkHint{0};  /**< Chunk size hint for parallel_for. */
-      std::shared_ptr<void>      m_ratioPolicy;   /**< Type-erased adaptive ratio policy. */
+      // Type-erased adaptive ratio policy. Stored as shared_ptr<void> because
+      // IAdaptiveRatioPolicy is templated on BootstrapStatistic, but that parameter
+      // does not appear in any virtual method signature — the cast back via
+      // static_pointer_cast is safe regardless of the BootstrapStatistic used.
+      std::shared_ptr<void>      m_ratioPolicy;
 
       /** @name Diagnostics from most recent run (protected by m_diagMutex)
        *  @{ */

--- a/libs/statistics/StatUtils.h
+++ b/libs/statistics/StatUtils.h
@@ -705,13 +705,20 @@ namespace mkc_timeseries
     static constexpr bool   DefaultCompress      = true;
     
     static inline std::vector<Decimal>
-    percentBarsToLogBars(const std::vector<Decimal>& pct)
+    percentBarsToLogBars(const std::vector<Decimal>& pct,
+			 double ruin_eps = StatUtils::DefaultRuinEps)
     {
       std::vector<Decimal> out;
       out.reserve(pct.size());
       const auto one = DecimalConstants<Decimal>::DecimalOne;
+      const Decimal d_ruin(ruin_eps);
       for (const auto& r : pct)
-	out.push_back(std::log(one + r));
+	{
+	  Decimal growth = one + r;
+	  if (growth <= d_ruin)
+	    growth = d_ruin;
+	  out.push_back(std::log(growth));
+	}
       return out;
     }
 
@@ -812,7 +819,7 @@ namespace mkc_timeseries
     static inline Decimal sharpeFromReturns(const std::vector<Decimal>& data, double eps = 1e-8)
     {
       auto [meanDec, varDec] = StatUtils<Decimal>::computeMeanAndVarianceFast(data);
-	
+
       const double var = num::to_double(varDec);
       const double sd  = std::sqrt(std::max(var + eps, eps));
       if (sd == 0.0)
@@ -961,7 +968,7 @@ namespace mkc_timeseries
 	if (loss_count < 0) loss_count = 0;
 	if (N < 0) N = 0;
 
-	const int k0_int = computeK0FromNAndLossCount(N, loss_count);;
+	const int k0_int = computeK0FromNAndLossCount(N, loss_count);
 
 	const xdouble k0   = static_cast<xdouble>(k0_int);
 	const xdouble lc   = static_cast<xdouble>(loss_count);
@@ -1643,14 +1650,14 @@ namespace mkc_timeseries
 	  double m = 1 + num::to_double(r);
 	  if (m <= 0)
 	    continue;
-	    
+
 	  Decimal lr(std::log(m));
 	  if (r > DecimalConstants<Decimal>::DecimalZero)
 	    lw += lr;
 	  else
 	    ll += lr;
 	}
-	
+
       return computeFactor(lw, ll, compressResult);
     }
 
@@ -2605,6 +2612,9 @@ namespace mkc_timeseries
         throw std::invalid_argument("quantileType7Sorted: input vector must not be empty");
       }
 
+      // Single-element vector: the only value is the quantile at every p.
+      if (sorted.size() == 1) return sorted.front();
+
       // Handle edge cases at boundaries
       if (p <= 0.0) return sorted.front();
       if (p >= 1.0) return sorted.back();
@@ -2661,6 +2671,9 @@ namespace mkc_timeseries
       if (data.empty()) {
         throw std::invalid_argument("quantileType7Unsorted: input vector must not be empty");
       }
+
+      // Single-element vector: the only value is the quantile at every p.
+      if (data.size() == 1) return data.front();
 
       // Handle edge cases at boundaries
       if (p <= 0.0) return *std::min_element(data.begin(), data.end());


### PR DESCRIPTION
# Bug Report: Statistics Library Code Review Fixes

**Date:** 2026-04-15
**Branch:** bugs/palvalidator_filtering
**Files reviewed:** BiasCorrectedBootstrap.h, MOutOfNPercentileBootstrap.h, StatUtils.h

---

## StatUtils.h

### Bug 1: `quantileType7Sorted` — out-of-bounds read for single-element vectors

**Severity:** High (undefined behavior)
**Location:** `StatUtils::quantileType7Sorted()`

**Problem:** For a single-element sorted vector with `p` in (0, 1), the type-7
formula computes `h = (1-1)*p + 1 = 1.0`, giving `i = 1`. The function then
reads `sorted[1]` which is out of bounds. Although the interpolation fraction
is 0.0 (so the OOB value is multiplied by zero and the result is numerically
"correct"), reading past the end of the vector is undefined behavior.

**Fix:** Added an early return for `sorted.size() == 1` before the index
arithmetic. The quantile of a single value is that value at every probability.

---

### Bug 2: `quantileType7Unsorted` — unsigned underflow for single-element vectors

**Severity:** Critical (guaranteed crash or memory corruption)
**Location:** `StatUtils::quantileType7Unsorted()`

**Problem:** For a single-element vector with `p` in (0, 1), the clamping logic
`if (i1 >= data.size()) i1 = data.size() - 1` sets `i1 = 0`. The subsequent
access `work0[i1 - 1]` underflows `std::size_t` to `SIZE_MAX`, causing an
access billions of positions past the end of the vector. This is a guaranteed
crash or silent memory corruption.

**Fix:** Added an early return for `data.size() == 1` before the index
arithmetic, matching the fix for `quantileType7Sorted`.

---

### Bug 3: `percentBarsToLogBars` — undefined behavior for returns <= -100%

**Severity:** Medium (UB producing -inf/NaN, silent data corruption)
**Location:** `StatUtils::percentBarsToLogBars()`

**Problem:** The function computed `std::log(one + r)` with no guard for
`one + r <= 0`. If a return is -100% or worse, `std::log` receives a
non-positive argument, producing `-inf`, `NaN`, or a floating-point domain
error. The companion function `makeLogGrowthSeries` correctly clamped with
`ruin_eps`; this function did not.

**Fix:** Added `ruin_eps` clamping identical to `makeLogGrowthSeries`. The
function now accepts an optional `ruin_eps` parameter (defaulting to
`DefaultRuinEps`) and clamps `growth` to at least `ruin_eps` before taking the
log. The default-argument signature preserves backward compatibility with all
existing call sites.

---

### Observation 4: `computeLogProfitFactor` — silently discards total-loss returns

**Severity:** Low (known legacy behavior, not fixed)
**Location:** `StatUtils::computeLogProfitFactor()`

**Problem:** When `1 + r <= 0` (a return of -100% or worse), the observation is
silently skipped (`continue`). This means catastrophic losses are ignored,
potentially inflating the profit factor. The robust variant
(`computeLogProfitFactorRobust`) correctly clamps to `ruin_eps` instead.

**Status:** Not fixed. This is intentional legacy behavior — existing tests
verify that ruin events are skipped and PF returns 100 (the "no losses" case).
Callers requiring ruin-aware profit factors should use the robust variant.

---

### Fix 5: Double semicolon

**Severity:** Cosmetic
**Location:** `SmoothAdditiveWinCountFadingDenomPolicy::computeDenom()`

**Problem:** `const int k0_int = computeK0FromNAndLossCount(N, loss_count);;`
had a trailing extra semicolon.

**Fix:** Removed the duplicate semicolon.

---

### Observation 6: `sharpeFromReturns` — `sd == 0.0` guard

**Severity:** N/A (not a bug)
**Location:** `StatUtils::sharpeFromReturns()`, two overloads

**Analysis:** Both overloads compute `sd = sqrt(max(var + eps, eps))`. With the
default `eps = 1e-8`, `sd` is always positive. However, callers can pass
`eps = 0.0` explicitly, in which case constant returns produce `var = 0`,
`sd = 0`, and the guard correctly returns zero instead of dividing by zero.

**Status:** Not fixed. The guard is reachable and necessary when `eps = 0.0`.

---

## BiasCorrectedBootstrap.h

### Fix 7: Reserved identifier in include guard

**Severity:** Low (technically undefined behavior per C++ standard)

**Problem:** The include guard `__BCA_BOOTSTRAP_H` uses a double-underscore
prefix, which is reserved for the implementation per [lex.name].

**Fix:** Renamed to `MKC_BCA_BOOTSTRAP_H`.

---

### Fix 8: Incorrect "zero-size" comment for `m_provider`

**Severity:** Cosmetic (misleading documentation)

**Problem:** Comment claimed "zero-size when Provider = void" but `char` is
1 byte, not an empty class. `[[no_unique_address]]` only elides storage for
empty class types.

**Fix:** Updated comment to accurately state "minimal (1 byte + padding)".

---

## MOutOfNPercentileBootstrap.h

### Fix 9: Dead code in `runWithRefinement`

**Severity:** Low (unreachable fallback branch)

**Problem:** After the outer `if (!m_ratioPolicy)` null check, the inner
`static_pointer_cast` from the non-null `shared_ptr<void>` always returns a
non-null pointer. The `else` fallback branch was unreachable dead code.

**Fix:** Removed the dead `else` branch. Added a comment on the `m_ratioPolicy`
member explaining why the `shared_ptr<void>` type erasure is safe
(BootstrapStatistic does not appear in any virtual method signature of
`IAdaptiveRatioPolicy`).

---

### Fix 10: Constructor parameter shadows member `m_ratio`

**Severity:** Low (correctness hazard, `-Wshadow` warning)

**Problem:** The constructor parameter `m_ratio` shadowed the member `m_ratio`.
The initializer list `m_ratio(m_ratio)` is technically correct (outer name
resolves to member, inner to parameter), but fragile and triggers `-Wshadow`.

**Fix:** Renamed the parameter to `ratio` in both the constructor and the
`createFixedRatio` factory.

---

### Fix 11: Restructured `computeAdaptiveRatio` null check

**Severity:** Low (eliminated redundant post-cast null check)

**Problem:** The function performed `static_pointer_cast` from `m_ratioPolicy`
then checked if the result was null. Since `static_pointer_cast` from a
non-null source is always non-null, the fallback was unreachable.

**Fix:** Restructured to check `m_ratioPolicy` for null first (using the
default policy), then unconditionally cast and call in the non-null path.

---

## AutoBootstrapSelector Tournament Interface

**Date:** 2026-04-15
**Files reviewed:** AutoBootstrapScoring.h, AutoBootstrapSelector.h, AutoCIResult.h,
BootstrapPenaltyCalculator.h, CandidateReject.h, AutoBootstrapConfiguration.h

---

### Fix 12: `MOutOfNHardFailure` missing from `rejectionMaskToString()`

**Severity:** Medium (diagnostic output incomplete)
**Location:** `CandidateReject.h`, `rejectionMaskToString()`

**Problem:** `computeRejectionMask()` correctly set the `MOutOfNHardFailure` bit
(bit 8) when an M-out-of-N candidate had `distribution_degenerate` or
`insufficient_spread`. However, `rejectionMaskToString()` had no `append()` call
for this bit. The `rejection_text` field on the candidate's `ScoreBreakdown` was
empty or incomplete when M-out-of-N was rejected for a hard failure, making the
diagnostic output misleading.

**Fix:** Added `append(CandidateReject::MOutOfNHardFailure, "MOUTN_HARD_FAILURE")`
to `rejectionMaskToString()`.

---

### Fix 13: `computeRejectionMask()` incomplete relative to `CandidateGateKeeper`

**Severity:** Medium (diagnostic gap — selection correctness unaffected)
**Location:** `AutoBootstrapSelector.h`, `computeRejectionMask()`;
`CandidateReject.h`, `CandidateReject` enum and `rejectionMaskToString()`

**Problem:** `CandidateGateKeeper::isBcaCandidateValid()` and
`isCommonCandidateValid()` enforced several hard gates that had no corresponding
bit in `computeRejectionMask()`:

| Gate (in GateKeeper)                    | Rejection bit? |
|-----------------------------------------|----------------|
| BCa `n < kBcaMinSampleSize`            | None           |
| BCa `!getAccelIsReliable()`            | None           |
| BCa `\|skewBoot\| > kBcaSkewHardLimit` | None           |
| BCa `!getBcaTransformMonotone()`       | None           |
| PercentileT `n < kPercentileTMinSampleSize` | None      |
| Non-finite interval bounds (all methods) | None          |

The `passed_gates` field in `ScoreBreakdown` was correctly computed from the
actual gatekeeper, but when `passed_gates=false` the `rejection_mask` and
`rejection_text` did not explain why. A candidate could show `passed_gates=false`
with `rejection_text=""`.

**Fix:** Added six new bits to the `CandidateReject` enum: `BcaSkewHardFail`,
`BcaAccelUnreliable`, `BcaTransformNonMonotone`, `BcaMinSampleSize`,
`PercentileTMinSampleSize`, `BoundsNonFinite`. Added matching checks in
`computeRejectionMask()` and `append()` calls in `rejectionMaskToString()`.
The rejection mask now fully mirrors all gates in `CandidateGateKeeper`.

---

### Fix 14: `tie_epsilon_used` reflected last comparison, not decisive one

**Severity:** Low (diagnostic reporting only)
**Location:** `AutoBootstrapScoring.h`, `ImprovedTournamentSelector::consider()`

**Problem:** `m_tie_epsilon_used` was overwritten on every call to `consider()`,
regardless of whether the candidate changed the winner. If the winner was
determined at candidate index 2 and candidates 3–5 were considered but didn't
win, `getTieEpsilon()` returned the epsilon from the comparison with candidate 5,
not the comparison that actually determined the winner. The
`SelectionDiagnostics::tie_epsilon` field therefore reported a potentially
misleading value.

**Fix:** Moved the `m_tie_epsilon_used = eps` assignment inside the two branches
where the winner actually changes (clear win and tie-break win), so it always
reflects the decisive comparison.

---

### Fix 15: Missing `rejected_for_score` in `BcaRejectionAnalysis` (BUG-4)

**Severity:** Medium (ambiguous diagnostic state)
**Location:** `AutoBootstrapScoring.h`, `BcaRejectionAnalysis`;
`AutoCIResult.h`, `SelectionDiagnostics`;
`AutoBootstrapSelector.h`, `analyzeBcaRejection()` and `select()`

**Problem:** When BCa passed all hard gates but was simply outscored by another
method, all four rejection flags (`rejectedForInstability`, `rejectedForLength`,
`rejectedForDomain`, `rejectedForNonFinite`) remained `false` while `bcaChosen`
was also `false`. Callers had to infer the "fairly outscored" state by checking
that all flags were false — fragile and undiscoverable. This was documented
inline as BUG-4.

**Fix:**
- Added `m_rejected_for_score` field and `rejectedForScore()` getter to
  `BcaRejectionAnalysis` (with a default parameter for backward compatibility).
- Added `m_bca_rejected_for_score` field, constructor parameter, and
  `wasBCaRejectedForScore()` getter to `SelectionDiagnostics`.
- `analyzeBcaRejection()` now computes `rejected_for_score = true` when BCa
  passed all hard gates but was not chosen.
- `select()` passes the new field through to `SelectionDiagnostics`.
- Removed the BUG-4 NOTE comment.

---

### Fix 16: BCa effective-B fraction hardcoded in two locations

**Severity:** Low (fragile duplication, correctness risk on future changes)
**Location:** `AutoBootstrapConfiguration.h`;
`AutoBootstrapScoring.h`, `CandidateGateKeeper::passesEffectiveBGate()`;
`AutoBootstrapSelector.h`, `analyzeBcaRejection()`

**Problem:** The BCa minimum effective fraction (`0.90`) appeared as a magic
number in two separate locations: `passesEffectiveBGate()` (the actual gate)
and `analyzeBcaRejection()` (the diagnostic mirror). If one was changed without
the other, the diagnostic analysis would silently disagree with the actual
gating decision. This was partially noted inline as BUG-5 (which concerned the
analogous `kMinEffectiveBAbsolute` constant, already centralized).

**Fix:**
- Added `kBcaMinEffectiveFraction = 0.90` to `AutoBootstrapConfiguration`.
- `passesEffectiveBGate()` now uses `kBcaMinEffectiveFraction` as the default,
  and the redundant `BCa`/`default` switch cases were collapsed.
- `analyzeBcaRejection()` now references `kBcaMinEffectiveFraction` instead of
  hardcoded `0.90`.
- Removed the stale BUG-5 NOTE comment.
