### PR TITLE
Palvalidator v2 5 1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(PalValidator VERSION 2.5.0 LANGUAGES CXX)
+project(PalValidator VERSION 2.5.1 LANGUAGES CXX)
 
 # Extract Git information for version header
 find_package(Git QUIET)

--- a/libs/statistics/AutoCIResult.h
+++ b/libs/statistics/AutoCIResult.h
@@ -602,10 +602,10 @@ namespace palvalidator
 	  m_bca_rejected_for_length(bcaRejectedForLength),
 	  m_bca_rejected_for_domain(bcaRejectedForDomain),
 	  m_bca_rejected_for_non_finite(bcaRejectedForNonFinite),
+	  m_bca_rejected_for_score(bcaRejectedForScore),
 	  m_num_candidates(numCandidates),
 	  m_score_breakdowns(std::move(scoreBreakdowns)),
-	  m_tie_epsilon(tie_epsilon),
-	  m_bca_rejected_for_score(bcaRejectedForScore)
+	  m_tie_epsilon(tie_epsilon)
 	{}
 
 	// -- Existing Getters (unchanged) --


### PR DESCRIPTION
# Release Notes
 
## What's Changed
 
### ⚡ Performance
 
#### Concurrent BCa Bootstrap ([#302](https://github.com/testhound/palvalidator/pull/302))
 
The BCa bootstrap resampling loop inside `detail::ComputeBootstrappedWidths` now runs in parallel across all available hardware threads via `ThreadPoolExecutor<0>`, replacing the previous single-threaded executor. A single shared thread pool is used for both the upside and downside width bootstraps, avoiding the overhead of spinning up a second pool. The `kConfidenceLevel` constant is annotated with an architecture note explaining why a 90% two-sided interval is used rather than two separate one-sided intervals — both yield the same 5th/95th percentile bounds while halving the number of BCa passes required.
 
**Files changed:** `BootStrapIndicators.h`
 
---
 
### 🔒 Statistical Correctness
 
#### RNG Stream Independence for Parallel MCPT ([#304](https://github.com/testhound/palvalidator/pull/304))
 
Replaced probabilistic RNG safety in the Monte Carlo Permutation Test (MCPT) framework with a structural mathematical guarantee. Each of the 32 `ThreadPoolExecutor` worker threads now receives a dedicated PCG32 stream via a new `RandomMersenne::withStream(uint64_t stream_id)` factory method, seeded from OS entropy via `randutils::auto_seed_256` with the stream ID derived from the OS thread identity. Previously, all `tls_rng` instances shared the same PCG32 cycle and could produce overlapping output sequences with probability ~1.2×10⁻⁷ per run — a small but unnecessary risk in a significance-testing framework. Overlap is now mathematically impossible by construction. Four new unit tests validate the factory method and the production call-site pattern.
 
**Files changed:** `RandomMersenne.h`, `PermutationTestComputationPolicy.h`, `RandomTest.cpp`
 
---
 
### 🐛 Bug Fixes
 
#### MCPT Policy Corrections and Log Profit Factor Regularization ([#303](https://github.com/testhound/palvalidator/pull/303))
 
Several correctness issues across the permutation test policy classes and bootstrap analysis stage:
 
- **Small-sample log profit factor over-regularization fixed** — `SmoothAdditiveWinCountFadingDenomPolicy` previously derived the Bayesian prior pseudo-count `k0` from total bar count alone, which over-regularized bootstrap resamples in the rare large-N/sparse-loss case (e.g., N=55, loss_count=5 yielded `fade = 0.67` instead of the correct `0.50`). The new `computeK0FromNAndLossCount` helper takes both N and loss_count into account.
- **Latent NaN bug eliminated** — `BootStrappedLogProfitFactorPolicy` extracted `PercentNumber` values (e.g., `2.0` for a 2% stop-loss) and would have produced `log(−1.0)` → NaN had they ever been passed to a function expecting decimal fractions. The dead extraction block is removed entirely.
- **`BootStrappedSharpeRatioPolicy` architectural correction** — removed an incorrectly placed BCa bootstrap (1000 replications per permutation) from inside the permutation test statistic. The policy now computes a direct Sharpe ratio via `StatUtils::sharpeFromReturns`, matching the design intent of permutation test policies.
- **Silent `dynamic_pointer_cast` failure now throws** — a failed downcast to `PalStrategy<Decimal>` previously allowed execution to continue with zero-valued parameters; it now throws `BackTesterException`.
- **`ResultLogPFPolicy::finalizeFromRatio` NaN guard** — non-positive inputs to `std::log` now throw `std::logic_error` instead of silently propagating `-inf`/`NaN`.
- **Dead argument removal** — `runBarLevelAutoProfitFactorBootstrap` and `runTradeLevelAutoProfitFactorBootstrap` were passing stop-loss and profit-target values that were silently discarded by the constructor; call sites updated to the canonical 3-parameter form.
- **New regression test file** (`StatUtilsPermutationTest.cpp`) with 10 deterministic tests covering null distribution pileup behavior, cap binding, and strict log(PF) monotonicity.
 
**Files changed:** `StatUtils.h`, `BootstrapAnalysisStage.h/.cpp`, `MonteCarloTestPolicy.h`, `StatUtilsPolicyTest.cpp`, `StatUtilsPermutationTest.cpp` *(new)*
 
---
 
#### Filtering Pipeline Bug Fixes ([#305](https://github.com/testhound/palvalidator/pull/305))
 
Correctness issues identified during code review of the filtering and bootstrap pipeline:
 
- **Dangling reference** — `HurdleAnalysisStage` stored `TradingHurdleCalculator` as a `const&` to a stack-local object created in `PerformanceFilter::createPipeline()`. The pipeline outlived the local, causing undefined behavior. Fixed by storing by value.
- **Early return too aggressive for trade-level bootstrapping** — the `BootstrapAnalysisStage::execute()` guard `highResReturns.size() < 2` was applied unconditionally, incorrectly skipping evaluation when `tradeLevelReturns` was the relevant data source. Now conditioned on the bootstrapping mode.
- **BCa mean missing size guard** — `runBCaMeanBootstrap` always ran on `highResReturns` regardless of mode; a size guard is now added so it skips gracefully when bar-level data is insufficient.
- **Wrong backtester in fallback path** — `initializeBacktester()` hardcoded `DailyBackTester` regardless of strategy timeframe. Replaced with `BackTesterFactory::backTestStrategy()` to dispatch correctly based on `ctx.timeFrame`.
- **Uncounted exception-throwing strategies** — strategies that threw during evaluation were excluded from results without incrementing summary counters, causing totals to not add up. Fixed by calling `incrementFailBootstrapCount()` in the exception handler.
- **Narrowing conversion** — `totalStrategies` changed from `unsigned int` to `const size_t` to match `vector::size()`.
- **Method name typo** — `getAdjusteConfidenceInterval` → `getAdjustedConfidenceInterval`.
- **Non-const statics** — two `static Num` locals in `getAdjustedConfidenceInterval()` that are never modified are now `const`.
 
**Files changed:** `HurdleAnalysisStage.h`, `BootstrapAnalysisStage.h/.cpp`, `PerformanceFilter.cpp`
 
---
 
#### Statistics Library and AutoBootstrap Selector Fixes ([#306](https://github.com/testhound/palvalidator/pull/306))
 
Fixes across `StatUtils.h`, `BiasCorrectedBootstrap.h`, `MOutOfNPercentileBootstrap.h`, and the AutoBootstrap selector tournament interface:
 
**StatUtils:**
- **Critical crash fix** — `quantileType7Unsorted` underflowed `std::size_t` to `SIZE_MAX` for single-element vectors, causing a guaranteed crash or memory corruption. Fixed with an early return.
- **UB fix** — `quantileType7Sorted` performed an out-of-bounds read for single-element vectors (numerically benign but undefined behavior). Fixed with an early return.
- **`percentBarsToLogBars` NaN fix** — added `ruin_eps` clamping for returns ≤ −100%, consistent with `makeLogGrowthSeries`. Backward-compatible via a default parameter.
- **Double semicolon** removed from `SmoothAdditiveWinCountFadingDenomPolicy::computeDenom()`.
 
**BiasCorrectedBootstrap:**
- **Reserved identifier** — include guard `__BCA_BOOTSTRAP_H` renamed to `MKC_BCA_BOOTSTRAP_H`.
- **Misleading comment** — "zero-size when Provider = void" corrected to "minimal (1 byte + padding)" since `char` is not an empty class.
 
**MOutOfNPercentileBootstrap:**
- **Dead code** — unreachable `else` branch removed from `runWithRefinement`.
- **Shadow warning** — constructor parameter `m_ratio` renamed to `ratio` to eliminate `-Wshadow`.
- **Redundant null check** — `computeAdaptiveRatio` restructured to check `m_ratioPolicy` before casting, eliminating an unreachable post-cast null check.
 
**AutoBootstrap Selector Tournament Interface:**
- **`MOutOfNHardFailure` missing from `rejectionMaskToString()`** — the bit was correctly set but never rendered, leaving `rejection_text` empty for M-out-of-N hard failures.
- **Incomplete `computeRejectionMask()`** — six new rejection bits added (`BcaSkewHardFail`, `BcaAccelUnreliable`, `BcaTransformNonMonotone`, `BcaMinSampleSize`, `PercentileTMinSampleSize`, `BoundsNonFinite`) to fully mirror all gates enforced by `CandidateGateKeeper`.
- **`tie_epsilon_used` now reflects the decisive comparison** — previously overwritten on every `consider()` call regardless of whether the winner changed.
- **`rejected_for_score` added to `BcaRejectionAnalysis`** — closes a diagnostic ambiguity where BCa could show `bcaChosen=false` with all rejection flags `false` (BUG-4).
- **BCa effective-B fraction centralized** — magic literal `0.90` consolidated into `AutoBootstrapConfiguration::kBcaMinEffectiveFraction` used by both the gate and its diagnostic mirror (BUG-5).
 
**Files changed:** `StatUtils.h`, `BiasCorrectedBootstrap.h`, `MOutOfNPercentileBootstrap.h`, `CandidateReject.h`, `AutoBootstrapSelector.h`, `AutoBootstrapScoring.h`, `AutoCIResult.h`, `AutoBootstrapConfiguration.h`
 
---
 
## Pull Requests
 
| PR | Title | Merged |
|---|---|---|
| [#302](https://github.com/testhound/palvalidator/pull/302) | Make bootstrap concurrent | Apr 9, 2026 |
| [#303](https://github.com/testhound/palvalidator/pull/303) | Cleanup/mcpt policy classes | Apr 12, 2026 |
| [#304](https://github.com/testhound/palvalidator/pull/304) | Use PCG independent streams for permutation testing | Apr 13, 2026 |
| [#305](https://github.com/testhound/palvalidator/pull/305) | Fix bugs/issues discovered by claude code during code review | Apr 14, 2026 |
| [#306](https://github.com/testhound/palvalidator/pull/306) | Add multiple cleanup fixes from claude code review | Apr 16, 2026 |
 
**Full Changelog:** https://github.com/testhound/palvalidator/compare/...master