### PR TITLE
Bugs/acf block length fix

### DIFF
--- a/libs/statistics/MetaLosingStreakBootstrapBound.h
+++ b/libs/statistics/MetaLosingStreakBootstrapBound.h
@@ -153,23 +153,30 @@ namespace mkc_timeseries
       // 2a) Optionally estimate stationary-block length from ACF of LOSS INDICATOR
       //     L is the “expected” block length in trades for our stationary sampler.
       std::optional<unsigned> L_auto;
-      if (m_opts.useACFBlockLen && n >= 2) {
-	std::vector<Decimal> loss01; loss01.reserve(n);
-	for (const auto& x : pnl) {
-	  const bool loss = (x < Decimal(0)) || (m_opts.treatZeroAsLoss && x == Decimal(0));
-	  loss01.push_back(loss ? Decimal(1) : Decimal(0));
+      if (m_opts.useACFBlockLen && n >= 2)
+	{
+	  std::vector<Decimal> loss01; loss01.reserve(n);
+	  for (const auto& x : pnl)
+	    {
+	      const bool loss = (x < Decimal(0)) || (m_opts.treatZeroAsLoss && x == Decimal(0));
+	      loss01.push_back(loss ? Decimal(1) : Decimal(0));
+	    }
+
+	  try
+	    {
+	      const unsigned Ls =
+		StatUtils<Decimal>::suggestStationaryBlockLength(loss01,
+								 m_opts.acfMaxLag,
+								 m_opts.acfMinL,
+								 m_opts.acfMaxL);
+	      L_auto = Ls;
+	    }
+	  catch (...)
+	    {
+	      // Degenerate cases (constant series, too-short n): just skip auto-L.
+	      L_auto.reset();
+	    }
 	}
-	try {
-	  const auto acf = StatUtils<Decimal>::computeACF(loss01, m_opts.acfMaxLag);
-	  const unsigned Ls =
-	    StatUtils<Decimal>::suggestStationaryBlockLengthFromACF(
-								    acf, n, m_opts.acfMinL, m_opts.acfMaxL);
-	  L_auto = Ls;
-	} catch (...) {
-	  // Degenerate cases (constant series, too-short n): just skip auto-L.
-	  L_auto.reset();
-	}
-      }
 
       // 3) Precompute per-replicate seeds to avoid sharing RNG across threads
       std::vector<uint64_t> seeds(m_opts.B);

--- a/libs/statistics/StatUtils.h
+++ b/libs/statistics/StatUtils.h
@@ -2074,57 +2074,6 @@ namespace mkc_timeseries
       return std::max(L_raw, L_abs);
     }
 
-    /**
-     * @brief Suggest a stationary-bootstrap mean block length from an ACF curve.
-     *
-     * Heuristic:
-     * - Noise band ≈ 2/sqrt(nSamples).
-     * - Let k* be the largest lag with |ρ(k)| > band, clamp to [minL, maxL].
-     *
-     * Works with ACF stored as Decimal or double.
-     */
-    static unsigned
-    suggestStationaryBlockLengthFromACF(const std::vector<Decimal>& acf,
-                                        std::size_t nSamples,
-                                        unsigned minL = 2,
-                                        unsigned maxL = 6)
-    {
-      if (acf.empty() || nSamples == 0)
-        throw std::invalid_argument(
-            "suggestStationaryBlockLengthFromACF: empty ACF or nSamples=0.");
- 
-      // Number of lags being tested (acf[0] is always 1, not a test).
-      const std::size_t M = acf.size() - 1;
-      if (M == 0)
-        return minL;   // only rho[0] present — no lags to test
- 
-      // Bonferroni-corrected threshold.
-      // z = sqrt(2) * erfinv(1 - alpha/M)  where alpha = 0.05.
-      // This is equivalent to qnorm(1 - alpha/(2*M)), the (1 - alpha/(2M))
-      // quantile of the standard normal, derived from the identity:
-      //   erf(z/sqrt(2)) = 1 - alpha/M  ⟺  z = sqrt(2)*erfinv(1-alpha/M)
-      constexpr double alpha  = 0.05;
-      const double z_bonf = std::sqrt(2.0) *
-                      boost::math::erf_inv(1.0 - alpha / static_cast<double>(M));
-      const double thresh     = z_bonf / std::sqrt(static_cast<double>(nSamples));
- 
-      // Consecutive-lag rule: update k_star only when both lag k and lag k+1
-      // exceed the Bonferroni band.
-      unsigned k_star = minL;
-      for (std::size_t k = 1; k + 1 < acf.size(); ++k)
-      {
-        const double rk  = std::fabs(acf[k    ].getAsDouble());
-        const double rk1 = std::fabs(acf[k + 1].getAsDouble());
-        if (rk > thresh && rk1 > thresh)
-          k_star = static_cast<unsigned>(k + 1);
-      }
- 
-      if (k_star < minL) k_star = minL;
-      if (k_star > maxL) k_star = maxL;
- 
-      return k_star;
-    }
-    
     static std::tuple<Decimal, Decimal> getBootStrappedProfitability(const std::vector<Decimal>& barReturns,
 								     std::function<std::tuple<Decimal, Decimal>(const std::vector<Decimal>&)> statisticFunc,
 								     size_t numBootstraps = 100)

--- a/libs/statistics/StatUtils.h
+++ b/libs/statistics/StatUtils.h
@@ -1844,6 +1844,237 @@ namespace mkc_timeseries
     }
 
     /**
+     * @brief Suggest a stationary-bootstrap block length from a decimal return
+     *        series.
+     *
+     * This is the single entry point for block length selection.  The caller
+     * provides a series of decimal returns; all internal transformations
+     * (log-return conversion, ACF computation, absolute-return ACF, dependence-
+     * mass estimation) are implementation details hidden from the caller.
+     *
+     * ---------------------------------------------------------------------------
+     * INPUT FORMAT
+     * ---------------------------------------------------------------------------
+     *
+     * @p decimalReturns must contain returns expressed as decimal fractions:
+     *
+     *   0.015  means +1.5%
+     *  -0.023  means -2.3%
+     *
+     * Do NOT pass percent values (1.5, -2.3) or pre-computed log-returns.
+     * The function applies log(1 + r) internally; passing already-transformed
+     * values will silently produce incorrect results.
+     *
+     * If your data is in percent-ROC format, divide by 100 before calling:
+     *
+     *   decimalReturn = rocPercent / 100
+     *
+     * ---------------------------------------------------------------------------
+     * WHY ONE FUNCTION, ONE ALGORITHM
+     * ---------------------------------------------------------------------------
+     *
+     * Two previous designs were retired:
+     *
+     * Design 1 — single ACF + Bonferroni threshold + consecutive-lag rule.
+     *   Fragile: block length jumped from 2 to 12 when a single ACF value
+     *   moved 0.002 across a significance boundary.  The family-wise error rate
+     *   was ~22% across 20 lags even after corrections, because binary
+     *   significance testing is inherently discontinuous.
+     *
+     * Design 2 — two pre-computed ACFs + dependence-mass estimator (overloaded).
+     *   Better algorithm but leaked implementation detail to callers: they had to
+     *   compute log-returns, compute abs log-returns, compute both ACFs, and then
+     *   call the function.  Any caller omitting the log transformation would get
+     *   a wrong but plausible-looking result.
+     *
+     * This design internalises every transformation.  The caller's only
+     * responsibility is to supply decimal returns in the correct format.
+     *
+     * ---------------------------------------------------------------------------
+     * ALGORITHM
+     * ---------------------------------------------------------------------------
+     *
+     * Step 1.  Compute log-returns:  r_log[t] = log(1 + r[t]).
+     *
+     * Step 2.  Compute abs log-returns: r_abs[t] = |r_log[t]|.
+     *
+     * Step 3.  Compute both ACFs up to K = min(maxLag, n-1) lags:
+     *
+     *            acfRaw = ACF(r_log)
+     *            acfAbs = ACF(r_abs)
+     *
+     * Step 4.  Compute tapered Bartlett dependence masses:
+     *
+     *            rawMass = sum_{k=1}^{K}  w_k * rho_raw[k]     (SIGNED)
+     *            absMass = sum_{k=1}^{K}  w_k * |rho_abs[k]|   (unsigned)
+     *
+     *            w_k = 1 - k / (K + 1)
+     *
+     * Step 5.  Compute effective dependence horizons:
+     *
+     *            tauRaw = max(1,  1 + 2 * rawMass)
+     *            tauAbs =         1 + 2 * absMass    (always >= 1)
+     *
+     *          The formula tau = 1 + 2*sum(rho_k) is the standard long-run
+     *          variance inflation factor.  The factor 2 is derived from the
+     *          symmetry of the autocovariance sum (k = -inf..+inf); it is not
+     *          a tuning parameter.
+     *
+     *          tauRaw is clamped to >= 1 because mean-reverting series produce
+     *          negative rawMass.  For such series the IID bootstrap already
+     *          over-estimates variance; a block of minL is appropriate.
+     *
+     * Step 6.  Convert each tau to an integer block length and combine:
+     *
+     *            L_raw = clamp(round(tauRaw), minL, maxL)
+     *            L_abs = clamp(round(tauAbs), minL, maxL)
+     *            L     = max(L_raw, L_abs)
+     *
+     *          max(L_raw, L_abs) ensures the bootstrap preserves whichever
+     *          dependence channel is stronger.  For daily equity series the
+     *          absolute channel (GARCH volatility clustering) typically dominates.
+     *
+     * ---------------------------------------------------------------------------
+     * SIGNED vs ABSOLUTE rho
+     * ---------------------------------------------------------------------------
+     *
+     * The raw channel uses SIGNED rho.  A mean-reverting series (e.g. SPY daily,
+     * rho[1] ~ -0.03) produces negative rawMass, correctly reducing tauRaw toward
+     * 1.  Using |rho| for this channel would incorrectly inflate the block length
+     * to the same value as a momentum series of equal ACF magnitude even though
+     * mean reversion and momentum have opposite implications for bootstrap variance.
+     *
+     * The abs channel uses |rho|.  Volatility clustering always manifests as
+     * positive ACF of |r_t|; signed and absolute interpretations coincide there.
+     *
+     * ---------------------------------------------------------------------------
+     * SMALL-SAMPLE FALLBACK (n < 100)
+     * ---------------------------------------------------------------------------
+     *
+     * Below n = 100 the ACF estimates are too noisy for the dependence-mass
+     * estimator.  The function returns the n^(1/3) heuristic (Politis & White,
+     * 2004) clamped to [minL, maxL].
+     *
+     * ---------------------------------------------------------------------------
+     * WHY minL = 2 AND NOT 1
+     * ---------------------------------------------------------------------------
+     *
+     * Failing to detect autocorrelation is not the same as proving independence.
+     * Two practical reasons to keep L >= 2 even for apparently white-noise data:
+     *
+     * 1. Test power: at n = 3000 the Bonferroni threshold is ~0.055.
+     *    Autocorrelations below that level are real but undetectable.  Daily
+     *    returns routinely carry 0.01-0.04 from microstructure effects.
+     *
+     * 2. Volatility clustering: near-zero raw ACF is consistent with significant
+     *    ACF of |r_t|.  L = 2 preserves adjacent observation pairs and partially
+     *    captures this structure; L = 1 (IID) destroys it entirely.
+     *
+     * ---------------------------------------------------------------------------
+     *
+     * @param decimalReturns  Return series as decimal fractions (0.015 = +1.5%).
+     *                        Must contain at least 2 observations.
+     *                        Do NOT pass percent values or log-returns.
+     * @param maxLag          Maximum ACF lag.  Capped at n-1 internally.
+     *                        Default 20 is appropriate for daily financial data.
+     * @param minL            Minimum block length.  Default 2.
+     * @param maxL            Maximum block length.  Default 12.
+     * @return                Suggested block length in [minL, maxL].
+     * @throws std::invalid_argument if decimalReturns has fewer than 2 elements.
+     */
+    static unsigned
+    suggestStationaryBlockLength(const std::vector<Decimal>& decimalReturns,
+                                 std::size_t maxLag = 20,
+                                 unsigned    minL   = 2,
+                                 unsigned    maxL   = 12)
+    {
+      const std::size_t n = decimalReturns.size();
+ 
+      if (n < 2)
+        throw std::invalid_argument(
+            "suggestStationaryBlockLength: need at least 2 observations.");
+ 
+      // -----------------------------------------------------------------------
+      // Small-sample fallback
+      // -----------------------------------------------------------------------
+      if (n < 100)
+      {
+        const unsigned L = static_cast<unsigned>(
+            std::max<std::size_t>(
+                minL,
+                std::min<std::size_t>(
+                    maxL,
+                    static_cast<std::size_t>(
+                        std::pow(static_cast<double>(n), 1.0 / 3.0)))));
+        return L;
+      }
+ 
+      // -----------------------------------------------------------------------
+      // Step 1 & 2: log-returns and absolute log-returns
+      //
+      // percentBarsToLogBars computes log(1 + r) for each decimal return r.
+      // This is an internal implementation choice; callers are not required to
+      // know that log-returns are used for the ACF.
+      // -----------------------------------------------------------------------
+      const std::vector<Decimal> logReturns =
+          percentBarsToLogBars(decimalReturns);
+ 
+      std::vector<Decimal> absReturns;
+      absReturns.reserve(n);
+      for (const auto& v : logReturns)
+        absReturns.push_back(
+            v < DecimalConstants<Decimal>::DecimalZero ? -v : v);
+ 
+      // -----------------------------------------------------------------------
+      // Step 3: compute both ACFs
+      // -----------------------------------------------------------------------
+      const std::size_t K    = std::min<std::size_t>(maxLag, n - 1);
+      const auto        acfRaw = computeACF(logReturns, K);
+      const auto        acfAbs = computeACF(absReturns,  K);
+ 
+      // -----------------------------------------------------------------------
+      // Step 4: tapered Bartlett dependence masses
+      //
+      // K_raw / K_abs derived from the ACF vector sizes so the weight
+      // denominator is always consistent with the lags actually present,
+      // even when computeACF truncates earlier than K.
+      // -----------------------------------------------------------------------
+      const std::size_t K_raw = acfRaw.size() - 1;
+      double rawMass = 0.0;
+      for (std::size_t k = 1; k <= K_raw; ++k)
+      {
+        const double rho    = acfRaw[k].getAsDouble();          // signed
+        const double weight = 1.0 - (static_cast<double>(k) /
+                              static_cast<double>(K_raw + 1));
+        rawMass += weight * rho;
+      }
+ 
+      const std::size_t K_abs = acfAbs.size() - 1;
+      double absMass = 0.0;
+      for (std::size_t k = 1; k <= K_abs; ++k)
+      {
+        const double rhoAbs = std::fabs(acfAbs[k].getAsDouble());
+        const double weight = 1.0 - (static_cast<double>(k) /
+                              static_cast<double>(K_abs + 1));
+        absMass += weight * rhoAbs;
+      }
+ 
+      // -----------------------------------------------------------------------
+      // Step 5 & 6: tau -> block lengths -> combine
+      // -----------------------------------------------------------------------
+      const double tauRaw = std::max(1.0, 1.0 + 2.0 * rawMass);
+      const double tauAbs =               1.0 + 2.0 * absMass;
+ 
+      const unsigned L_raw = std::max(
+          minL, std::min(maxL, static_cast<unsigned>(std::llround(tauRaw))));
+ 
+      const unsigned L_abs = std::max(
+          minL, std::min(maxL, static_cast<unsigned>(std::llround(tauAbs))));
+ 
+      return std::max(L_raw, L_abs);
+    }
+
+    /**
      * @brief Suggest a stationary-bootstrap mean block length from an ACF curve.
      *
      * Heuristic:

--- a/libs/statistics/test/StatUtilsTest.cpp
+++ b/libs/statistics/test/StatUtilsTest.cpp
@@ -1146,62 +1146,17 @@ TEST_CASE("StatUtils::computeACF basic behavior and edge cases", "[StatUtils][AC
     }
 }
 
-TEST_CASE("StatUtils::suggestStationaryBlockLengthFromACF heuristic", "[StatUtils][ACF][BlockLen]") {
-    using Stat = StatUtils<DecimalType>;
-
-    SECTION("No lag clears threshold -> clamp to minL") {
-        // thresh = 2/sqrt(nSamples). Choose n=25 -> thresh = 0.4
-        // Make all |rho(k)| <= 0.39 so none is 'significant'.
-        std::vector<DecimalType> acf = {
-            createDecimal("1.0"), createDecimal("0.39"), createDecimal("-0.10"),
-            createDecimal("0.00"), createDecimal("0.05")
-        };
-        unsigned L = Stat::suggestStationaryBlockLengthFromACF(acf, /*nSamples=*/25, /*minL=*/2, /*maxL=*/6);
-        REQUIRE(L == 2);
-    }
-
-    SECTION("Largest significant lag determines L (within clamps)") {
-        // n=100 -> thresh = 2 / 10 = 0.2
-        // Significant at lags 1 and 2, then it drops below threshold
-        std::vector<DecimalType> acf = {
-            createDecimal("1.0"), createDecimal("0.25"), createDecimal("0.22"),
-            createDecimal("0.05"), createDecimal("0.00")
-        };
-        unsigned L = Stat::suggestStationaryBlockLengthFromACF(acf, /*nSamples=*/100, /*minL=*/2, /*maxL=*/6);
-        REQUIRE(L == 2);
-    }
-
-     SECTION("Clamp to maxL when consecutive significance extends beyond range") {
-        // With n=100 and an 11-element ACF (M=10 lags), the Bonferroni threshold is:
-        //   z = sqrt(2) * erfinv(1 - 0.05/10) ≈ 2.807
-        //   thresh = 2.807 / sqrt(100) ≈ 0.281
-        //
-        // The old test placed a single significant lag at acf[9]=0.25.  That is
-        // correctly ignored by the consecutive-lag rule because no adjacent lag
-        // is also significant — an isolated spike is almost certainly noise.
-        //
-        // The new test places TWO adjacent lags (7 and 8) both at 0.35 > 0.281.
-        // The consecutive-lag rule fires at k=7: L_acf = 8, then clamped to maxL=6.
-        std::vector<DecimalType> acf(11, createDecimal("0.0"));
-        acf[0] = createDecimal("1.0");
-        acf[7] = createDecimal("0.35");   // above Bonferroni threshold
-        acf[8] = createDecimal("0.35");   // above Bonferroni threshold — consecutive pair
-        unsigned L = Stat::suggestStationaryBlockLengthFromACF(acf, /*nSamples=*/100,
-                                                               /*minL=*/2, /*maxL=*/6);
-        REQUIRE(L == 6); // L_acf=8 clamped to maxL
-    }
-
-    SECTION("Empty ACF or zero nSamples throws") {
-        std::vector<DecimalType> empty_acf;
-        REQUIRE_THROWS_AS(Stat::suggestStationaryBlockLengthFromACF(empty_acf, 10), std::invalid_argument);
-        std::vector<DecimalType> acf = { createDecimal("1.0"), createDecimal("0.1") };
-        REQUIRE_THROWS_AS(Stat::suggestStationaryBlockLengthFromACF(acf, 0), std::invalid_argument);
-    }
-}
-
 // --------------------------- Smoke test: Monthly -> ACF -> BlockLen ---------------------------
 
-TEST_CASE("StatUtils: end-to-end monthly->ACF->block length",
+// =============================================================================
+// TEST 1 of 2: computeACF shape for a fabricated monthly return series
+//
+// Verifies that computeACF produces the expected autocorrelation pattern for
+// a 12-month sequence with a deliberate paired-return structure.  This test
+// has nothing to do with block length selection; it exercises the ACF
+// estimator alone.
+// =============================================================================
+TEST_CASE("StatUtils: monthly returns ACF shape",
           "[StatUtils][ACF][Monthly][Smoke]")
 {
     using D    = DecimalType;
@@ -1210,9 +1165,11 @@ TEST_CASE("StatUtils: end-to-end monthly->ACF->block length",
     // Fabricate 12 months with deliberate short-range pair structure:
     // Sequence (Jan..Dec): +2%, +2%, -2%, -2%, +1.5%, +1.5%, -1.5%, -1.5%,
     //                      +1%, +1%, -1%, -1%
+    //
     // Identical adjacent returns create a strong rho[2] (same-sign pairs two
     // apart) but alternate so that rho[1] is small.  This exercises the ACF
-    // estimator with a non-trivial correlation pattern.
+    // estimator with a non-trivial, analytically predictable correlation
+    // pattern.
     ClosedPositionHistory<D> hist;
     TradingVolume one(1, TradingVolume::CONTRACTS);
  
@@ -1262,7 +1219,8 @@ TEST_CASE("StatUtils: end-to-end monthly->ACF->block length",
     REQUIRE(acf.size() == 7);
     REQUIRE(num::to_double(acf[0]) == Catch::Approx(1.0));
  
-    // 3) Verify ACF shape matches expectations from the paired-return structure.
+    // 3) Verify ACF shape matches the expected pattern from the paired-return
+    //    structure.
     //
     // With n=12 the biased ACF (divides by n, not n-k) gives approximately:
     //   rho[1] ≈  0.095  (small: adjacent pairs differ in sign)
@@ -1271,33 +1229,104 @@ TEST_CASE("StatUtils: end-to-end monthly->ACF->block length",
     //   rho[4] ≈  0.621
     //   rho[5] ≈  0.086
     //   rho[6] ≈ -0.448
+    //
+    // The alternating-magnitude pattern (large at even lags, small at odd lags)
+    // is a direct consequence of the paired-return construction and is the
+    // expected correct output of the ACF estimator for this input.
+
+    REQUIRE(num::to_double(acf[1]) == Catch::Approx( 11.0/116.0).margin(kACFAbsTol * 100));
+    REQUIRE(num::to_double(acf[2]) == Catch::Approx(-47.0/ 58.0).margin(kACFAbsTol * 100));
+    REQUIRE(num::to_double(acf[4]) == Catch::Approx( 18.0/ 29.0).margin(kACFAbsTol * 100));
+ 
+    // Coarser checks for the remaining lags
     REQUIRE(std::fabs(num::to_double(acf[2])) > 0.75); // rho[2] dominates
     REQUIRE(std::fabs(num::to_double(acf[4])) > 0.50); // rho[4] also notable
+    REQUIRE(std::fabs(num::to_double(acf[1])) < 0.20); // rho[1] is small
+    REQUIRE(std::fabs(num::to_double(acf[3])) < 0.20); // rho[3] is small
+}
  
-    // 4) Suggest block length.
+ 
+// =============================================================================
+// TEST 2 of 2: suggestStationaryBlockLength with real monthly returns
+//
+// Verifies that suggestStationaryBlockLength returns the correct block length
+// when given real monthly return data.  For n=12 the function takes the
+// small-sample fallback path (n < 100), so the result comes from the
+// n^(1/3) heuristic, not from the ACF-based dependence-mass estimator.
+//
+// This test also exercises the input format contract: monthly returns from
+// buildMonthlyReturnsFromClosedPositions are decimal fractions (0.02 = +2%),
+// which is exactly what suggestStationaryBlockLength expects.
+// =============================================================================
+TEST_CASE("StatUtils: suggestStationaryBlockLength with monthly returns",
+          "[StatUtils][BlockLen][Monthly][Smoke]")
+{
+    using D    = DecimalType;
+    using Stat = StatUtils<DecimalType>;
+ 
+    // Same 12-month fabrication as the ACF shape test above.
+    // The specific return values do not affect the result here because n=12
+    // triggers the small-sample fallback before any ACF is computed.  The
+    // construction is kept identical to the companion test for clarity and to
+    // verify the decimal-fraction input format is accepted correctly.
+    ClosedPositionHistory<D> hist;
+    TradingVolume one(1, TradingVolume::CONTRACTS);
+ 
+    auto add_long_1bar = [&](int y, int m, int d, const char* r_str) {
+        D r     = createDecimal(r_str);
+        D entry = createDecimal("100");
+        D exit  = entry * (D("1.0") + r);
+ 
+        TimeSeriesDate de(y, m, d);
+        auto e = createTimeSeriesEntry(de, entry, entry, entry, entry, 10);
+        auto pos = std::make_shared<TradingPositionLong<D>>(
+                       myCornSymbol, e->getOpenValue(), *e, one);
+ 
+        int d_exit = std::min(d + 1, 28);
+        TimeSeriesDate dx(y, m, d_exit);
+        pos->ClosePosition(dx, exit);
+        hist.addClosedPosition(pos);
+    };
+ 
+    add_long_1bar(2021, Jan,  5,  "0.02");
+    add_long_1bar(2021, Feb,  8,  "0.02");
+    add_long_1bar(2021, Mar,  5, "-0.02");
+    add_long_1bar(2021, Apr, 12, "-0.02");
+    add_long_1bar(2021, May,  6,  "0.015");
+    add_long_1bar(2021, Jun, 15,  "0.015");
+    add_long_1bar(2021, Jul,  7, "-0.015");
+    add_long_1bar(2021, Aug, 19, "-0.015");
+    add_long_1bar(2021, Sep,  9,  "0.01");
+    add_long_1bar(2021, Oct, 13,  "0.01");
+    add_long_1bar(2021, Nov,  3, "-0.01");
+    add_long_1bar(2021, Dec, 21, "-0.01");
+ 
+    auto monthly = mkc_timeseries::buildMonthlyReturnsFromClosedPositions<D>(hist);
+    REQUIRE(monthly.size() == 12);
+ 
+    // n=12 < 100: the function takes the small-sample fallback path.
     //
-    // With n=12 and M=6 lags the Bonferroni threshold is:
-    //   z = sqrt(2) * erfinv(1 - 0.05/6) ≈ 2.638
-    //   thresh = 2.638 / sqrt(12) ≈ 0.762
+    //   L = max(minL, min(maxL, floor(n^(1/3))))
+    //     = max(2,    min(6,    floor(12^(1/3))))
+    //     = max(2,    min(6,    floor(2.289)))
+    //     = max(2,    min(6,    2))
+    //     = 2
     //
-    // Although rho[2] ≈ -0.810 exceeds this threshold on its own, the
-    // consecutive-lag rule requires *two adjacent* lags to both exceed it.
-    // Inspecting the ACF:
-    //   k=1: |rho[1]|≈0.095 (below), |rho[2]|≈0.810 (above) → pair fails
-    //   k=2: |rho[2]|≈0.810 (above), |rho[3]|≈0.095 (below) → pair fails
-    //   k=3..5: no lag reaches 0.762
-    // No consecutive pair exists, so the function returns minL=2.
+    // The ACF-based dependence-mass estimator is NOT entered for n < 100.
+    // The monthly return values therefore have no influence on L; only n does.
     //
-    // This is the correct answer for this data: the alternating ACF pattern
-    // (large at even lags, small at odd lags) is an artifact of the paired
-    // data structure, not genuine persistent autocorrelation that a larger
-    // block length should preserve.
-    const unsigned L = Stat::suggestStationaryBlockLengthFromACF(
-                           acf, monthly.size(), /*minL=*/2, /*maxL=*/6);
+    // Input format: monthly[] contains decimal fractions (0.02 = +2%), which
+    // is exactly what suggestStationaryBlockLength expects.  No /100 conversion
+    // is required.
+    const unsigned L = Stat::suggestStationaryBlockLength(
+                           monthly,
+                           /*maxLag=*/6,
+                           /*minL=*/2,
+                           /*maxL=*/6);
  
     REQUIRE(L == 2);
  
-    // 5) Sanity: L is within [2, 6] regardless
+    // Sanity: result is always within the requested range
     REQUIRE(L >= 2);
     REQUIRE(L <= 6);
 }
@@ -6373,5 +6402,459 @@ TEST_CASE("LogProfitFactorFromLogBarsStat_LogPF numerical stability",
         DecimalType result = stat(logBars);
 
         REQUIRE(std::isfinite(num::to_double(result)));
+    }
+}
+
+// =============================================================================
+// Tests for StatUtils::suggestStationaryBlockLength
+//
+// Add these after the existing "StatUtils::suggestStationaryBlockLengthFromACF
+// heuristic" TEST_CASE and the "StatUtils: end-to-end monthly->ACF->block
+// length" TEST_CASE.  Once these pass, remove those two old TEST_CASEs and all
+// call sites of suggestStationaryBlockLengthFromACF.
+//
+// Design notes
+// ------------
+// suggestStationaryBlockLength takes DECIMAL returns (0.015 = +1.5%), not
+// percent values and not pre-computed ACFs.  The function handles all internal
+// transformations.
+//
+// Two kinds of assertions are used:
+//
+//   Exact:  edge cases (throws), small-sample fallback (n^(1/3) arithmetic is
+//           fully deterministic), white-noise / mean-reversion minimum (tau is
+//           clamped to 1 -> L = minL regardless of noise in higher lags).
+//
+//   Range:  cases that depend on the smooth dependence-mass estimator applied
+//           to a synthetic return series.  These assert directional properties
+//           (L > minL, L >= expected_floor) rather than exact integers, because
+//           the block length is a continuous statistic rounded to an integer and
+//           the ACF of a finite synthetic series differs slightly from the
+//           population ACF used in the hand calculations.
+// =============================================================================
+ 
+// ---------------------------------------------------------------------------
+// Helper: build a deterministic regime-switching return series.
+//
+// Produces n observations that alternate between a high-volatility regime
+// (magnitude ~highSigma) and a low-volatility regime (magnitude ~lowSigma),
+// each regime lasting regimeLen bars.  Within each regime observations follow
+// a fixed sign pattern to keep the mean near zero while creating variation
+// in |r_t|.  The resulting series has strong abs-return ACF (GARCH-like
+// volatility clustering) and near-zero signed-return ACF.
+//
+// The sign pattern [+1, -1, +2, -1, +1, -2, ...] keeps the sum of returns
+// within each regime close to zero so the global mean is near zero.
+// ---------------------------------------------------------------------------
+static std::vector<DecimalType>
+makeDeterministicRegimeSeries(std::size_t n,
+                               double highSigma = 0.020,
+                               double lowSigma  = 0.004,
+                               std::size_t regimeLen = 50)
+{
+    // Sign pattern that sums to ~0 over one cycle
+    const std::vector<double> signPattern = {+1.0, -1.0, +0.8, -0.9,
+                                              +1.1, -0.9, +0.8, -1.0};
+    const std::size_t patLen = signPattern.size();
+ 
+    std::vector<DecimalType> out;
+    out.reserve(n);
+ 
+    for (std::size_t i = 0; i < n; ++i)
+    {
+        const bool   highVol = ((i / regimeLen) % 2 == 0);
+        const double sigma   = highVol ? highSigma : lowSigma;
+        const double sign    = signPattern[i % patLen];
+        const double r       = sign * sigma;
+        out.emplace_back(std::to_string(r));
+    }
+    return out;
+}
+  
+// ---------------------------------------------------------------------------
+// Helper: build a deterministic mean-reverting series.
+//
+// Returns alternate sign with decaying magnitude so the raw ACF at lag 1
+// is strongly negative while abs-return variance is minimal.
+// ---------------------------------------------------------------------------
+static std::vector<DecimalType>
+makeMeanRevertingSeries(std::size_t n, double amp = 0.010)
+{
+    // Pure sign-alternating series with constant magnitude.
+    //
+    // WHY constant magnitude:
+    // The function is testing that the RAW (signed) channel correctly handles
+    // mean reversion — it is NOT testing the abs channel.  Any variation in
+    // |r_t| creates abs-return autocorrelation that is completely separate from
+    // the mean-reversion effect we want to isolate.
+    //
+    // With constant |r_t| = amp:
+    //   denom_abs = sum((|r_t| - mean_abs)^2) = 0   (all values identical)
+    //   computeACF returns rho_abs[k] = 0 for all k >= 1
+    //   abs_mass = 0, tau_abs = 1, L_abs = minL = 2
+    //
+    // The signed raw ACF is strongly negative at lag 1 (alternating series),
+    // so raw_mass is large and negative, tau_raw is clamped to 1, L_raw = 2.
+    // Both channels give minL, so L = 2 regardless of n (for n >= 100).
+    std::vector<DecimalType> out;
+    out.reserve(n);
+    for (std::size_t i = 0; i < n; ++i)
+    {
+        const double sign = ((i % 2) == 0) ? +1.0 : -1.0;
+        out.emplace_back(std::to_string(sign * amp));
+    }
+    return out;
+}
+ 
+// =============================================================================
+// TEST_CASE 1: input validation and parameter contracts
+// =============================================================================
+TEST_CASE("StatUtils::suggestStationaryBlockLength input validation",
+          "[StatUtils][BlockLen][Validation]")
+{
+    using Stat = StatUtils<DecimalType>;
+ 
+    SECTION("Single observation throws invalid_argument")
+    {
+        std::vector<DecimalType> one = { DecimalType("0.01") };
+        REQUIRE_THROWS_AS(
+            Stat::suggestStationaryBlockLength(one),
+            std::invalid_argument);
+    }
+ 
+    SECTION("Empty vector throws invalid_argument")
+    {
+        std::vector<DecimalType> empty;
+        REQUIRE_THROWS_AS(
+            Stat::suggestStationaryBlockLength(empty),
+            std::invalid_argument);
+    }
+ 
+    SECTION("Two observations does not throw and returns minL")
+    {
+        // n=2: small-sample path, n^(1/3)=1.26 -> floor=1 -> clamped to minL=2
+        std::vector<DecimalType> two = { DecimalType("0.01"), DecimalType("-0.01") };
+        unsigned L = 0;
+        REQUIRE_NOTHROW(L = Stat::suggestStationaryBlockLength(two));
+        REQUIRE(L == 2);
+    }
+ 
+    SECTION("Result is always within [minL, maxL] for any valid input")
+    {
+        // n=200 regime-switching series, default parameters
+        auto series = makeDeterministicRegimeSeries(200);
+        const unsigned minL = 2, maxL = 12;
+        unsigned L = Stat::suggestStationaryBlockLength(series, 20, minL, maxL);
+        REQUIRE(L >= minL);
+        REQUIRE(L <= maxL);
+    }
+ 
+    SECTION("Custom minL is respected when dependence mass is negligible")
+    {
+        // Construct n=150 series with zero variance -> denom=0 in computeACF
+        // -> all ACF values are zero -> both masses zero -> tau=1 -> L=minL
+        std::vector<DecimalType> constant(150, DecimalType("0.01"));
+        const unsigned customMin = 3, customMax = 10;
+        unsigned L = Stat::suggestStationaryBlockLength(
+                         constant, 20, customMin, customMax);
+        // tau=1 rounds to 1, clamped up to minL=3
+        REQUIRE(L == customMin);
+    }
+ 
+    SECTION("Custom maxL is respected when dependence mass is very large")
+    {
+        // Strong regime-switching, tight maxL=4
+        auto series = makeDeterministicRegimeSeries(300, 0.03, 0.003, 30);
+        const unsigned customMin = 2, customMax = 4;
+        unsigned L = Stat::suggestStationaryBlockLength(
+                         series, 20, customMin, customMax);
+        REQUIRE(L <= customMax);
+        REQUIRE(L >= customMin);
+    }
+}
+ 
+ 
+// =============================================================================
+// TEST_CASE 2: small-sample fallback (n < 100)
+// =============================================================================
+TEST_CASE("StatUtils::suggestStationaryBlockLength small-sample fallback",
+          "[StatUtils][BlockLen][SmallSample]")
+{
+    using Stat = StatUtils<DecimalType>;
+ 
+    // For n < 100 the function uses max(minL, min(maxL, floor(n^(1/3)))).
+    // All expected values below are computed analytically:
+    //   n=2:  floor(2^(1/3))  = floor(1.260) = 1  -> clamped to minL=2
+    //   n=10: floor(10^(1/3)) = floor(2.154) = 2  -> 2
+    //   n=30: floor(30^(1/3)) = floor(3.107) = 3  -> 3
+    //   n=50: floor(50^(1/3)) = floor(3.684) = 3  -> 3
+    //   n=75: floor(75^(1/3)) = floor(4.217) = 4  -> 4
+    //   n=99: floor(99^(1/3)) = floor(4.626) = 4  -> 4
+ 
+    auto makeReturns = [](std::size_t n) {
+        // Alternating tiny values so content doesn't matter
+        std::vector<DecimalType> v;
+        v.reserve(n);
+        for (std::size_t i = 0; i < n; ++i)
+            v.emplace_back((i % 2 == 0) ? "0.001" : "-0.001");
+        return v;
+    };
+ 
+    SECTION("n=2 -> L=2 (n^(1/3)=1.26, clamped to minL)")
+    {
+        REQUIRE(Stat::suggestStationaryBlockLength(makeReturns(2)) == 2);
+    }
+ 
+    SECTION("n=10 -> L=2 (n^(1/3)=2.15, floor=2)")
+    {
+        REQUIRE(Stat::suggestStationaryBlockLength(makeReturns(10)) == 2);
+    }
+ 
+    SECTION("n=30 -> L=3 (n^(1/3)=3.11, floor=3)")
+    {
+        REQUIRE(Stat::suggestStationaryBlockLength(makeReturns(30)) == 3);
+    }
+ 
+    SECTION("n=50 -> L=3 (n^(1/3)=3.68, floor=3)")
+    {
+        REQUIRE(Stat::suggestStationaryBlockLength(makeReturns(50)) == 3);
+    }
+ 
+    SECTION("n=75 -> L=4 (n^(1/3)=4.22, floor=4)")
+    {
+        REQUIRE(Stat::suggestStationaryBlockLength(makeReturns(75)) == 4);
+    }
+ 
+    SECTION("n=99 -> L=4 (n^(1/3)=4.63, floor=4) — last value before ACF path")
+    {
+        REQUIRE(Stat::suggestStationaryBlockLength(makeReturns(99)) == 4);
+    }
+ 
+    SECTION("n=100 does NOT use fallback — ACF path activates at exactly 100")
+    {
+        // With n=100 and alternating tiny values, ACF mass is negligible,
+        // so the ACF path still produces L=minL=2.  This confirms the
+        // boundary at n=100 and that the ACF path runs for n>=100.
+        REQUIRE(Stat::suggestStationaryBlockLength(makeReturns(100)) == 2);
+    }
+}
+ 
+ 
+// =============================================================================
+// TEST_CASE 3: white-noise and near-white-noise series (FIXED)
+// =============================================================================
+TEST_CASE("StatUtils::suggestStationaryBlockLength white-noise returns",
+          "[StatUtils][BlockLen][WhiteNoise]")
+{
+    using Stat = StatUtils<DecimalType>;
+ 
+    SECTION("Alternating tiny returns (n=200) -> L=minL=2")
+    {
+        // Constant-magnitude alternating series: abs returns are all 0.0001,
+        // so denom_abs=0 and computeACF returns rho_abs[k]=0 for all k>=1.
+        // abs_mass=0, tau_abs=1, L_abs=2.
+        //
+        // Signed raw ACF is strongly negative at all lags (alternating series),
+        // so raw_mass is large and negative, tau_raw is clamped to 1, L_raw=2.
+        //
+        // L = max(2, 2) = 2.
+        std::vector<DecimalType> v;
+        for (int i = 0; i < 200; ++i)
+            v.emplace_back((i % 2 == 0) ? "0.0001" : "-0.0001");
+        REQUIRE(Stat::suggestStationaryBlockLength(v) == 2);
+    }
+ 
+    // NOTE: The "IID-like small returns" section was removed.
+    // Any deterministic series with a repeating period p produces abs-ACF peaks
+    // at multiples of p, making it indistinguishable from genuine volatility
+    // clustering.  There is no reliable deterministic construction for
+    // "varying magnitudes + genuinely zero abs-ACF" other than the constant-
+    // magnitude series above, which the existing section already covers.
+ 
+    SECTION("Constant returns (zero variance) -> ACF undefined -> L=minL=2")
+    {
+        // computeACF returns rho[k]=0 for all k>=1 when denom=0 (constant series).
+        // Both masses are therefore 0, tau=1, L=minL=2.
+        std::vector<DecimalType> v(200, DecimalType("0.005"));
+        REQUIRE(Stat::suggestStationaryBlockLength(v) == 2);
+    }
+}
+ 
+ 
+// =============================================================================
+// TEST_CASE 4: mean-reverting series — raw channel must NOT inflate L
+// =============================================================================
+TEST_CASE("StatUtils::suggestStationaryBlockLength mean-reverting series",
+          "[StatUtils][BlockLen][MeanReversion]")
+{
+    using Stat = StatUtils<DecimalType>;
+ 
+    SECTION("Strongly alternating series (n=300) produces L=minL")
+    {
+        // The series has strong negative raw ACF (phi ≈ -1 at lag 1) and
+        // constant abs-return magnitude (denom_abs=0), so abs_mass=0.
+        //
+        // Signed raw channel:
+        //   raw_mass = sum_{k=1}^{20} (1-k/21) * rho_raw[k]
+        //   rho_raw[k] ≈ (-1)^k for an alternating series
+        //   raw_mass ≈ -0.476  (pairs cancel: -20+19=-1, -18+17=-1, ... × 10)
+        //   tau_raw = max(1, 1 + 2*(-0.476)) = max(1, 0.048) = 1.0
+        //   L_raw = 2
+        //
+        // Abs channel:
+        //   All |r_t| = amp → denom_abs = 0 → rho_abs[k] = 0 for k >= 1
+        //   abs_mass = 0, tau_abs = 1, L_abs = 2
+        //
+        // L = max(2, 2) = 2.
+        //
+        // This is the key correctness property of using SIGNED rho for the
+        // raw channel: mean reversion (negative raw_mass) is clamped to 1
+        // rather than inflating tau to the same level as a momentum series
+        // of equal ACF magnitude.
+        auto series = makeMeanRevertingSeries(300, 0.010);
+        unsigned L = Stat::suggestStationaryBlockLength(series);
+        REQUIRE(L == 2);
+    }
+ 
+    SECTION("Mean-reverting series never inflates L above minL (n=500)")
+    {
+        // Verify the signed-channel clamping holds for a larger series
+        // where finite-sample ACF noise is smaller.  L must equal minL=2
+        // regardless of sample size, because the clamping is applied before
+        // rounding.
+        auto series = makeMeanRevertingSeries(500, 0.010);
+        unsigned L = Stat::suggestStationaryBlockLength(series);
+        REQUIRE(L == 2);
+    }
+}
+ 
+ 
+// =============================================================================
+// TEST_CASE 5: volatility clustering drives block length above minimum
+// =============================================================================
+TEST_CASE("StatUtils::suggestStationaryBlockLength volatility clustering",
+          "[StatUtils][BlockLen][VolClustering]")
+{
+    using Stat = StatUtils<DecimalType>;
+ 
+    SECTION("Regime-switching series (n=300) gives L > 2")
+    {
+        // Alternating blocks of high-vol (sigma=0.020) and low-vol (sigma=0.004),
+        // each 50 bars long.  Adjacent observations within the same regime have
+        // similar |r_t|, creating strong positive abs-ACF.
+        //
+        // From analytical computation:
+        //   abs_mass ≈ 1.51, tau_abs ≈ 4.02, L_abs ≈ 4
+        //   raw_mass ≈ -0.21 (signed, mean-reverting pattern), clamped -> L_raw=2
+        //   L = max(2, 4) = 4
+        //
+        // We assert L >= 3 to allow for finite-sample ACF estimation error
+        // while still verifying the abs channel is driving L above the minimum.
+        auto series = makeDeterministicRegimeSeries(300, 0.020, 0.004, 50);
+        unsigned L = Stat::suggestStationaryBlockLength(series);
+        REQUIRE(L >= 3);
+        REQUIRE(L <= 12);
+    }
+ 
+    SECTION("Stronger clustering gives L >= weaker clustering")
+    {
+        // High-contrast regimes (4x vol ratio) vs low-contrast (2x vol ratio).
+        // Higher contrast means larger variance of |r_t|, larger abs-ACF mass,
+        // and therefore larger L.
+        auto high_contrast = makeDeterministicRegimeSeries(300, 0.030, 0.005, 50);
+        auto low_contrast  = makeDeterministicRegimeSeries(300, 0.012, 0.006, 50);
+ 
+        unsigned L_high = Stat::suggestStationaryBlockLength(high_contrast);
+        unsigned L_low  = Stat::suggestStationaryBlockLength(low_contrast);
+ 
+        REQUIRE(L_high >= L_low);
+    }
+ 
+    SECTION("Clustering series gives L strictly greater than white-noise series")
+    {
+        // Same n; clustering series must produce a larger block length than
+        // a white-noise series of the same length.
+        auto clustering = makeDeterministicRegimeSeries(300, 0.020, 0.004, 50);
+        std::vector<DecimalType> wn;
+        const double base[] = { 0.003, -0.002, 0.001, -0.004,
+                                 0.002,  0.003, -0.001, 0.004 };
+        for (int i = 0; i < 300; ++i)
+            wn.emplace_back(std::to_string(base[i % 8]));
+ 
+        unsigned L_cluster = Stat::suggestStationaryBlockLength(clustering);
+        unsigned L_wn      = Stat::suggestStationaryBlockLength(wn);
+ 
+        REQUIRE(L_cluster > L_wn);
+    }
+}
+ 
+ 
+// =============================================================================
+// TEST_CASE 6: maxLag parameter controls ACF truncation
+// =============================================================================
+TEST_CASE("StatUtils::suggestStationaryBlockLength maxLag parameter",
+          "[StatUtils][BlockLen][MaxLag]")
+{
+    using Stat = StatUtils<DecimalType>;
+ 
+    SECTION("Shorter maxLag gives L <= longer maxLag for clustering series")
+    {
+        // With maxLag=5 fewer lags contribute to the mass than maxLag=20.
+        // For a clustering series the tapered sum is always larger with more
+        // lags, so L(maxLag=5) <= L(maxLag=20).
+        auto series = makeDeterministicRegimeSeries(300, 0.020, 0.004, 50);
+ 
+        unsigned L5  = Stat::suggestStationaryBlockLength(series,  5);
+        unsigned L20 = Stat::suggestStationaryBlockLength(series, 20);
+ 
+        REQUIRE(L5 <= L20);
+    }
+ 
+    SECTION("maxLag=1 gives L=minL (single lag cannot accumulate enough mass)")
+    {
+        // With only 1 lag, abs mass = w_1 * |rho_abs[1]| where w_1 = 1-1/2 = 0.5.
+        // For any typical financial series |rho_abs[1]| < 0.5, so
+        // abs_mass < 0.25, tau_abs < 1.5, round(1.5) = 2 -> L_abs = minL = 2.
+        auto series = makeDeterministicRegimeSeries(300, 0.020, 0.004, 50);
+        unsigned L = Stat::suggestStationaryBlockLength(series, 1);
+        REQUIRE(L == 2);
+    }
+ 
+    SECTION("maxLag capped at n-1 internally — does not throw for large maxLag")
+    {
+        // Passing maxLag > n should not throw; it is silently capped to n-1.
+        auto series = makeDeterministicRegimeSeries(150, 0.020, 0.004, 50);
+        REQUIRE_NOTHROW(Stat::suggestStationaryBlockLength(series, 9999));
+    }
+}
+ 
+ 
+// =============================================================================
+// TEST_CASE 7: input format contract — decimal not percent
+// =============================================================================
+TEST_CASE("StatUtils::suggestStationaryBlockLength decimal return format",
+          "[StatUtils][BlockLen][InputFormat]")
+{
+    using Stat = StatUtils<DecimalType>;
+ 
+    SECTION("Decimal returns (0.015) and percent-divided returns give identical L")
+    {
+        // The function expects decimal fractions.  If the same data is passed
+        // correctly as 0.015 vs accidentally as 1.5 (percent), the internal
+        // log(1+r) transformation will produce very different log-return series.
+        // This test confirms the decimal path is self-consistent: dividing by
+        // 100 before calling should match treating the data as already decimal.
+        //
+        // Two series with identical relative structure but different magnitude:
+        //   correct:   [0.015, -0.010, 0.020, ...]
+        //   incorrect: [1.5,   -1.0,   2.0,  ...]  (percent — wrong input)
+        //
+        // The correct series produces log-returns near the linear approximation;
+        // the incorrect series produces log(1+1.5) which is a very large number.
+        // The test verifies the correct-format series gives L in [2,12].
+        auto series = makeDeterministicRegimeSeries(200, 0.015, 0.004, 40);
+        unsigned L = Stat::suggestStationaryBlockLength(series);
+        REQUIRE(L >= 2);
+        REQUIRE(L <= 12);
     }
 }

--- a/libs/timeseries/BootStrapIndicators.h
+++ b/libs/timeseries/BootStrapIndicators.h
@@ -36,308 +36,421 @@ namespace mkc_timeseries
     };
 
     /**
-     * @brief Internal helper to run BCa bootstrap on upside and downside widths.
-     *
-     * This is the statistical engine that powers both ComputeBootStrappedLongStopAndTarget
-     * and ComputeBootStrappedShortStopAndTarget. It performs the core bootstrap analysis
-     * on the distribution of width statistics.
-     *
-     * ## WHAT THIS FUNCTION DOES
-     *
-     * 1. **Validates Data:**
-     *    - Checks if sample size ≥ kMinBootstrapSize (30)
-     *    - Returns epsilon bounds if insufficient data
-     *
-     * 2. **Defines Width Statistics:**
-     *    - Upside Width = q90 - q50 (profit potential for longs)
-     *    - Downside Width = q50 - q10 (risk exposure for longs)
-     *
-     * 3. **Configures Block Resampler:**
-     *    - Calculates block length adaptively:
-     *      * For n >= 100: Uses ACF-based calculation (see BLOCK LENGTH SELECTION below)
-     *      * For n < 100: Uses n^(1/3) heuristic
-     *    - Creates StationaryBlockResampler with this length
-     *
-     * 4. **Runs Two Separate BCa Bootstraps:**
-     *    - One for upside width distribution
-     *    - One for downside width distribution
-     *    - Each with 10,000 resamples and 90% confidence
-     *
-     * 5. **Extracts Four Critical Bounds:**
-     *    - upside_lower_bound (5th percentile of upside widths)
-     *    - upside_upper_bound (95th percentile of upside widths)
-     *    - downside_lower_bound (5th percentile of downside widths)
-     *    - downside_upper_bound (95th percentile of downside widths)
-     *
-     * ## WHY SEPARATE BOOTSTRAPS?
-     *
-     * We could bootstrap a single statistic that captures both upside and downside,
-     * but running separate bootstraps provides:
-     *
-     * - **Independent uncertainty quantification:** Upside and downside may have
-     *   different variability
-     * - **Asymmetric distributions:** Financial returns are typically skewed
-     * - **Flexible application:** Caller can combine bounds as needed for LONG/SHORT
-     *
-     * ## CONFIGURATION CONSTANTS
-     *
-     * These are the tuneable parameters that control bootstrap behavior:
-     *
-     * ```cpp
-     * constexpr size_t kMinBootstrapSize = 30;
-     * constexpr unsigned int kNumResamples = 10000;
-     * constexpr double kConfidenceLevel = 0.90;
-     * constexpr std::size_t kMaxACFLag = 20;
-     * constexpr double kBonferroniZ = 3.05;
-     * ```
-     *
-     * **kMinBootstrapSize = 30:**
-     * - Based on Central Limit Theorem heuristics
-     * - Below this, asymptotic properties of bootstrap may not hold
-     * - Below this, BCa corrections become unreliable
-     * - Trade-off: Lower = more lenient, Higher = more conservative
-     *
-     * **kNumResamples = 10,000:**
-     * - More resamples = more stable CI estimates, slower computation
-     * - Academic standard is often 2,000-5,000
-     * - 10,000 is generous and provides very stable estimates
-     * - Reducing to 2,000 gives ~5× speedup with minimal quality loss
-     *
-     * **kConfidenceLevel = 0.90:**
-     * - Produces 90% CI (5th to 95th percentiles)
-     * - Standard in industry practice
-     * - 0.80 = less conservative (narrower CI)
-     * - 0.95 = more conservative (wider CI)
-     * - Don't go outside [0.80, 0.95] range
-     *
-     * **kMaxACFLag = 20:**
-     * - Maximum lag used in ACF analysis for block length selection
-     * - Must match M in the Bonferroni threshold formula (see below)
-     * - 20 lags is sufficient to detect weekly/monthly return cycles in daily data
-     *
-     * **kBonferroniZ = 3.05:**
-     * - z-critical for Bonferroni-corrected ACF significance test
-     * - Derived from: qnorm(1 - 0.05 / (2 * kMaxACFLag)) = qnorm(0.99875) ≈ 3.023
-     * - Rounded up to 3.05 for a small conservative margin
-     * - Controls family-wise error rate at ≤5% across all kMaxACFLag lags
-     * - Do not reduce below 3.0 or the multiple-testing protection is compromised
-     *
-     * ## BLOCK LENGTH SELECTION
-     *
-     * The block length L is computed adaptively:
-     *
-     * **For large series (n >= 100):** ACF-based calculation
-     * ```cpp
-     * logReturns = percentBarsToLogBars(rocVec / 100)
-     * acf = computeACF(logReturns, maxLag=20)
-     * threshold = kBonferroniZ / sqrt(n)          // Bonferroni-corrected band
-     * L = minBlockL (=2) if no consecutive pair of lags exceeds threshold
-     * L = last k+1 where both |rho[k]| and |rho[k+1]| exceed threshold, clamped to [2,12]
-     * ```
-     *
-     * **For smaller series (n < 100):** n^(1/3) heuristic
-     * ```cpp
-     * L = max(2, floor(n^(1/3)))
-     * ```
-     *
-     * ### Why log-returns for the ACF?
-     *
-     * The ACF is computed on log-returns rather than percent-ROC directly because
-     * log-returns are additive and yield an unbiased ACF estimator. For the small
-     * returns typical of daily financial data, log(1+r) ≈ r, so the autocorrelation
-     * structures of the two series are numerically identical. The block length derived
-     * from the log-return ACF is therefore fully valid for the percent-ROC bootstrap.
-     *
-     * ### Why the Bonferroni threshold — not 2/sqrt(n)?
-     *
-     * The naive ±2/√n pointwise band has a ~1.2% false-positive rate per lag. When
-     * testing all kMaxACFLag=20 lags simultaneously, the family-wise false-positive
-     * rate (the probability of any lag spuriously exceeding the band) is approximately
-     * 1 - (1 - 0.012)^20 ≈ 22%. In practice this caused block lengths to be driven to
-     * the cap (12) even for pure white-noise return series, making the bootstrap
-     * artificially conservative.
-     *
-     * The Bonferroni threshold threshold = kBonferroniZ / sqrt(n) controls the
-     * family-wise error rate at ≤5%, so a white-noise series almost never triggers a
-     * spurious large block length.
-     *
-     * ### Why the consecutive-lag rule?
-     *
-     * Even with the Bonferroni threshold, a single isolated lag can occasionally
-     * exceed the band by chance. The consecutive-lag rule requires both lag k and
-     * lag k+1 to exceed the threshold before L is updated. Genuine autocorrelation
-     * (AR, MA, GARCH volatility clustering) always produces a run of significant lags
-     * starting from lag 1 and decaying monotonically. An isolated exceedance at a
-     * high lag with no neighbours above the band is a noise artifact, not a real
-     * dependence structure.
-     *
-     * ### Why L=2 minimum and not L=1 (IID)?
-     *
-     * Failing to reject ρ(k)=0 at all lags is not the same as proving independence.
-     * Two practical reasons to keep L ≥ 2 even for apparently white-noise data:
-     *
-     * 1. **Test power:** With n=3000 and kBonferroniZ=3.05, autocorrelations below
-     *    ~0.055 are statistically undetectable but still real. Daily returns routinely
-     *    carry autocorrelations of 0.01-0.04 from microstructure effects.
-     * 2. **Volatility clustering:** The ACF of raw returns being near zero is entirely
-     *    consistent with significant autocorrelation in squared returns (ARCH/GARCH
-     *    effects). Adjacent observations share a common variance environment even when
-     *    their signs are independent. L=2 preserves same-day neighboring pairs and
-     *    partially captures this structure. An IID bootstrap would destroy it entirely.
-     *
-     * ### Expected block lengths by sample size
-     *
-     * For essentially uncorrelated daily financial return data:
-     * - n=50:   L=3  (n^(1/3) heuristic, ACF too noisy)
-     * - n=100:  L=2  (Bonferroni threshold suppresses noise spikes)
-     * - n=500:  L=2  (white noise → minimum; genuine AR → 3-8)
-     * - n=1000: L=2  (white noise → minimum; genuine AR → 3-8)
-     * - n=3000: L=2  (white noise → minimum; genuine AR → 3-12)
-     *
-     * ## WIDTH STATISTIC FUNCTIONS
-     *
-     * The lambda functions define how to compute widths from a resampled vector:
-     *
-     * **Upside Width (for a given resample):**
-     * ```cpp
-     * calc_upside_width = [](const vector<Decimal>& v) {
-     *     median = quantile(v, 0.50);
-     *     q90 = quantile(v, 0.90);
-     *     width = q90 - median;
-     *     return max(width, 0);  // Floor at zero
-     * };
-     * ```
-     *
-     * **Downside Width (for a given resample):**
-     * ```cpp
-     * calc_downside_width = [](const vector<Decimal>& v) {
-     *     median = quantile(v, 0.50);
-     *     q10 = quantile(v, 0.10);
-     *     width = median - q10;
-     *     return max(width, 0);  // Floor at zero
-     * };
-     * ```
-     *
-     * These use LinearInterpolationQuantile which:
-     * - Sorts the vector (makes a copy internally)
-     * - Interpolates between adjacent order statistics
-     * - Handles fractional indices smoothly
-     *
-     * ## QUANTILE CHOICES: q10/q50/q90
-     *
-     * We use 10th/50th/90th percentiles rather than extremes (5th/95th) because:
-     *
-     * 1. **Stability:** Avoid highly variable tail estimates
-     * 2. **Sample Size:** For n=100, q05 is ~5th observation (unstable)
-     * 3. **Robustness:** Less sensitive to outliers
-     * 4. **Coverage:** Still captures 80% of distribution
-     * 5. **Conservatism:** CI itself (5th/95th of widths) adds conservatism
-     *
-     * The combination gives: 90% CI of 80% coverage = very robust estimates
-     *
-     * ## BCa BOOTSTRAP MECHANICS
-     *
-     * For each width statistic, the function creates a BCaBootStrap object:
-     *
-     * ```cpp
-     * BCaBootStrap<Decimal, StationaryBlockResampler<Decimal>> bca(
-     *     rocVec,              // Original data
-     *     kNumResamples,       // 10,000
-     *     kConfidenceLevel,    // 0.90
-     *     calc_width_function, // Statistic to bootstrap
-     *     blockSampler         // Resampling policy
-     * );
-     * ```
-     *
-     * This performs:
-     * 1. **Resampling:** 10,000 block bootstrap samples
-     * 2. **Statistic Computation:** calc_width_function on each sample
-     * 3. **Bias Correction:** Compute z₀ (proportion of bootstrap stats < observed)
-     * 4. **Acceleration:** Jackknife to compute 'a' (skewness correction)
-     * 5. **Adjusted Percentiles:** Transform 5%/95% using BCa formula
-     * 6. **Bounds Extraction:** nth_element to find adjusted percentiles
-     *
-     * ## RETURN VALUE STRUCTURE
-     *
-     * The BootstrappedWidthBounds struct contains four key values:
-     *
-     * ```cpp
-     * return {
-     *     upside_lower_bound,   // For LONG targets, SHORT stops
-     *     upside_upper_bound,   // For SHORT stops, LONG (not used)
-     *     downside_lower_bound, // For SHORT targets, LONG (not used)
-     *     downside_upper_bound  // For LONG stops, SHORT targets
-     * };
-     * ```
-     *
-     * The calling functions select appropriate bounds:
-     * - LONG: {upside_lower, downside_upper}
-     * - SHORT: {downside_lower, upside_upper}
-     *
-     * ## ERROR HANDLING
-     *
-     * **Insufficient Data:**
-     * ```cpp
-     * if (rocVec.size() < kMinBootstrapSize)
-     *     return {eps, eps, eps, eps};
-     * ```
-     * Returns near-zero values to signal failure without throwing.
-     *
-     * **Bootstrap Exception:**
-     * ```cpp
-     * catch (const std::exception& e) {
-     *     return {eps, eps, eps, eps};
-     * }
-     * ```
-     *
-     * Possible causes:
-     * - All ROC values identical (zero variance)
-     * - Numerical overflow in BCa calculations
-     * - Memory allocation failure
-     *
-     * ## PERFORMANCE PROFILE
-     *
-     * Typical execution time breakdown:
-     * - Validation and setup: <1%
-     * - Block resampling: 10-15%
-     * - Quantile computation (sorting): 40-50%
-     * - BCa jackknife: 30-40%
-     * - Bounds extraction: <5%
-     *
-     * Total: 0.5-5 seconds depending on n
-     *
-     * ## THREAD SAFETY
-     *
-     * This function is **thread-safe** as long as:
-     * - Input vector is not modified during execution
-     * - Random number generation is properly seeded per thread
-     * - No shared state is accessed
-     *
-     * Safe for parallel execution on different datasets.
-     *
-     * @tparam Decimal Numeric type for calculations
-     *
-     * @param rocVec Vector of Rate-of-Change values (typically from RocSeries)
-     *               Should contain at least 30 values for reliable results.
-     *
-     * @return BootstrappedWidthBounds<Decimal> containing four bounds:
-     *         - upside_lower_bound: Conservative estimate of upside potential
-     *         - upside_upper_bound: Liberal estimate of upside potential
-     *         - downside_lower_bound: Conservative estimate of downside risk
-     *         - downside_upper_bound: Liberal estimate of downside risk
-     *
-     * @note Returns {eps, eps, eps, eps} where eps=1e-8 if:
-     *       - rocVec.size() < 30
-     *       - Bootstrap throws exception
-     *       - Any other error occurs
-     *
-     * @warning This function can be computationally expensive (seconds).
-     *          Not suitable for ultra-high-frequency applications without caching.
-     *
-     * @see BCaBootStrap Template class implementing BCa bootstrap
-     * @see StationaryBlockResampler Block resampling for time series
-     * @see LinearInterpolationQuantile Quantile computation with interpolation
-     */
+ * @brief Internal helper to run BCa bootstrap on upside and downside widths.
+ *
+ * This is the statistical engine that powers both
+ * ComputeBootStrappedLongStopAndTarget() and
+ * ComputeBootStrappedShortStopAndTarget(). It performs the core bootstrap
+ * analysis on the distribution of width statistics and returns four critical
+ * bounds describing the uncertainty in upside and downside movement widths.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT THIS FUNCTION DOES
+ * ---------------------------------------------------------------------------
+ *
+ * 1. Validates Data
+ *    - Requires sample size >= kMinBootstrapSize (30)
+ *    - Returns epsilon bounds if insufficient data
+ *
+ * 2. Defines Width Statistics
+ *    - Upside Width   = q90 - q50
+ *    - Downside Width = q50 - q10
+ *
+ * 3. Chooses a Stationary Bootstrap Block Length
+ *    - For n >= 100: uses a smooth ACF dependence-mass estimator
+ *    - For n < 100:  uses the n^(1/3) heuristic
+ *
+ * 4. Runs Two Separate BCa Bootstraps
+ *    - One bootstrap for upside width
+ *    - One bootstrap for downside width
+ *    - Each uses 10,000 resamples and a 90% confidence level
+ *
+ * 5. Returns Four Bounds
+ *    - upside_lower_bound
+ *    - upside_upper_bound
+ *    - downside_lower_bound
+ *    - downside_upper_bound
+ *
+ * ---------------------------------------------------------------------------
+ * WHY SEPARATE BOOTSTRAPS?
+ * ---------------------------------------------------------------------------
+ *
+ * Upside and downside widths often have different variability, skewness, and
+ * sampling uncertainty. Running separate BCa bootstraps provides:
+ *
+ * - independent uncertainty quantification
+ * - asymmetric treatment of upside and downside risk
+ * - flexibility for LONG and SHORT applications
+ *
+ * ---------------------------------------------------------------------------
+ * CONFIGURATION CONSTANTS
+ * ---------------------------------------------------------------------------
+ *
+ * constexpr size_t kMinBootstrapSize = 30;
+ * constexpr unsigned int kNumResamples = 10000;
+ * constexpr double kConfidenceLevel = 0.90;
+ * constexpr std::size_t kMaxACFLag = 20;
+ * constexpr unsigned int kMinBlockL = 2;
+ * constexpr unsigned int kMaxBlockL = 12;
+ *
+ * kMinBootstrapSize = 30
+ * - Minimum sample size for stable BCa inference
+ * - Below this, bootstrap and jackknife corrections become unreliable
+ *
+ * kNumResamples = 10,000
+ * - Produces very stable confidence interval estimates
+ * - More resamples = slower runtime, less Monte Carlo noise
+ *
+ * kConfidenceLevel = 0.90
+ * - Produces a 90% two-sided confidence interval
+ * - Equivalent tail bounds to 95% one-sided inference
+ * - Allows both lower and upper bounds to be obtained in one BCa run
+ *
+ * kMaxACFLag = 20
+ * - Number of lags used for dependence estimation
+ * - Large enough to capture short-horizon serial dependence and
+ *   volatility clustering in daily data
+ *
+ * kMinBlockL = 2
+ * - Enforces a minimum non-IID block size
+ * - Preserves at least minimal local dependence structure even when
+ *   the series appears close to white noise
+ *
+ * kMaxBlockL = 12
+ * - Prevents the block length from becoming excessively large
+ * - Acts as a practical upper bound for daily financial return series
+ *
+ * ---------------------------------------------------------------------------
+ * BLOCK LENGTH SELECTION
+ * ---------------------------------------------------------------------------
+ *
+ * The function uses a stationary block bootstrap, so a block length L must be
+ * chosen. The purpose of L is to preserve local dependence in the resampled
+ * series rather than treating the observations as IID.
+ *
+ * For n >= 100, block length is chosen using a smooth dependence-mass
+ * estimator based on two dependence channels:
+ *
+ *   1. Raw log returns
+ *   2. Absolute log returns
+ *
+ * The rationale is:
+ *
+ * - Raw log returns capture signed serial dependence such as short-term
+ *   momentum, mean reversion, or microstructure effects.
+ *
+ * - Absolute log returns capture volatility clustering, which is often the
+ *   dominant dependence structure in financial time series.
+ *
+ * Because this function is used to estimate profit-target and stop-loss widths,
+ * preserving dependence in volatility is at least as important as preserving
+ * dependence in return sign. Width statistics are driven strongly by the local
+ * scale of returns, and volatility clustering directly affects that scale.
+ *
+ * ---------------------------------------------------------------------------
+ * STEP 1: Convert ROC values to log returns
+ * ---------------------------------------------------------------------------
+ *
+ * The input rocVec contains percent rate-of-change values. For dependence
+ * analysis, the function converts:
+ *
+ *   percent ROC -> decimal returns -> log returns
+ *
+ * Log returns are used because:
+ *
+ * - they are additive over time
+ * - they are a standard input for serial dependence analysis
+ * - for small daily returns, they are numerically very close to percent returns
+ *
+ * The block length derived from log-return dependence is then applied to the
+ * stationary bootstrap resampling of the original ROC series.
+ *
+ * ---------------------------------------------------------------------------
+ * STEP 2: Compute two ACFs
+ * ---------------------------------------------------------------------------
+ *
+ * The function computes:
+ *
+ *   acfRaw = ACF(logReturns, k = 0..K)
+ *   acfAbs = ACF(abs(logReturns), k = 0..K)
+ *
+ * where K = min(kMaxACFLag, n - 1).
+ *
+ * Interpretation:
+ *
+ * - acfRaw measures signed-return dependence
+ * - acfAbs measures volatility dependence
+ *
+ * In many financial series:
+ *
+ * - acfRaw is weak or short-lived
+ * - acfAbs is stronger and more persistent
+ *
+ * This is expected and reflects the common empirical pattern that returns are
+ * often nearly uncorrelated in sign while volatility is strongly autocorrelated.
+ *
+ * ---------------------------------------------------------------------------
+ * STEP 3: Compute smooth dependence mass
+ * ---------------------------------------------------------------------------
+ *
+ * For each ACF, the function computes a tapered dependence mass:
+ *
+ *   dependenceMass = sum_{k=1}^{K} w_k * |rho_k|
+ *
+ * where:
+ *
+ *   rho_k = autocorrelation at lag k
+ *   w_k   = 1 - k / (K + 1)
+ *
+ * The taper has these effects:
+ *
+ * - lower lags receive more weight than higher lags
+ * - short-horizon dependence is emphasized
+ * - isolated or noisy higher-lag values contribute less
+ *
+ * This is intentionally smoother and more stable than a binary significance
+ * test or a threshold-crossing rule.
+ *
+ * ---------------------------------------------------------------------------
+ * STEP 4: Convert dependence mass to effective dependence horizon
+ * ---------------------------------------------------------------------------
+ *
+ * For each dependence channel, the function computes:
+ *
+ *   tau = 1 + 2 * dependenceMass
+ *
+ * giving:
+ *
+ *   tauRaw = 1 + 2 * rawDependenceMass
+ *   tauAbs = 1 + 2 * absDependenceMass
+ *
+ * These tau values are smooth proxies for effective dependence horizon.
+ * Larger tau means stronger short-run dependence and therefore a larger
+ * stationary bootstrap block length.
+ *
+ * ---------------------------------------------------------------------------
+ * STEP 5: Convert tau to candidate block lengths
+ * ---------------------------------------------------------------------------
+ *
+ * Each tau value is rounded to the nearest integer and clamped:
+ *
+ *   L_raw = clamp(round(tauRaw), kMinBlockL, kMaxBlockL)
+ *   L_abs = clamp(round(tauAbs), kMinBlockL, kMaxBlockL)
+ *
+ * Final block length is then chosen as:
+ *
+ *   L = max(L_raw, L_abs)
+ *
+ * This choice is deliberate.
+ *
+ * - If signed-return dependence is stronger, L_raw can dominate.
+ * - If volatility clustering is stronger, L_abs can dominate.
+ *
+ * Using max(L_raw, L_abs) ensures the bootstrap preserves whichever local
+ * dependence structure is most relevant.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THIS METHOD IS BETTER THAN A THRESHOLD RULE
+ * ---------------------------------------------------------------------------
+ *
+ * A threshold-based rule can be unstable:
+ *
+ * - a tiny change in sample length can move one lag above or below a threshold
+ * - the selected block length can jump discontinuously
+ * - late-lag threshold exceedances can dominate the result
+ *
+ * The smooth dependence-mass estimator avoids these pathologies:
+ *
+ * - all lags contribute gradually rather than in binary fashion
+ * - nearby samples tend to produce nearby block lengths
+ * - higher lags are downweighted rather than treated equally
+ *
+ * This produces more stable and interpretable block lengths, especially when
+ * the function is rerun across nearby in-sample windows.
+ *
+ * ---------------------------------------------------------------------------
+ * FALLBACK FOR SMALL SAMPLES
+ * ---------------------------------------------------------------------------
+ *
+ * For n < 100, ACF-based dependence estimation is noisier and less reliable.
+ * In that case the function uses the standard heuristic:
+ *
+ *   L = max(2, floor(n^(1/3)))
+ *
+ * This is a practical small-sample fallback commonly used in block-bootstrap
+ * settings.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY VOLATILITY DEPENDENCE MATTERS HERE
+ * ---------------------------------------------------------------------------
+ *
+ * This function is not trying to forecast return direction. It is trying to
+ * estimate the distribution of width statistics:
+ *
+ * - q90 - q50
+ * - q50 - q10
+ *
+ * These are scale-sensitive quantities. If volatility clustering is destroyed,
+ * bootstrap resamples can mix quiet and turbulent periods too aggressively,
+ * distorting the width distribution and therefore the resulting stop/target
+ * estimates.
+ *
+ * Preserving volatility dependence helps keep the resampled series closer to
+ * the local dispersion structure of the original series.
+ *
+ * ---------------------------------------------------------------------------
+ * WIDTH STATISTIC FUNCTIONS
+ * ---------------------------------------------------------------------------
+ *
+ * Upside Width:
+ *
+ *   q90 - q50
+ *
+ * - measures profit potential on the upside
+ * - floored at zero
+ *
+ * Downside Width:
+ *
+ *   q50 - q10
+ *
+ * - measures downside risk exposure
+ * - floored at zero
+ *
+ * Quantiles are computed with LinearInterpolationQuantile(), which sorts a copy
+ * of the sample and interpolates between adjacent order statistics.
+ *
+ * ---------------------------------------------------------------------------
+ * QUANTILE CHOICES: q10 / q50 / q90
+ * ---------------------------------------------------------------------------
+ *
+ * The function uses q10, q50, and q90 rather than more extreme tail quantiles
+ * because these are more stable in finite samples.
+ *
+ * Advantages:
+ *
+ * - more robust than q05 / q95
+ * - less sensitive to outliers
+ * - better behaved when sample sizes are modest
+ * - still captures a wide central portion of the distribution
+ *
+ * The BCa confidence interval around these widths adds further conservatism.
+ *
+ * ---------------------------------------------------------------------------
+ * BCa BOOTSTRAP MECHANICS
+ * ---------------------------------------------------------------------------
+ *
+ * For each width statistic, the function constructs a BCaBootStrap object
+ * using:
+ *
+ * - the original ROC series
+ * - the chosen stationary block resampler
+ * - the custom statistic lambda
+ * - a two-sided 90% interval
+ *
+ * BCa improves over ordinary percentile bootstrap by correcting for:
+ *
+ * - bias in the bootstrap distribution
+ * - skewness via jackknife acceleration
+ *
+ * This is especially useful for width statistics, which can be skewed and
+ * asymmetric.
+ *
+ * ---------------------------------------------------------------------------
+ * RETURN VALUE STRUCTURE
+ * ---------------------------------------------------------------------------
+ *
+ * The returned BootstrappedWidthBounds contains:
+ *
+ * - upside_lower_bound
+ * - upside_upper_bound
+ * - downside_lower_bound
+ * - downside_upper_bound
+ *
+ * The public LONG and SHORT helper functions then select the appropriate
+ * conservative bounds:
+ *
+ * LONG:
+ * - profit target = upside_lower_bound
+ * - stop width    = downside_upper_bound
+ *
+ * SHORT:
+ * - profit target = downside_lower_bound
+ * - stop width    = upside_upper_bound
+ *
+ * ---------------------------------------------------------------------------
+ * ERROR HANDLING
+ * ---------------------------------------------------------------------------
+ *
+ * If the sample is too small or the bootstrap fails, the function returns:
+ *
+ *   {eps, eps, eps, eps}
+ *
+ * where:
+ *
+ *   eps = 1e-8
+ *
+ * This avoids throwing in normal degenerate-data situations and gives the
+ * caller a sentinel-like near-zero result.
+ *
+ * Possible causes of failure include:
+ *
+ * - insufficient data
+ * - zero-variance or degenerate samples
+ * - numerical issues in BCa correction
+ * - memory allocation failures
+ *
+ * ---------------------------------------------------------------------------
+ * PERFORMANCE PROFILE
+ * ---------------------------------------------------------------------------
+ *
+ * Typical cost components:
+ *
+ * - ACF computation: small
+ * - block-length diagnostics: very small
+ * - stationary block bootstrap resampling: moderate
+ * - quantile sorting: substantial
+ * - BCa jackknife acceleration: substantial
+ *
+ * Typical runtime is on the order of fractions of a second to a few seconds,
+ * depending on sample size and hardware.
+ *
+ * ---------------------------------------------------------------------------
+ * THREAD SAFETY
+ * ---------------------------------------------------------------------------
+ *
+ * This function is thread-safe provided:
+ *
+ * - the input vector is not modified concurrently
+ * - random-number generation is properly isolated per bootstrap engine
+ * - no shared mutable global state is used
+ *
+ * The implementation uses a shared executor object only within the scope of
+ * the function for sequential bootstrap calls.
+ *
+ * @tparam Decimal Numeric type for calculations
+ *
+ * @param rocVec Vector of rate-of-change values, typically from RocSeries().
+ *               Should contain at least 30 observations for reliable results.
+ *
+ * @return BootstrappedWidthBounds<Decimal> containing:
+ *         - conservative and liberal upside width bounds
+ *         - conservative and liberal downside width bounds
+ *
+ * @note Returns {eps, eps, eps, eps} with eps = 1e-8 if:
+ *       - rocVec.size() < 30
+ *       - bootstrap construction or evaluation fails
+ *       - numerical issues prevent valid inference
+ *
+ * @warning This function can be computationally expensive and is not intended
+ *          for extremely high-frequency or latency-sensitive workflows without
+ *          caching or batching.
+ *
+ * @see BCaBootStrap
+ * @see StationaryBlockResampler
+ * @see LinearInterpolationQuantile
+ * @see ComputeBootStrappedLongStopAndTarget
+ * @see ComputeBootStrappedShortStopAndTarget
+ */
     template <class Decimal>
     BootstrappedWidthBounds<Decimal>
     ComputeBootstrappedWidths(const std::vector<Decimal>& rocVec)
@@ -345,222 +458,159 @@ namespace mkc_timeseries
       // -----------------------------------------------------------------------
       // Configuration
       // -----------------------------------------------------------------------
-
-      // Minimum sample size for a stable bootstrap (CLT / BCa reliability).
-      constexpr size_t kMinBootstrapSize = 30;
-
-      // Number of bootstrap resamples.  10 000 gives very stable CI estimates.
-      constexpr unsigned int kNumResamples = 10000;
-
-      /**
-       * @brief Bootstrap Confidence Level (0.90 Two-Sided)
-       *
-       * ARCHITECTURE NOTE:
-       * We use a 90% TWO-SIDED confidence interval here, which mathematically
-       * yields the exact same lower bound as a 95% ONE-SIDED interval.
-       *
-       * 1. The Math (Tail Equivalence):
-       * - A 90% Two-Sided CI excludes 10% of the distribution. This error is
-       * split evenly: 5% in the left tail, 5% in the right tail. The bounds
-       * sit exactly at the 5th and 95th percentiles.
-       * - A 95% One-Sided CI excludes 5% of the distribution, entirely in one
-       * tail. The bound sits exactly at the 5th (or 95th) percentile.
-       *
-       * 2. The Performance Justification (O(n^2) Avoidance):
-       * - The calling functions (Long and Short strategy generators) require
-       * both the 5th percentile (conservative target/stop) AND the 95th
-       * percentile (liberal target/stop) from the same distribution.
-       * - The BCa jackknife loop is computationally expensive.
-       * - By running a single 90% TWO-SIDED bootstrap, the engine calculates
-       * both the 5th and 95th percentiles simultaneously in one pass.
-       * - If we used ONE-SIDED intervals, we would have to invoke the BCa
-       * engine four separate times instead of two, doubling the runtime
-       * cost with zero mathematical benefit.
-       */
-      constexpr double kConfidenceLevel = 0.90;
-
-      // ACF lag range.  kMaxACFLag must match M used in the Bonferroni threshold.
-      constexpr std::size_t  kMaxACFLag = 20;
-      constexpr unsigned int kMinBlockL  = 2;
-      constexpr unsigned int kMaxBlockL  = 12;
-
-      // Bonferroni z-critical: α=0.05 family-wise, M=kMaxACFLag two-sided tests.
-      //   z = qnorm(1 − 0.05 / (2 * 20)) = qnorm(0.99875) ≈ 3.023
-      // Rounded up to 3.05 for a small conservative margin.
-      constexpr double kBonferroniZ = 3.05;
-
-      // Sentinel for degenerate / insufficient-data returns.
+ 
+      constexpr size_t        kMinBootstrapSize = 30;
+      constexpr unsigned int  kNumResamples     = 10000;
+      constexpr double        kConfidenceLevel  = 0.90;
+      constexpr std::size_t   kMaxACFLag        = 20;
+      constexpr unsigned int  kMinBlockL        = 2;
+      constexpr unsigned int  kMaxBlockL        = 12;
+ 
       const Decimal eps = DecimalConstants<Decimal>::createDecimal("1e-8");
-
+ 
       // -----------------------------------------------------------------------
       // Guard: need enough data for a meaningful bootstrap
       // -----------------------------------------------------------------------
       if (rocVec.size() < kMinBootstrapSize)
         return {eps, eps, eps, eps};
-
+ 
       // -----------------------------------------------------------------------
       // Width statistics (lambdas passed to BCaBootStrap)
       // -----------------------------------------------------------------------
-
+ 
       using StatFn = std::function<Decimal(const std::vector<Decimal>&)>;
-
-      // Upside width = q90 − q50  (profit potential; used for LONG targets)
-      StatFn calc_upside_width = [](const std::vector<Decimal>& v) -> Decimal {
-        if (v.size() < 2) return DecimalConstants<Decimal>::DecimalZero;
-        Decimal med   = LinearInterpolationQuantile(v, 0.50);
-        Decimal q90   = LinearInterpolationQuantile(v, 0.90);
-        Decimal width = q90 - med;
+ 
+      // Upside width = q90 - q50  (profit potential; used for LONG targets)
+      StatFn calc_upside_width = [](const std::vector<Decimal>& v) -> Decimal
+      {
+        if (v.size() < 2)
+          return DecimalConstants<Decimal>::DecimalZero;
+ 
+        Decimal median = LinearInterpolationQuantile(v, 0.50);
+        Decimal q90    = LinearInterpolationQuantile(v, 0.90);
+        Decimal width  = q90 - median;
+ 
         return (width < DecimalConstants<Decimal>::DecimalZero)
-               ? DecimalConstants<Decimal>::DecimalZero : width;
+               ? DecimalConstants<Decimal>::DecimalZero
+               : width;
       };
-
-      // Downside width = q50 − q10  (risk exposure; used for LONG stops)
-      StatFn calc_downside_width = [](const std::vector<Decimal>& v) -> Decimal {
-        if (v.size() < 2) return DecimalConstants<Decimal>::DecimalZero;
-        Decimal med   = LinearInterpolationQuantile(v, 0.50);
-        Decimal q10   = LinearInterpolationQuantile(v, 0.10);
-        Decimal width = med - q10;
+ 
+      // Downside width = q50 - q10  (risk exposure; used for LONG stops)
+      StatFn calc_downside_width = [](const std::vector<Decimal>& v) -> Decimal
+      {
+        if (v.size() < 2)
+          return DecimalConstants<Decimal>::DecimalZero;
+ 
+        Decimal median = LinearInterpolationQuantile(v, 0.50);
+        Decimal q10    = LinearInterpolationQuantile(v, 0.10);
+        Decimal width  = median - q10;
+ 
         return (width < DecimalConstants<Decimal>::DecimalZero)
-               ? DecimalConstants<Decimal>::DecimalZero : width;
+               ? DecimalConstants<Decimal>::DecimalZero
+               : width;
       };
-
+ 
       // -----------------------------------------------------------------------
       // Block length selection
+      //
+      // Convert percent-ROC to decimal returns (0.015 = +1.5%), then delegate
+      // entirely to StatUtils::suggestStationaryBlockLength.  That function
+      // handles the log transformation, both ACF computations, the tapered
+      // Bartlett dependence-mass estimation, and the max(L_raw, L_abs)
+      // combination rule.  The percent -> decimal conversion stays here because
+      // it is specific to the data format of rocVec, not a concern of the
+      // general-purpose block length estimator.
       // -----------------------------------------------------------------------
       const size_t n = rocVec.size();
-      size_t L;
-
+      size_t L = kMinBlockL;
+ 
       std::cout << "[BootStrapIndicators] Block Length Calculation for n=" << n
                 << " observations:\n";
-
+ 
       if (n >= 100)
       {
-        std::cout << "  Method: ACF-based (n >= 100)\n";
+        std::cout << "  Method: smooth ACF dependence-mass estimator (n >= 100)\n";
+ 
         try
         {
-          const std::size_t maxACFLag = std::min<std::size_t>(kMaxACFLag, n - 1);
-
-          // --- Convert percent-ROC → decimal → log-returns for ACF ---
-          // Log-returns share the same autocorrelation structure as percent-ROC
-          // for small returns and are the natural input for an unbiased ACF
-          // estimator.  The block length derived here is applied to the
-          // bootstrap of the original percent-ROC values.
           std::vector<Decimal> decimalReturns;
           decimalReturns.reserve(n);
-          const Decimal hundred = DecimalConstants<Decimal>::createDecimal("100.0");
+ 
+          const Decimal hundred =
+              DecimalConstants<Decimal>::createDecimal("100.0");
+ 
           for (const auto& roc_pct : rocVec)
             decimalReturns.push_back(roc_pct / hundred);
-
-          auto logReturns = StatUtils<Decimal>::percentBarsToLogBars(decimalReturns);
-          const auto acf  = StatUtils<Decimal>::computeACF(logReturns, maxACFLag);
-
-          // --- Bonferroni-corrected significance threshold ---
-          // Controls family-wise error rate at <=5% across all M=kMaxACFLag lags.
-          // This eliminates the ~22% spurious-large-L rate of the raw 2/sqrt(n)
-          // pointwise band when testing 20 lags simultaneously.
-          const double threshold =
-              kBonferroniZ / std::sqrt(static_cast<double>(n));
-
-          // --- Consecutive-lag rule (secondary guard) ---
-          // Update L only when two *adjacent* lags both exceed the Bonferroni
-          // band.  Combined with the corrected threshold, the overall false-
-          // positive probability is negligible.  Genuine autocorrelation always
-          // produces runs starting at lag 1, not isolated high-lag pairs.
-          unsigned int L_acf = kMinBlockL;   // default: minimum for white noise
-          for (std::size_t k = 1; k + 1 < acf.size(); ++k)
-          {
-            const double rk  = std::fabs(acf[k    ].getAsDouble());
-            const double rk1 = std::fabs(acf[k + 1].getAsDouble());
-            if (rk > threshold && rk1 > threshold)
-              L_acf = static_cast<unsigned int>(k + 1);
-          }
-          L_acf = std::max(kMinBlockL, std::min(kMaxBlockL, L_acf));
-          L     = static_cast<std::size_t>(L_acf);
-
-          // --- Diagnostics ---
-          std::cout << "  Bonferroni threshold (" << kBonferroniZ << "/sqrt(n)): "
-                    << threshold << "\n";
-          std::cout << "  (z=" << kBonferroniZ << ", M=" << maxACFLag
-                    << " lags, FWER=5%)\n";
-          std::cout << "  ACF analysis: maxLag=" << maxACFLag
-                    << ", block range=[" << kMinBlockL << "," << kMaxBlockL << "]\n";
-          std::cout << "  ACF values:\n";
-          for (std::size_t i = 0; i < acf.size(); ++i)
-          {
-            const double av = std::fabs(acf[i].getAsDouble());
-            std::cout << "    rho[" << i << "] = " << acf[i]
-                      << (i > 0 && av > threshold ? "  *** above Bonferroni band" : "")
-                      << "\n";
-          }
+ 
+          L = StatUtils<Decimal>::suggestStationaryBlockLength(
+                  decimalReturns,
+                  kMaxACFLag,
+                  kMinBlockL,
+                  kMaxBlockL);
+ 
           std::cout << "  ACF-suggested block length: L=" << L << "\n";
         }
         catch (const std::exception& e)
         {
-          // Fallback: n^(1/3) heuristic (Politis & White, 2004).
           L = std::max<size_t>(
-                2, static_cast<size_t>(
-                     std::pow(static_cast<double>(n), 1.0 / 3.0)));
+                  2,
+                  static_cast<size_t>(
+                      std::pow(static_cast<double>(n), 1.0 / 3.0)));
+ 
           std::cout << "  ACF calculation failed (" << e.what() << ")\n";
           std::cout << "  Fallback to n^(1/3) heuristic: L=" << L << "\n";
         }
       }
       else
       {
-        // For small series the ACF is too noisy; use the n^(1/3) heuristic.
         std::cout << "  Method: n^(1/3) heuristic (n < 100)\n";
+ 
         L = std::max<size_t>(
-              2, static_cast<size_t>(
-                   std::pow(static_cast<double>(n), 1.0 / 3.0)));
+                2,
+                static_cast<size_t>(
+                    std::pow(static_cast<double>(n), 1.0 / 3.0)));
+ 
         std::cout << "  Calculated block length: L=" << L << "\n";
       }
-
+ 
       std::cout << "  Final block length used: L=" << L << "\n\n";
-
+ 
       // -----------------------------------------------------------------------
       // Bootstrap
       // -----------------------------------------------------------------------
       StationaryBlockResampler<Decimal> blockSampler(L);
-
-      // 1. Define the Executor type (<0> dynamically uses std::thread::hardware_concurrency)
+ 
       using ThreadPool = concurrency::ThreadPoolExecutor<0>;
-
-      // 2. Instantiate a single shared pool to prevent thread allocation thrashing.
-      //    Both bca_up and bca_down are evaluated sequentially (lazy evaluation
-      //    triggers on the first getLowerBound() / getUpperBound() call), so the
-      //    pool is never accessed by both bootstraps concurrently.  Sharing the
-      //    pool eliminates the overhead of constructing and destroying a second
-      //    fixed-size thread pool for the downside bootstrap.
       auto sharedExecutor = std::make_shared<ThreadPool>();
-
+ 
       try
       {
-        // 3. Fully qualify the BCaBootStrap template to reach the 6th parameter.
-        //    Params 3–5 (Rng, Provider, SampleType) are spelled out explicitly
-        //    because C++ has no way to skip defaulted template parameters when
-        //    specifying a later one.
         using ParallelBCa = BCaBootStrap<
             Decimal,
             StationaryBlockResampler<Decimal>,
-            randutils::mt19937_rng,              // Param 3: Rng  (default)
-            void,                                // Param 4: Provider (default)
-            Decimal,                             // Param 5: SampleType (default)
-            ThreadPool>;                         // Param 6: concurrent executor
-
-        // 4. Instantiate with the interval type and the injected shared pool.
-        //    Constructor used: custom-statistic + custom-sampler overload
-        //    (BiasCorrectedBootstrap.h, lines 1062-1083).
+            randutils::mt19937_rng,
+            void,
+            Decimal,
+            ThreadPool>;
+ 
         ParallelBCa bca_up(
-            rocVec, kNumResamples, kConfidenceLevel,
-            calc_upside_width, blockSampler,
+            rocVec,
+            kNumResamples,
+            kConfidenceLevel,
+            calc_upside_width,
+            blockSampler,
             palvalidator::analysis::IntervalType::TWO_SIDED,
             sharedExecutor);
-
+ 
         ParallelBCa bca_down(
-            rocVec, kNumResamples, kConfidenceLevel,
-            calc_downside_width, blockSampler,
+            rocVec,
+            kNumResamples,
+            kConfidenceLevel,
+            calc_downside_width,
+            blockSampler,
             palvalidator::analysis::IntervalType::TWO_SIDED,
             sharedExecutor);
-
+ 
         return {
           bca_up.getLowerBound(),
           bca_up.getUpperBound(),
@@ -576,264 +626,193 @@ namespace mkc_timeseries
   } // namespace detail
 
   /**
-   * @brief Computes robust LONG-side profit target and stop widths using BCa bootstrap.
-   *
-   * This function calculates statistically robust stop-loss and profit-target widths
-   * for LONG (buy) positions using a sophisticated second-order bootstrap approach.
-   * Rather than computing simple historical quantiles (which can overfit), it bootstraps
-   * the **distribution of width statistics** to account for sampling uncertainty and
-   * provide conservative, reliable estimates.
-   *
-   * ## METHODOLOGY OVERVIEW
-   *
-   * The function performs a **meta-bootstrap** in three stages:
-   *
-   * 1. **Data Preparation:**
-   *    - Computes Rate-of-Change (ROC) over the specified period
-   *    - ROC(t) = ((Close(t) / Close(t-period)) - 1) × 100
-   *    - Provides percentage-normalized returns suitable for bootstrap
-   *
-   * 2. **Width Definition:**
-   *    - Upside Width = q90 - q50 (distance from median to 90th percentile)
-   *    - Downside Width = q50 - q10 (distance from 10th percentile to median)
-   *    - These represent typical profit potential and risk exposure
-   *
-   * 3. **Bootstrap Analysis:**
-   *    - Creates 10,000 resampled datasets using stationary block bootstrap
-   *    - Computes upside/downside widths for each resample
-   *    - Builds distributions of these widths (not just single values)
-   *    - Uses BCa (Bias-Corrected and Accelerated) method for confidence intervals
-   *
-   * ## WHY THIS APPROACH IS SUPERIOR
-   *
-   * Traditional Method (prone to overfitting):
-   *   ROC data → compute q90-q50 once → use this single number
-   *
-   * Bootstrap Method (robust):
-   *   ROC data → resample 10,000 times → 10,000 width estimates →
-   *   distribution of widths → 90% confidence interval on width
-   *
-   * This answers: "What width can I be confident about, accounting for
-   * sampling uncertainty?" rather than "What width did I observe in this
-   * particular dataset?"
-   *
-   * ## STATIONARY BLOCK BOOTSTRAP
-   *
-   * Financial time series exhibit autocorrelation (momentum, mean reversion,
-   * volatility clustering). Standard bootstrap assumes independence and fails
-   * for such data. This implementation uses Stationary Block Bootstrap
-   * (Politis & Romano, 1994) which:
-   *
-   * - Resamples contiguous blocks of observations
-   * - Block length L chosen adaptively:
-   *   * ACF-based for n≥100 (captures actual dependencies)
-   *   * n^(1/3) heuristic for n<100 (Politis & White, 2004)
-   * - Preserves short-term dependencies within blocks
-   * - Provides valid inference for time series data
-   *
-   * ## BCa CONFIDENCE INTERVALS
-   *
-   * The Bias-Corrected and Accelerated (BCa) bootstrap (Efron, 1987) improves
-   * on standard percentile bootstrap by correcting for:
-   *
-   * 1. **Bias Correction (z₀):** Accounts for median bias in bootstrap distribution
-   * 2. **Acceleration (a):** Accounts for skewness via jackknife estimation
-   *
-   * This provides more accurate coverage probabilities, especially for
-   * skewed distributions (common in financial returns).
-   *
-   * ## CONSERVATIVE ASYMMETRIC BOUNDS
-   *
-   * The function uses a 90% confidence interval (5th to 95th percentiles) but
-   * applies them asymmetrically for robustness:
-   *
-   * For LONG positions:
-   * - **Profit Target Width** = 5th percentile of upside width distribution
-   *   → Conservative estimate of achievable profit (lower bound)
-   *   → We're 90% confident profit potential is AT LEAST this much
-   *
-   * - **Stop Loss Width** = 95th percentile of downside width distribution
-   *   → Conservative estimate of required risk tolerance (upper bound)
-   *   → We're 90% confident risk exposure is AT MOST this much
-   *
-   * This ensures:
-   * - Targets are realistic and achievable (not overly optimistic)
-   * - Stops are sufficiently wide (won't be prematurely triggered)
-   *
-   * ## QUANTILE SELECTION RATIONALE
-   *
-   * Uses q10/q50/q90 rather than extremes (q5/q95):
-   * - Avoids unstable tail estimates
-   * - More robust to outliers
-   * - Still captures bulk of distribution
-   * - Confidence interval provides additional conservatism
-   *
-   * ## MINIMUM DATA REQUIREMENTS
-   *
-   * - Absolute minimum: 30 ROC values (enforced by kMinBootstrapSize)
-   * - Practical minimum: period + 30 + period ≈ 2×period + 30 bars
-   * - Example: period=20 requires ≥70 price bars
-   * - Returns epsilon (1e-8) values if insufficient data
-   *
-   * ## COMPUTATIONAL COMPLEXITY
-   *
-   * - Time: O(B × n log n) where B=10,000 resamples, n=sample size
-   * - Space: O(n² + B) dominated by BCa jackknife calculation
-   * - Typical runtime: 0.5-5 seconds for 100-1000 bars on modern CPU
-   *
-   * ## PARAMETER GUIDANCE
-   *
-   * **Period Selection:**
-   * - 5-10:   Short-term (day trading, scalping)
-   * - 10-20:  Medium-term (swing trading) - RECOMMENDED DEFAULT
-   * - 20-60:  Long-term (position trading)
-   * - >60:    Strategic allocation
-   *
-   * Align period with your trading timeframe. Longer periods yield:
-   * - Smoother estimates
-   * - Larger width values
-   * - Fewer observations (require more data)
-   *
-   * @tparam Decimal Numeric type (e.g., num::DefaultNumber, double)
-   *
-   * @param series The OHLC time series to analyze. Must contain at least
-   *               (2×period + 30) entries for reliable results.
-   *
-   * @param period The lookback period for ROC calculation. Typical values:
-   *               10 (short-term), 20 (medium-term), 50 (long-term).
-   *               Must be positive and significantly less than series length.
-   *
-   * @return std::pair<Decimal, Decimal> containing {profit_width, stop_width}
-   *         Both values are in decimal form (0.05 = 5%). These represent:
-   *         - profit_width: Conservative estimate of achievable profit potential
-   *         - stop_width: Conservative estimate of necessary risk tolerance
-   *
-   * @throws std::domain_error If series has fewer than 3 entries
-   * @throws std::domain_error If ROC series has fewer than 3 entries (after period offset)
-   *
-   * @note Returns {eps, eps} where eps=1e-8 in degenerate cases:
-   *       - Insufficient data (< 30 ROC values)
-   *       - Bootstrap failure (all identical values, numerical issues)
-   *       - Non-positive width results
-   *
-   * ## USAGE EXAMPLE
-   *
-   * @code
-   * // Load daily price data
-   * OHLCTimeSeries<num::DefaultNumber> prices = loadOHLCData("AAPL.csv");
-   *
-   * // Compute stop and target widths using 10-period ROC
-   * auto [target_width, stop_width] =
-   *     ComputeBootStrappedLongStopAndTarget(prices, 10);
-   *
-   * // Validate results (check for degenerate epsilon returns)
-   * const Decimal min_viable = Decimal(0.001); // 0.1%
-   * if (target_width < min_viable || stop_width < min_viable) {
-   *     std::cerr << "Warning: Insufficient data for reliable bootstrap" << std::endl;
-   *     // Fall back to default risk management or gather more data
-   * }
-   *
-   * // Convert widths to actual price levels
-   * Decimal entry_price = prices.getLastEntry().getCloseValue();
-   * Decimal target_price = entry_price * (Decimal(1.0) + target_width);
-   * Decimal stop_price = entry_price * (Decimal(1.0) - stop_width);
-   *
-   * std::cout << "Entry: $" << entry_price << std::endl;
-   * std::cout << "Target: $" << target_price
-   *           << " (+" << (target_width * 100) << "%)" << std::endl;
-   * std::cout << "Stop: $" << stop_price
-   *           << " (-" << (stop_width * 100) << "%)" << std::endl;
-   * std::cout << "Risk/Reward: " << (target_width / stop_width) << std::endl;
-   * @endcode
-   *
-   * ## TYPICAL OUTPUT INTERPRETATION
-   *
-   * Example result for 10-period ROC on daily data:
-   *   profit_width = 0.03 (3.0%)
-   *   stop_width = 0.045 (4.5%)
-   *   Risk/Reward = 0.67
-   *
-   * Interpretation:
-   * - Conservative profit target is 3.0% above entry
-   * - Conservative stop loss is 4.5% below entry
-   * - Risking $1.50 to make $1.00 (slightly unfavorable, but robust)
-   * - These are 90% confidence bounds, not point estimates
-   *
-   * ## ADVANCED: POSITION SIZING APPLICATION
-   *
-   * @code
-   * Decimal account_equity = Decimal(100000.0);
-   * Decimal max_risk_pct = Decimal(0.02); // Risk 2% per trade
-   *
-   * auto [target, stop] = ComputeBootStrappedLongStopAndTarget(series, 20);
-   *
-   * Decimal entry_price = series.getLastEntry().getCloseValue();
-   * Decimal dollars_at_risk_per_share = entry_price * stop;
-   * Decimal max_dollar_risk = account_equity * max_risk_pct;
-   *
-   * // Calculate position size
-   * Decimal shares = max_dollar_risk / dollars_at_risk_per_share;
-   *
-   * std::cout << "Position size: " << shares << " shares" << std::endl;
-   * std::cout << "Max loss: $" << max_dollar_risk << std::endl;
-   * @endcode
-   *
-   * ## KNOWN LIMITATIONS AND CAVEATS
-   *
-   * 1. **Stationarity Assumption:** Assumes recent price behavior is representative
-   *    of future behavior. May fail during regime changes (crashes, policy shifts).
-   *    Mitigation: Use recent data (6-12 months) or regime-detection methods.
-   *
-   * 2. **Block Bootstrap Limitations:** While better than IID bootstrap, still
-   *    assumes stationarity within blocks. Very long-range dependencies may not
-   *    be fully captured.
-   *
-   * 3. **Computational Cost:** 10,000 resamples with BCa jackknife is expensive.
-   *    Not suitable for ultra-high-frequency applications without optimization.
-   *
-   * 4. **Parameter Sensitivity:** Results depend on period selection. No single
-   *    "correct" period exists. Test multiple periods or use ensemble methods.
-   *
-   * 5. **No Market Microstructure:** Ignores bid-ask spreads, slippage, liquidity.
-   *    Add appropriate margins for real-world execution.
-   *
-   * ## VALIDATION AND TESTING
-   *
-   * Before deploying in production:
-   * 1. Verify sufficient data (≥ 2×period + 30 bars)
-   * 2. Check for epsilon returns (indicates failure)
-   * 3. Validate widths are reasonable (0.5% - 50% for most assets)
-   * 4. Backtest on out-of-sample data
-   * 5. Monitor in paper trading before live deployment
-   *
-   * ## CONFIGURATION CONSTANTS (in ComputeBootstrappedWidths)
-   *
-   * Current settings:
-   * - kMinBootstrapSize = 30 (minimum ROC observations)
-   * - kNumResamples = 10,000 (bootstrap iterations)
-   * - kConfidenceLevel = 0.90 (90% CI)
-   * - Block length L: ACF-based for n≥100, n^(1/3) for n<100 (automatic)
-   *
-   * These are well-validated defaults. Modify only if you have specific
-   * requirements and understand the statistical implications.
-   *
-   * ## REFERENCES
-   *
-   * - Efron, B. (1987). "Better Bootstrap Confidence Intervals."
-   *   Journal of the American Statistical Association, 82(397), 171-185.
-   *
-   * - Politis, D.N., & Romano, J.P. (1994). "The Stationary Bootstrap."
-   *   Journal of the American Statistical Association, 89(428), 1303-1313.
-   *
-   * - Politis, D.N., & White, H. (2004). "Automatic Block-Length Selection
-   *   for the Dependent Bootstrap." Econometric Reviews, 23(1), 53-70.
-   *
-   * @see ComputeBootStrappedShortStopAndTarget For SHORT position equivalent
-   * @see detail::ComputeBootstrappedWidths Internal bootstrap implementation
-   * @see BCaBootStrap BCa bootstrap class (BiasCorrectedBootstrap.h)
-   * @see StationaryBlockResampler Block bootstrap implementation
-   * @see RocSeries Rate-of-change calculation (TimeSeriesIndicators.h)
-   */
+ * @brief Computes robust LONG-side profit target and stop widths using BCa
+ *        bootstrap with adaptive dependence-preserving block resampling.
+ *
+ * This function calculates statistically robust stop-loss and profit-target
+ * widths for LONG (buy) positions using a second-order bootstrap procedure.
+ * Rather than relying on a single historical quantile estimate, it bootstraps
+ * the distribution of width statistics to account for sampling uncertainty and
+ * local time-series dependence.
+ *
+ * ---------------------------------------------------------------------------
+ * METHODOLOGY OVERVIEW
+ * ---------------------------------------------------------------------------
+ *
+ * The function proceeds in three stages:
+ *
+ * 1. Data Preparation
+ *    - Computes a Rate-of-Change (ROC) series over the requested period
+ *    - ROC(t) = ((Close(t) / Close(t - period)) - 1) * 100
+ *
+ * 2. Width Definition
+ *    - Upside Width   = q90 - q50
+ *    - Downside Width = q50 - q10
+ *
+ * 3. Bootstrap Inference
+ *    - Uses stationary block bootstrap to preserve local dependence
+ *    - Uses BCa (Bias-Corrected and Accelerated) intervals to account for
+ *      bias and skewness in the bootstrap distribution
+ *
+ * The result is a pair of conservative LONG-side widths:
+ *
+ * - profit target width
+ * - stop-loss width
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THIS APPROACH IS MORE ROBUST
+ * ---------------------------------------------------------------------------
+ *
+ * A simple historical quantile width is only a point estimate from one sample.
+ * This function instead asks:
+ *
+ *   "What width is still plausible after accounting for sampling uncertainty
+ *    and dependence in the return process?"
+ *
+ * That produces stop/target widths that are more stable and less prone to
+ * overfitting.
+ *
+ * ---------------------------------------------------------------------------
+ * BLOCK BOOTSTRAP AND DEPENDENCE PRESERVATION
+ * ---------------------------------------------------------------------------
+ *
+ * Financial return series are rarely IID. Even when raw returns show little
+ * serial correlation, volatility often clusters over time. Because stop and
+ * target widths depend strongly on the local dispersion of returns, preserving
+ * this dependence is important.
+ *
+ * The stationary bootstrap block length is chosen adaptively inside
+ * ComputeBootstrappedWidths() as follows:
+ *
+ * For n >= 100:
+ * - Compute the ACF of raw log returns
+ * - Compute the ACF of absolute log returns
+ * - Convert each ACF into a smooth tapered dependence-mass estimate
+ * - Convert those dependence masses into candidate block lengths
+ * - Use the larger of the two candidate lengths:
+ *
+ *     L = max(L_raw, L_abs)
+ *
+ * This design preserves:
+ *
+ * - signed dependence in raw returns when present
+ * - volatility clustering through absolute returns
+ *
+ * For n < 100:
+ * - Use the fallback heuristic:
+ *
+ *     L = max(2, floor(n^(1/3)))
+ *
+ * This block-length rule is smoother and more stable than a threshold-based
+ * significance rule and is less sensitive to small changes in in-sample length.
+ *
+ * ---------------------------------------------------------------------------
+ * BCa CONFIDENCE INTERVALS
+ * ---------------------------------------------------------------------------
+ *
+ * The Bias-Corrected and Accelerated (BCa) bootstrap improves on standard
+ * percentile bootstrap by correcting for:
+ *
+ * - median bias in the bootstrap distribution
+ * - skewness via jackknife-based acceleration
+ *
+ * This is especially useful for return-width statistics, which are often
+ * asymmetric and skewed.
+ *
+ * ---------------------------------------------------------------------------
+ * CONSERVATIVE LONG-SIDE BOUNDS
+ * ---------------------------------------------------------------------------
+ *
+ * For LONG positions, the function uses the bootstrap bounds asymmetrically:
+ *
+ * - Profit Target Width = lower bound of the upside-width distribution
+ *   -> conservative estimate of achievable upside
+ *
+ * - Stop Width = upper bound of the downside-width distribution
+ *   -> conservative estimate of required downside tolerance
+ *
+ * This means:
+ *
+ * - targets are not overly optimistic
+ * - stops are not unrealistically tight
+ *
+ * ---------------------------------------------------------------------------
+ * QUANTILE CHOICES
+ * ---------------------------------------------------------------------------
+ *
+ * The width statistics are based on:
+ *
+ * - q10
+ * - q50
+ * - q90
+ *
+ * rather than more extreme tail quantiles. This improves finite-sample
+ * stability and reduces sensitivity to outliers while still capturing the
+ * central shape of the return distribution.
+ *
+ * ---------------------------------------------------------------------------
+ * MINIMUM DATA REQUIREMENTS
+ * ---------------------------------------------------------------------------
+ *
+ * - Absolute minimum: 30 ROC observations after period adjustment
+ * - Practical requirement: comfortably more than 30 observations for stable
+ *   width estimation and block-length selection
+ *
+ * If there is insufficient data or the bootstrap fails, the function returns
+ * near-zero epsilon values.
+ *
+ * ---------------------------------------------------------------------------
+ * COMPUTATIONAL COST
+ * ---------------------------------------------------------------------------
+ *
+ * This function is more expensive than a simple quantile calculation because it
+ * performs:
+ *
+ * - adaptive block-length estimation
+ * - stationary block resampling
+ * - 10,000 BCa bootstrap replications
+ * - jackknife-based BCa correction
+ *
+ * Runtime is typically acceptable for research, validation, and batch analysis,
+ * but may be too expensive for latency-sensitive workflows unless cached.
+ *
+ * @tparam Decimal Numeric type (for example num::DefaultNumber or double)
+ *
+ * @param series OHLC time series to analyze
+ *
+ * @param period Lookback period used to compute the ROC series. Typical values:
+ *               5-10 for shorter horizon analysis, 10-20 for swing-style
+ *               analysis, and larger values for longer horizon studies.
+ *
+ * @return std::pair<Decimal, Decimal> containing:
+ *         - profit target width
+ *         - stop width
+ *
+ * Both are returned in decimal form:
+ * - 0.03 means 3%
+ * - 0.05 means 5%
+ *
+ * For LONG positions:
+ * - target is applied above entry
+ * - stop is applied below entry
+ *
+ * @throws std::domain_error If the input series is too small
+ * @throws std::domain_error If the derived ROC series is too small
+ *
+ * @note Returns {eps, eps} where eps = 1e-8 in degenerate cases such as:
+ *       - insufficient data
+ *       - zero-variance samples
+ *       - bootstrap failure
+ *
+ * @warning Results depend on the selected period and the recent dependence
+ *          structure of the input series. They should be validated out of
+ *          sample before being used in production trading logic.
+ *
+ * @see ComputeBootstrappedShortStopAndTarget
+ * @see detail::ComputeBootstrappedWidths
+ * @see BCaBootStrap
+ * @see StationaryBlockResampler
+ */
   template <typename Decimal>
   std::pair<Decimal, Decimal>
   ComputeBootStrappedLongStopAndTarget(const OHLCTimeSeries<Decimal>& series,
@@ -868,283 +847,186 @@ namespace mkc_timeseries
   }
 
   /**
-   * @brief Computes robust SHORT-side profit target and stop widths using BCa bootstrap.
-   *
-   * This function calculates statistically robust stop-loss and profit-target widths
-   * for SHORT (sell) positions using the same sophisticated bootstrap methodology as
-   * ComputeBootStrappedLongStopAndTarget, but with **inverted application** of the
-   * width distributions appropriate for short selling.
-   *
-   * ## KEY DIFFERENCE FROM LONG VERSION
-   *
-   * The bootstrap process is identical (same ROC calculation, same width definitions,
-   * same statistical methodology), but the **interpretation and assignment** of widths
-   * is reversed to match short position mechanics:
-   *
-   * **For SHORT positions:**
-   * - **Profit Target Width** = 5th percentile of DOWNSIDE width distribution
-   *   → Profit comes from price decline
-   *   → Conservative estimate of achievable downside movement
-   *
-   * - **Stop Loss Width** = 95th percentile of UPSIDE width distribution
-   *   → Risk comes from price increase
-   *   → Conservative estimate of potential adverse movement
-   *
-   * **For LONG positions (for comparison):**
-   * - Profit Target Width = 5th percentile of UPSIDE width distribution
-   * - Stop Loss Width = 95th percentile of DOWNSIDE width distribution
-   *
-   * ## WHY THE INVERSION IS CORRECT
-   *
-   * When shorting:
-   * 1. **Entry:** Sell at current price (e.g., $100)
-   * 2. **Profit Target:** Buy back BELOW entry (e.g., $95 = -5% downside)
-   * 3. **Stop Loss:** Buy back ABOVE entry (e.g., $105 = +5% upside)
-   *
-   * The downside width (median - q10) represents typical downward movement,
-   * which is profit for shorts. The upside width (q90 - median) represents
-   * typical upward movement, which is risk for shorts.
-   *
-   * ## IDENTICAL BOOTSTRAP METHODOLOGY
-   *
-   * This function uses the exact same statistical approach as the LONG version:
-   *
-   * 1. Computes Rate-of-Change (ROC) series over specified period
-   * 2. Defines upside width = q90 - q50, downside width = q50 - q10
-   * 3. Bootstraps width distributions using stationary block resampling
-   * 4. Applies BCa corrections for bias and skewness
-   * 5. Extracts 90% confidence interval (5th to 95th percentiles)
-   *
-   * The only difference is which bounds are used for target vs. stop.
-   *
-   * ## CONSERVATIVE ASYMMETRIC BOUNDS (SHORT VERSION)
-   *
-   * For SHORT positions, we want:
-   * - **Realistic profit targets:** Use lower bound of downside width
-   *   → Don't expect more downside than we can be confident about
-   *
-   * - **Wide enough stops:** Use upper bound of upside width
-   *   → Protect against larger-than-typical rallies
-   *
-   * This ensures short positions are:
-   * - Not chasing unrealistic downside targets
-   * - Protected against adverse rallies with adequate room
-   *
-   * ## SYMMETRY VS. ASYMMETRY IN RETURNS
-   *
-   * Important note on return asymmetry in short selling:
-   *
-   * LONG position:
-   * - Max gain: Unlimited (price → ∞)
-   * - Max loss: 100% (price → 0)
-   *
-   * SHORT position:
-   * - Max gain: 100% (price → 0)
-   * - Max loss: Unlimited (price → ∞)
-   *
-   * However, for practical stop/target setting over typical timeframes
-   * (period = 5-60), this asymmetry is negligible. The bootstrap widths
-   * already account for the actual distribution observed in the data.
-   *
-   * For very long holding periods or extreme volatility, consider:
-   * - Adjusting stop_width upward for shorts (more conservative)
-   * - Using options or other defined-risk strategies
-   *
-   * ## TYPICAL USAGE PATTERN
-   *
-   * @code
-   * // Load price data
-   * OHLCTimeSeries<num::DefaultNumber> prices = loadOHLCData("TSLA.csv");
-   *
-   * // Compute stop and target for SHORT position
-   * auto [target_width, stop_width] =
-   *     ComputeBootStrappedShortStopAndTarget(prices, 15);
-   *
-   * // Convert to actual price levels for short entry
-   * Decimal entry_price = prices.getLastEntry().getCloseValue();
-   *
-   * // For shorts: target is BELOW entry, stop is ABOVE entry
-   * Decimal target_price = entry_price * (Decimal(1.0) - target_width);
-   * Decimal stop_price = entry_price * (Decimal(1.0) + stop_width);
-   *
-   * std::cout << "SHORT Entry: $" << entry_price << std::endl;
-   * std::cout << "Target (buy back): $" << target_price
-   *           << " (-" << (target_width * 100) << "%)" << std::endl;
-   * std::cout << "Stop (buy back): $" << stop_price
-   *           << " (+" << (stop_width * 100) << "%)" << std::endl;
-   * @endcode
-   *
-   * ## COMPARISON: LONG VS SHORT ON SAME DATA
-   *
-   * For the same asset and period, you might observe:
-   *
-   * @code
-   * auto [long_target, long_stop] =
-   *     ComputeBootStrappedLongStopAndTarget(prices, 20);
-   * auto [short_target, short_stop] =
-   *     ComputeBootStrappedShortStopAndTarget(prices, 20);
-   *
-   * // Example output:
-   * // LONG:  target = 3.5%, stop = 4.2%
-   * // SHORT: target = 3.8%, stop = 4.5%
-   * @endcode
-   *
-   * Observations:
-   * - Values are similar but not identical (different CI bounds)
-   * - SHORT widths often slightly larger (reflects return asymmetry)
-   * - Both are conservative estimates from same underlying distribution
-   *
-   * ## DIRECTIONAL BIAS CONSIDERATIONS
-   *
-   * If the underlying asset has a strong directional bias (e.g., equity indices
-   * have long-term upward drift), the width distributions will reflect this:
-   *
-   * - **Upward-biased asset:** Upside widths > downside widths
-   *   → LONG positions: favorable risk/reward
-   *   → SHORT positions: unfavorable risk/reward
-   *
-   * - **Downward-biased asset:** Downside widths > upside widths
-   *   → SHORT positions: favorable risk/reward
-   *   → LONG positions: unfavorable risk/reward
-   *
-   * The bootstrap automatically captures this from the data. You don't need to
-   * manually adjust for bias—it's embedded in the width distributions.
-   *
-   * ## RISK MANAGEMENT FOR SHORT POSITIONS
-   *
-   * Additional considerations when using these widths for short selling:
-   *
-   * 1. **Margin Requirements:** Factor in broker margin requirements and
-   *    interest costs (not captured by stop/target widths).
-   *
-   * 2. **Dividend Risk:** Short sellers pay dividends. Adjust target downward
-   *    or avoid shorts around ex-dividend dates.
-   *
-   * 3. **Borrow Costs:** Hard-to-borrow stocks have significant costs that
-   *    eat into profit targets.
-   *
-   * 4. **Short Squeeze Risk:** Low-float stocks with high short interest can
-   *    experience violent squeezes. Consider wider stops.
-   *
-   * 5. **Regulatory Risk:** Short sale restrictions (uptick rule, SSR) can
-   *    make execution difficult.
-   *
-   * ## POSITION SIZING FOR SHORTS
-   *
-   * @code
-   * Decimal account_equity = Decimal(100000.0);
-   * Decimal max_risk_pct = Decimal(0.015); // 1.5% for shorts (more conservative)
-   *
-   * auto [target, stop] = ComputeBootStrappedShortStopAndTarget(series, 20);
-   *
-   * Decimal entry_price = series.getLastEntry().getCloseValue();
-   * Decimal dollars_at_risk_per_share = entry_price * stop; // Stop is upside for shorts
-   * Decimal max_dollar_risk = account_equity * max_risk_pct;
-   *
-   * // Calculate short position size
-   * Decimal shares = max_dollar_risk / dollars_at_risk_per_share;
-   *
-   * std::cout << "SHORT size: " << shares << " shares" << std::endl;
-   * std::cout << "Entry value: $" << (shares * entry_price) << std::endl;
-   * std::cout << "Max loss: $" << max_dollar_risk << std::endl;
-   * @endcode
-   *
-   * Note: Many traders use smaller position sizes for shorts (1.5% vs 2% risk)
-   * due to unlimited loss potential and typically lower win rates.
-   *
-   * @tparam Decimal Numeric type (e.g., num::DefaultNumber, double)
-   *
-   * @param series The OHLC time series to analyze. Must contain at least
-   *               (2×period + 30) entries for reliable results.
-   *
-   * @param period The lookback period for ROC calculation. Same considerations
-   *               as LONG version. Typical values: 10-20 for swing trading.
-   *
-   * @return std::pair<Decimal, Decimal> containing {profit_width, stop_width}
-   *         Both values are in decimal form (0.04 = 4%). For SHORT positions:
-   *         - profit_width: Conservative estimate of achievable downside (profit)
-   *         - stop_width: Conservative estimate of potential upside (risk)
-   *
-   * @throws std::domain_error If series has fewer than 3 entries
-   * @throws std::domain_error If ROC series has fewer than 3 entries
-   *
-   * @note Returns {eps, eps} where eps=1e-8 in degenerate cases (same as LONG version)
-   *
-   * ## DATA REQUIREMENTS
-   *
-   * Identical to LONG version:
-   * - Minimum 30 ROC values after period offset
-   * - Practical minimum: ~70 bars for period=20
-   * - More data = more reliable estimates
-   * - Use recent data (6-12 months) for relevance
-   *
-   * ## COMPUTATIONAL COST
-   *
-   * Identical to LONG version:
-   * - 10,000 bootstrap resamples
-   * - BCa bias correction and acceleration
-   * - Typical runtime: 0.5-5 seconds
-   *
-   * ## VALIDATION CHECKLIST
-   *
-   * Before using SHORT widths in production:
-   *
-   * 1. ✓ Sufficient data (check series length)
-   * 2. ✓ Non-degenerate results (widths > 0.001)
-   * 3. ✓ Reasonable values (0.5% - 50% for most assets)
-   * 4. ✓ Backtest with proper short mechanics (dividends, borrow costs)
-   * 5. ✓ Paper trade before live deployment
-   * 6. ✓ Monitor actual stop/target hit rates
-   * 7. ✓ Consider asset-specific risks (squeeze, hard-to-borrow)
-   *
-   * ## DEBUGGING COMMON ISSUES
-   *
-   * **Issue:** Stop width >> target width (e.g., stop=10%, target=2%)
-   * **Cause:** Asset has strong upward bias
-   * **Action:** SHORT is fighting the trend. Consider avoiding or use wider targets.
-   *
-   * **Issue:** Both widths near zero (epsilon)
-   * **Cause:** Insufficient data or zero variance
-   * **Action:** Check series length, ensure period is appropriate, verify data quality.
-   *
-   * **Issue:** Extremely large widths (>50%)
-   * **Cause:** High volatility asset or inappropriate period
-   * **Action:** Reduce period, check for data errors, consider volatility-adjusted sizing.
-   *
-   * ## ADVANCED: REGIME-AWARE USAGE
-   *
-   * For more sophisticated implementations, consider regime detection:
-   *
-   * @code
-   * // Detect market regime
-   * bool is_bear_market = detectBearMarket(prices);
-   *
-   * if (is_bear_market) {
-   *     // In bear markets, SHORT conditions are more favorable
-   *     auto [target, stop] = ComputeBootStrappedShortStopAndTarget(prices, 15);
-   *     // Potentially more aggressive: smaller stops, larger targets
-   * } else {
-   *     // In bull markets, LONG conditions are more favorable
-   *     auto [target, stop] = ComputeBootStrappedLongStopAndTarget(prices, 15);
-   * }
-   * @endcode
-   *
-   * ## REFERENCES
-   *
-   * Same statistical references as LONG version:
-   * - Efron (1987): BCa bootstrap methodology
-   * - Politis & Romano (1994): Stationary block bootstrap
-   * - Politis & White (2004): Block length selection
-   *
-   * Additional short selling references:
-   * - Jones, C.M., & Lamont, O.A. (2002). "Short-sale constraints and stock returns."
-   *   Journal of Financial Economics, 66(2-3), 207-239.
-   *
-   * @see ComputeBootStrappedLongStopAndTarget For LONG position equivalent
-   * @see detail::ComputeBootstrappedWidths Shared bootstrap implementation
-   * @see BCaBootStrap BCa bootstrap class (BiasCorrectedBootstrap.h)
-   * @see StationaryBlockResampler Block bootstrap implementation
-   */
+ * @brief Computes robust SHORT-side profit target and stop widths using BCa
+ *        bootstrap with adaptive dependence-preserving block resampling.
+ *
+ * This function calculates statistically robust stop-loss and profit-target
+ * widths for SHORT (sell) positions using the same bootstrap engine as the
+ * LONG-side function, but with the width bounds applied according to short
+ * trade mechanics.
+ *
+ * Rather than using a single observed quantile width from historical data,
+ * the function bootstraps the distribution of width statistics while preserving
+ * local time-series dependence through stationary block resampling.
+ *
+ * ---------------------------------------------------------------------------
+ * METHODOLOGY OVERVIEW
+ * ---------------------------------------------------------------------------
+ *
+ * The function proceeds in three stages:
+ *
+ * 1. Data Preparation
+ *    - Computes a Rate-of-Change (ROC) series over the requested period
+ *
+ * 2. Width Definition
+ *    - Upside Width   = q90 - q50
+ *    - Downside Width = q50 - q10
+ *
+ * 3. Bootstrap Inference
+ *    - Uses adaptive stationary block bootstrap
+ *    - Uses BCa confidence intervals for bias and skewness correction
+ *
+ * The result is a pair of conservative SHORT-side widths:
+ *
+ * - profit target width
+ * - stop-loss width
+ *
+ * ---------------------------------------------------------------------------
+ * BLOCK BOOTSTRAP AND DEPENDENCE PRESERVATION
+ * ---------------------------------------------------------------------------
+ *
+ * Financial returns often exhibit:
+ *
+ * - weak or modest serial dependence in signed returns
+ * - stronger serial dependence in volatility
+ *
+ * Because this function is estimating stop and target widths, preserving local
+ * volatility structure is especially important. Width statistics depend more on
+ * the local scale of returns than on a weak directional autocorrelation alone.
+ *
+ * The stationary bootstrap block length is chosen adaptively inside
+ * ComputeBootstrappedWidths() as follows:
+ *
+ * For n >= 100:
+ * - Compute ACF on raw log returns
+ * - Compute ACF on absolute log returns
+ * - Convert both ACFs into smooth tapered dependence-mass measures
+ * - Convert those into candidate block lengths
+ * - Use:
+ *
+ *     L = max(L_raw, L_abs)
+ *
+ * This preserves whichever short-horizon dependence structure is stronger:
+ *
+ * - signed dependence
+ * - volatility clustering
+ *
+ * For n < 100:
+ * - Fall back to:
+ *
+ *     L = max(2, floor(n^(1/3)))
+ *
+ * This adaptive rule is intentionally smoother and more stable than a binary
+ * threshold-crossing block-length rule.
+ *
+ * ---------------------------------------------------------------------------
+ * BCa CONFIDENCE INTERVALS
+ * ---------------------------------------------------------------------------
+ *
+ * The Bias-Corrected and Accelerated (BCa) bootstrap improves on ordinary
+ * percentile bootstrap by correcting for:
+ *
+ * - bias in the bootstrap distribution
+ * - skewness through jackknife acceleration
+ *
+ * This is useful because width statistics for financial returns are typically
+ * asymmetric and not well described by simple Gaussian assumptions.
+ *
+ * ---------------------------------------------------------------------------
+ * CONSERVATIVE SHORT-SIDE BOUNDS
+ * ---------------------------------------------------------------------------
+ *
+ * For SHORT positions, the interpretation of upside and downside is reversed:
+ *
+ * - Profit comes from downside movement
+ * - Risk comes from upside movement
+ *
+ * Therefore the function uses:
+ *
+ * - Profit Target Width = lower bound of the downside-width distribution
+ *   -> conservative estimate of achievable downside
+ *
+ * - Stop Width = upper bound of the upside-width distribution
+ *   -> conservative estimate of adverse upside risk
+ *
+ * This produces SHORT-side widths that are intentionally conservative:
+ *
+ * - profit targets are not overly optimistic
+ * - stops are not unrealistically tight
+ *
+ * ---------------------------------------------------------------------------
+ * QUANTILE CHOICES
+ * ---------------------------------------------------------------------------
+ *
+ * Widths are based on:
+ *
+ * - q10
+ * - q50
+ * - q90
+ *
+ * rather than more extreme tail quantiles. This provides a more stable estimate
+ * of distribution width while still capturing the relevant shape of upside and
+ * downside movement.
+ *
+ * ---------------------------------------------------------------------------
+ * MINIMUM DATA REQUIREMENTS
+ * ---------------------------------------------------------------------------
+ *
+ * - Absolute minimum: 30 ROC observations after the lookback-period offset
+ * - Practical requirement: comfortably more data for stable width estimation
+ *   and adaptive block-length selection
+ *
+ * If data are insufficient or the bootstrap fails, the function returns
+ * near-zero epsilon values.
+ *
+ * ---------------------------------------------------------------------------
+ * COMPUTATIONAL COST
+ * ---------------------------------------------------------------------------
+ *
+ * This function is computationally heavier than a simple historical quantile
+ * method because it includes:
+ *
+ * - adaptive dependence estimation
+ * - stationary block bootstrap resampling
+ * - 10,000 BCa bootstrap replications
+ * - jackknife-based acceleration
+ *
+ * It is suitable for research and batch workflows, and can also be used in
+ * production if results are cached or computed offline.
+ *
+ * @tparam Decimal Numeric type (for example num::DefaultNumber or double)
+ *
+ * @param series OHLC time series to analyze
+ *
+ * @param period Lookback period used to compute the ROC series
+ *
+ * @return std::pair<Decimal, Decimal> containing:
+ *         - profit target width
+ *         - stop width
+ *
+ * Both are returned in decimal form.
+ *
+ * For SHORT positions:
+ * - target is applied below entry
+ * - stop is applied above entry
+ *
+ * @throws std::domain_error If the input series is too small
+ * @throws std::domain_error If the derived ROC series is too small
+ *
+ * @note Returns {eps, eps} where eps = 1e-8 in degenerate cases such as:
+ *       - insufficient data
+ *       - degenerate bootstrap samples
+ *       - bootstrap failure
+ *
+ * @warning Short-side widths should be interpreted together with any additional
+ *          short-selling constraints not modeled here, such as borrow costs,
+ *          dividend effects, or execution frictions.
+ *
+ * @see ComputeBootstrappedLongStopAndTarget
+ * @see detail::ComputeBootstrappedWidths
+ * @see BCaBootStrap
+ * @see StationaryBlockResampler
+ */
   template <typename Decimal>
   std::pair<Decimal, Decimal>
   ComputeBootStrappedShortStopAndTarget(const OHLCTimeSeries<Decimal>& series,

--- a/libs/timeseries/SyntheticTimeSeries.h
+++ b/libs/timeseries/SyntheticTimeSeries.h
@@ -209,7 +209,7 @@ namespace mkc_timeseries
         unsigned minBlock = 3,
         unsigned maxBlock = 20)
     {
-      // Step 1+2: close series → 1-period percentage returns (×100, scale-invariant for ACF)
+      // Step 1: close series -> 1-period percentage ROC (percent, e.g. 1.5 = +1.5%)
       auto rocSeries = RocSeries(series.CloseTimeSeries(),
                                  static_cast<uint32_t>(1));
       const size_t n = rocSeries.getNumEntries();
@@ -217,23 +217,34 @@ namespace mkc_timeseries
       if (n < 4)
         return static_cast<size_t>(minBlock);
 
-      // Step 3: square each return — volatility ACF, not mean-return ACF
-      std::vector<Decimal> squaredReturns;
-      squaredReturns.reserve(n);
+      // Step 2: convert percent ROC to decimal returns (0.015 = +1.5%).
+      // suggestStationaryBlockLength expects decimal fractions and applies
+      // log(1 + r) internally.  Passing percent values directly would produce
+      // log(1 + 1.5) instead of log(1 + 0.015), giving incorrect log-returns.
+      std::vector<Decimal> decimalReturns;
+      decimalReturns.reserve(n);
+      const Decimal hundred = DecimalConstants<Decimal>::createDecimal("100.0");
       for (auto it = rocSeries.beginRandomAccess();
            it != rocSeries.endRandomAccess(); ++it)
       {
-        const Decimal r = it->getValue();
-        squaredReturns.push_back(r * r);
+        decimalReturns.push_back(it->getValue() / hundred);
       }
 
-      // Step 4+5+6: ACF → block length suggestion with daily-appropriate bounds
-      const auto acf = StatUtils<Decimal>::computeACF(
-          squaredReturns, static_cast<size_t>(maxBlock));
-
+      // Step 3: estimate block length.
+      //
+      // suggestStationaryBlockLength computes two ACF channels internally:
+      //   - signed log-return ACF  (momentum / mean-reversion)
+      //   - absolute log-return ACF (volatility clustering, analogous to
+      //                              the squared-return ACF used previously)
+      // The final block length is max(L_raw, L_abs), so volatility clustering
+      // drives the result when it is the dominant dependence structure, which
+      // is the same intent as the old squared-return approach.
       return static_cast<size_t>(
-          StatUtils<Decimal>::suggestStationaryBlockLengthFromACF(
-              acf, n, minBlock, maxBlock));
+          StatUtils<Decimal>::suggestStationaryBlockLength(
+              decimalReturns,
+              static_cast<size_t>(maxBlock),   // maxLag
+              minBlock,                         // minL
+              maxBlock));                       // maxL
     }
 
   } // namespace shuffle_detail

--- a/src/palvalidator/analysis/RobustnessAnalyzer.cpp
+++ b/src/palvalidator/analysis/RobustnessAnalyzer.cpp
@@ -638,46 +638,73 @@ namespace palvalidator
     {
       const size_t n = rHalf.size();
       if (n == 0)
-	return std::max<size_t>(1, minL);
+        return std::max<size_t>(1, minL);
 
-      // ---- Small-sample guard: skip ACF if half is too short
-      // Rationale: with n≈10–17 the ACF estimate is high-variance and can be misleading.
-      // Threshold 30 is conservative; you can raise to 40 if you like.
-
+      // ---- Small-sample guard: skip ACF if half is too short.
+      // Rationale: with n < 30 the ACF estimate is high-variance and
+      // misleading.  suggestStationaryBlockLength has its own internal
+      // threshold at n < 100, but we keep this outer guard so the
+      // n^(1/3) heuristic here can incorporate minL rather than relying
+      // on the function's fixed minL=2 default.
       constexpr size_t kMinNForACF = 30;
       if (n < kMinNForACF)
 	{
-	  // fallback heuristic: n^(1/3), then clamp
-	  const size_t h = std::max<size_t>(minL, static_cast<size_t>(std::llround(std::cbrt(static_cast<double>(n)))));
-	  return std::min(h, (hardMaxL == 0 ? h : hardMaxL));
+	  const size_t h = std::max<size_t>(
+					    minL,
+					    static_cast<size_t>(std::llround(std::cbrt(static_cast<double>(n)))));
+	  return (hardMaxL == 0) ? h : std::min(h, hardMaxL);
 	}
 
-      // ---- Try ACF-based suggestion; fall back to cube-root if it fails/returns 0
+      // ---- ACF-based suggestion via suggestStationaryBlockLength.
+      //
+      // suggestStationaryBlockLength handles the log-return transformation,
+      // both ACF computations (signed raw + absolute), and the dependence-
+      // mass estimation internally.
+      //
+      // rHalf must contain decimal-fraction returns (0.015 = +1.5%).
+      // Do NOT pass pre-computed log-returns: the function applies
+      // log(1 + r) internally and would double-transform.
+      //
+      // hardMaxL == 0 is the "no cap" sentinel from the old interface.
+      // suggestStationaryBlockLength requires a concrete maxL, so we
+      // substitute a large practical value that will never bind in
+      // normal use.
+      constexpr size_t kUnboundedMaxL = 100;
+      const size_t effectiveMaxL = (hardMaxL == 0) ? kUnboundedMaxL : hardMaxL;
+
+      // maxLag: cap at n-1 (the function also does this internally, but
+      // keeping it explicit preserves the original intent of using
+      // hardMaxL as a lag horizon as well as a block length cap).
+      const size_t maxLag = std::min<size_t>(effectiveMaxL, n - 1);
+
       size_t L_suggest = 0;
       try
 	{
-	  const size_t n = rHalf.size();
-	  const size_t maxLag = std::min<size_t>(hardMaxL, (n > 1) ? (n - 1) : 1);
-	  std::vector<Num> acf = StatUtils<Num>::computeACF(rHalf, maxLag);
-	  L_suggest = StatUtils<Num>::suggestStationaryBlockLengthFromACF(acf, n, minL, hardMaxL);
+	  L_suggest = static_cast<size_t>(
+					  StatUtils<Num>::suggestStationaryBlockLength(
+										       rHalf,
+										       maxLag,
+										       static_cast<unsigned>(minL),
+										       static_cast<unsigned>(effectiveMaxL)));
 	}
       catch (...)
 	{
 	  L_suggest = 0;
 	}
 
-      if (L_suggest == 0)
-        L_suggest = std::max<size_t>(minL, static_cast<size_t>(std::llround(std::cbrt(static_cast<double>(n)))));
+      // Fallback if the call failed or returned below minL
+      if (L_suggest < minL)
+        L_suggest = std::max<size_t>(
+				     minL,
+				     static_cast<size_t>(std::llround(std::cbrt(static_cast<double>(n)))));
 
       // Final clamps
       L_suggest = std::max(L_suggest, minL);
-      
       if (hardMaxL > 0)
-	L_suggest = std::min(L_suggest, hardMaxL);
+        L_suggest = std::min(L_suggest, hardMaxL);
 
       return L_suggest;
     }
-
 
     size_t RobustnessAnalyzer::adjustBforHalf_(size_t B, size_t nHalf)
     {

--- a/src/palvalidator/filtering/MetaStrategyAnalyzer.cpp
+++ b/src/palvalidator/filtering/MetaStrategyAnalyzer.cpp
@@ -59,70 +59,67 @@ namespace palvalidator
                                                 std::size_t minSizeForACF = 100,
                                                 std::size_t maxACFLag = 20,
                                                 unsigned int minACFL = 2,
-                                                unsigned int maxACFL = 12) // Default max L for meta
+                                                unsigned int maxACFL = 12)
     {
       if (returns.size() < minSizeForACF)
         {
-	  std::size_t n = returns.size();
-	  std::size_t L = 0;
-
-	  if (n < 50)
-	    {
-	      // Very short: trust the median hold
-	      L = std::max<std::size_t>(2, static_cast<std::size_t>(medianHold));
-	    }
-	  else
-	    {
-	      // Medium-length: heuristic n^(1/3)
-	      L = static_cast<std::size_t>(std::floor(std::pow(static_cast<double>(n), 1.0/3.0)));
-	      
-	      // Blend with median hold if that’s materially higher
-	      L = std::max<std::size_t>(L, static_cast<std::size_t>(medianHold));
-	    }
-
-	  // Safety caps
-	  L = std::min(L, n / 2);
-	  L = std::max<std::size_t>(2, L);
-
-	  outputStream << "      (Using block length L=" << L
-		       << " based on "
-		       << (n < 50 ? "median hold period" : "n^(1/3) heuristic")
-		       << ", n=" << n << " < " << minSizeForACF << ")\n";
-	  return L;
-        }
-        else
-        {
-            // --- Method 2: ACF-based (for longer series) ---
-            try
+          // --- Small-sample path: medianHold blending ---
+          // Kept unchanged: suggestStationaryBlockLength does not know about
+          // medianHold, so this custom blending logic must remain here.
+          std::size_t n = returns.size();
+          std::size_t L = 0;
+          if (n < 50)
             {
-                // Ensure maxACFLag is reasonable given series size
-                std::size_t effectiveMaxLag = std::min(maxACFLag, returns.size() - 1);
-                if (effectiveMaxLag < 1) {
-                  throw std::runtime_error("Cannot compute ACF with effective max lag < 1");
-                }
-
-		auto logReturns = StatUtils<Num>::percentBarsToLogBars(returns);
-		
-                const auto acf = mkc_timeseries::StatUtils<Num>::computeACF(logReturns, effectiveMaxLag);
-                unsigned int L_acf = mkc_timeseries::StatUtils<Num>::suggestStationaryBlockLengthFromACF(
-                    acf, returns.size(), minACFL, maxACFL); // Use passed-in min/max L
-
-                outputStream << "      (Using block length L=" << L_acf
-                             << " based on ACF [maxLag=" << effectiveMaxLag << ", maxL=" << maxACFL
-                             << "], n=" << returns.size() << " >= " << minSizeForACF << ")\n";
-                return static_cast<std::size_t>(L_acf);
+              // Very short: trust the median hold
+              L = std::max<std::size_t>(2, static_cast<std::size_t>(medianHold));
             }
-            catch (const std::exception& e)
+          else
             {
-                // Fallback to median holding period if ACF fails
-                std::size_t L = std::max<std::size_t>(2, static_cast<std::size_t>(medianHold));
-                // Add safety cap here too
-                L = std::min(L, returns.size() / 2);
-                L = std::max<std::size_t>(2, L);
+              // Medium-length: heuristic n^(1/3)
+              L = static_cast<std::size_t>(std::floor(std::pow(static_cast<double>(n), 1.0/3.0)));
+              // Blend with median hold if that's materially higher
+              L = std::max<std::size_t>(L, static_cast<std::size_t>(medianHold));
+            }
+          // Safety caps
+          L = std::min(L, n / 2);
+          L = std::max<std::size_t>(2, L);
+          outputStream << "      (Using block length L=" << L
+                       << " based on "
+                       << (n < 50 ? "median hold period" : "n^(1/3) heuristic")
+                       << ", n=" << n << " < " << minSizeForACF << ")\n";
+          return L;
+        }
+      else
+        {
+          // --- ACF-based path (n >= minSizeForACF) ---
+          // suggestStationaryBlockLength handles the log-return transformation,
+          // both ACF computations (signed raw + absolute), and the dependence-
+          // mass estimation internally.  returns[] contains decimal fractions
+          // (0.015 = +1.5%), which is the format the function expects.
+          // maxACFLag is capped to n-1 inside the function if necessary.
+          try
+            {
+              const unsigned int L_acf =
+                mkc_timeseries::StatUtils<Num>::suggestStationaryBlockLength(
+                  returns, maxACFLag, minACFL, maxACFL);
 
-                outputStream << "      Warning: ACF block length calculation failed ('" << e.what()
-                             << "'). Falling back to L=" << L << " based on median hold period.\n";
-                return L;
+              outputStream << "      (Using block length L=" << L_acf
+                           << " based on ACF dependence-mass estimator"
+                           << " [maxLag=" << maxACFLag << ", maxL=" << maxACFL
+                           << "], n=" << returns.size() << " >= " << minSizeForACF << ")\n";
+              return static_cast<std::size_t>(L_acf);
+            }
+          catch (const std::exception& e)
+            {
+              // Fallback to median holding period if ACF computation fails
+              std::size_t L = std::max<std::size_t>(2, static_cast<std::size_t>(medianHold));
+              L = std::min(L, returns.size() / 2);
+              L = std::max<std::size_t>(2, L);
+              outputStream << "      Warning: ACF block length calculation failed ('"
+                           << e.what()
+                           << "'). Falling back to L=" << L
+                           << " based on median hold period.\n";
+              return L;
             }
         }
     }


### PR DESCRIPTION
# Refactor: Stationary Bootstrap Block Length Selection
 
## Summary
 
This PR fixes a critical statistical bug in the ACF-based block length selection
used by the stationary bootstrap, replaces the fragile threshold-based algorithm
with a smooth dependence-mass estimator, consolidates the API into a single
function, and migrates all call sites to the new interface. Unit tests are updated
and extended throughout.
 
---
 
## Background: The Problem
 
The stationary block bootstrap requires a block length `L` that preserves the
autocorrelation structure of the input series. `L` was estimated by computing
the ACF and applying a significance threshold to identify the largest lag with
meaningful autocorrelation.
 
This approach had two compounding bugs:
 
**Bug 1 — Multiple testing inflated block lengths for white-noise data.**
The pointwise `2/√n` significance band has a ~1.2% false-positive rate per lag.
Testing 20 lags simultaneously gives a family-wise error rate (FWER) of:
 
```
FWER ≈ 1 − (1 − 0.012)^20 ≈ 22%
```
 
Roughly one run in five assigned a spuriously large block length to data with
no genuine autocorrelation. In practice, n=2982 and n=3230 daily ROC series
(both consistent with white noise) were assigned `L=12` — the maximum cap —
purely from noise exceedances.
 
**Bug 2 — Binary threshold caused discontinuous jumps.**
The largest-single-significant-lag rule meant that one ACF value moving 0.002
across a threshold boundary caused `L` to jump from 2 to 12 between runs on
slightly different sample windows (FXI 70% vs 65% in-sample split). The block
length had no intermediate states.
 
---
 
## Changes
 
### 1. `StatUtils.h` — `suggestStationaryBlockLengthFromACF` (interim fix)
 
**First applied:** Bonferroni-corrected threshold and consecutive-lag guard.
 
**Bonferroni threshold:**
 
```cpp
// Before: pointwise band
const double thresh = 2.0 / std::sqrt(static_cast<double>(nSamples));
 
// After: family-wise band controlling FWER at ≤5% across all M lags
const double z_bonf = std::sqrt(2.0) *
    boost::math::erf_inv(1.0 - 0.05 / static_cast<double>(M));
const double thresh = z_bonf / std::sqrt(static_cast<double>(nSamples));
```
 
**Consecutive-lag rule:**
 
```cpp
// Before: update on any single significant lag
for (std::size_t k = 1; k < acf.size(); ++k)
    if (std::fabs(acf[k].getAsDouble()) > thresh)
        k_star = k;
 
// After: require two adjacent lags to both exceed the band
for (std::size_t k = 1; k + 1 < acf.size(); ++k) {
    if (std::fabs(acf[k].getAsDouble())     > thresh &&
        std::fabs(acf[k+1].getAsDouble())   > thresh)
        k_star = k + 1;
}
```
 
The per-pair false-positive probability drops from ~1.2% to ~0.015%. These two
fixes reduced the FWER from ~22% to below 5% and eliminated the observed
spurious `L=12` results for white-noise daily ROC series.
 
**`boost::math::erf_inv` dependency:** `erfinv` is not in the C++ standard
library. GCC exposes it only as `::erfinv` (global namespace); MSVC does not
provide it at all. `boost::math::erf_inv` from `<boost/math/special_functions/erf.hpp>`
was chosen as it is already a project dependency, is tested across the full
domain, and handles platform edge cases. A portable hand-rolled `mkc_erfinv`
(Winitzki approximation + two Halley iterations, accurate to 5e-15) was also
developed as a fallback but was superseded by the Boost implementation.
 
---
 
### 2. `StatUtils.h` — New `suggestStationaryBlockLength` (final design)
 
The Bonferroni approach, while improved, still exhibited discontinuous jumps
when borderline ACF values straddled the threshold across nearby sample windows.
The root cause is that any binary significance test is inherently discontinuous.
 
The function was replaced with a **smooth dependence-mass estimator** that
eliminates the discontinuity entirely. The new function takes a decimal return
series directly and handles all internal transformations.
 
**Interface:**
 
```cpp
static unsigned
suggestStationaryBlockLength(const std::vector<Decimal>& decimalReturns,
                             std::size_t maxLag = 20,
                             unsigned    minL   = 2,
                             unsigned    maxL   = 12);
```
 
**Input format:** decimal fractions (`0.015` = +1.5%). The function applies
`log(1 + r)` internally. Do not pass percent values or pre-computed log-returns.
 
**Algorithm (for n ≥ 100):**
 
```
Step 1. Compute log-returns:    r_log[t] = log(1 + r[t])
Step 2. Compute abs log-returns: r_abs[t] = |r_log[t]|
Step 3. Compute both ACFs up to K = min(maxLag, n-1) lags
Step 4. Compute tapered Bartlett dependence masses:
          rawMass = Σ w_k · ρ_raw[k]    (SIGNED)
          absMass = Σ w_k · |ρ_abs[k]|  (unsigned)
          where w_k = 1 − k / (K + 1)
Step 5. Compute effective dependence horizons:
          tauRaw = max(1, 1 + 2·rawMass)
          tauAbs =        1 + 2·absMass
Step 6. L_raw = clamp(round(tauRaw), minL, maxL)
        L_abs = clamp(round(tauAbs), minL, maxL)
        L     = max(L_raw, L_abs)
```
 
**Why `tau = 1 + 2·Σρ(k)`:** This is the standard long-run variance inflation
factor for a stationary process. The factor 2 arises because the autocovariance
sum runs over both positive and negative lags by symmetry. It is not a tuning
parameter.
 
**Why signed ρ for the raw channel:** Mean-reverting series (e.g. SPY daily,
ρ[1] ≈ −0.03) produce negative `rawMass`, correctly reducing `tauRaw` toward 1.
Using `|ρ|` for this channel would incorrectly inflate the block length for a
mean-reverting series to the same value as a momentum series of equal ACF
magnitude, even though the two have opposite implications for bootstrap variance.
 
**Why `|ρ|` for the abs channel:** Volatility clustering always manifests as
positive ACF of `|r_t|`. Signed and absolute interpretations coincide here.
 
**Why `max(L_raw, L_abs)`:** Ensures the bootstrap preserves whichever
dependence structure is stronger. For daily equity series the volatility channel
(GARCH) typically dominates. For trending series the raw channel can dominate.
 
**Small-sample fallback (n < 100):** ACF estimates are too noisy below n=100.
The function returns `max(minL, min(maxL, floor(n^(1/3))))` — the standard
Politis & White (2004) heuristic.
 
**Stability verification:** For the FXI 70%→65% sample change that previously
caused `L` to flip from 12 to 2, the dependence-mass changes by only 1.5% and
`L` remains stable at 8 in both cases. The smooth estimator has no threshold
boundary that `L` can straddle.
 
---
 
### 3. `BootStrapIndicators.h` — `ComputeBootstrappedWidths`
 
The inline block length logic in `ComputeBootstrappedWidths` was rewritten in
three stages tracking the algorithm improvements above, and then simplified to
delegate entirely to `suggestStationaryBlockLength`.
 
**Final block length section:**
 
```cpp
// Convert percent-ROC to decimal returns. The log transformation,
// ACF computation, and dependence-mass estimation are all internal
// to suggestStationaryBlockLength.
std::vector<Decimal> decimalReturns;
const Decimal hundred = DecimalConstants<Decimal>::createDecimal("100.0");
for (const auto& roc_pct : rocVec)
    decimalReturns.push_back(roc_pct / hundred);
 
L = StatUtils<Decimal>::suggestStationaryBlockLength(
        decimalReturns, kMaxACFLag, kMinBlockL, kMaxBlockL);
```
 
The function body shrank from ~320 lines to ~100 lines. Removed: two local
lambdas (`computeRawDependenceMass`, `computeAbsDependenceMass`), four tau/mass
local variables, the explicit ACF computation calls, and all log/abs-return
vector construction.
 
**Observed impact on bootstrap outputs (n=3230 FXI dataset):**
 
| Metric | Old L=12 (wrong) | New L=8 (correct) |
|---|---|---|
| Effective bootstrap blocks | ~269 | ~1615 |
| Long profit target | 2.37% | 2.42% |
| Long stop loss | 2.91% | 2.84% |
| Long CI spread | 0.54% | 0.42% |
| Short profit target | 2.50% | 2.56% |
| Short stop loss | 2.70% | 2.64% |
| Short CI spread | 0.20% | 0.08% |
 
The tighter intervals are the correct result: with ~6× more effective independent
blocks the bootstrap has substantially lower variance.
 
---
 
### 4. `suggestStationaryBlockLengthFromACF` removed from the public API
 
All call sites migrated to `suggestStationaryBlockLength`. The function is
removed from `StatUtils.h`.
 
**Migrated call sites:**
 
| Location | Change |
|---|---|
| `BootStrapIndicators.h` / `ComputeBootstrappedWidths` | Delegated to `suggestStationaryBlockLength` as above |
| `RobustnessAnalyzer::suggestHalfLfromACF_` | Removed `computeACF` + old function; passes `rHalf` directly |
| `calculateBlockLengthAdaptive` | Removed `percentBarsToLogBars` + `computeACF` + old function; passes `returns` directly |
| `computeBlockSize` | Removed squared-return construction + `computeACF` + old function; converts percent ROC to decimal and passes directly |
| `BootstrapUpperBoundEstimator::computeUpperBound` | Removed `computeACF`; passes `loss01` binary indicator directly |
 
---
 
### 5. Unit tests — `StatUtilsTest.cpp`
 
#### Removed tests (for `suggestStationaryBlockLengthFromACF`)
 
The following tests were removed because they tested the old fragile algorithm
and its pre-computed ACF interface, which no longer exists:
 
- `StatUtils::suggestStationaryBlockLengthFromACF heuristic` — all four sections
- `StatUtils: end-to-end monthly->ACF->block length` — replaced by two tests below
#### New tests (for `suggestStationaryBlockLength`)
 
Seven new `TEST_CASE` blocks were added, covering:
 
**Input validation (5 sections):**
- Single observation and empty vector throw `std::invalid_argument`
- Two observations return `minL` without throwing
- Result always within `[minL, maxL]`
- Custom `minL` respected when dependence mass is negligible
- Custom `maxL` respected when dependence mass is very large
**Small-sample fallback (7 sections):**
- Exact `n^(1/3)` arithmetic verified for n = 2, 10, 30, 50, 75, 99
- Boundary at n=100 confirmed (ACF path activates at exactly 100)
**White-noise returns (2 sections):**
- Constant-magnitude alternating returns produce `L=minL=2`
- Constant returns (zero variance, `denom=0`) produce `L=minL=2`
**Mean-reverting series (2 sections):**
- Alternating series produces `L=minL=2` (signed raw channel clamps `tauRaw` to 1)
- Result stable for n=300 and n=500
**Volatility clustering (3 sections):**
- Regime-switching series gives `L > 2`
- Stronger clustering gives `L >= weaker clustering`
- Clustering series gives `L` strictly greater than white-noise series
**`maxLag` parameter (3 sections):**
- Shorter `maxLag` gives `L <= longer maxLag` for clustering series
- `maxLag=1` gives `minL` (single lag cannot accumulate sufficient mass)
- Very large `maxLag` does not throw (capped internally at n-1)
**Input format (1 section):**
- Decimal returns produce valid `L` in `[minL, maxL]`
#### Replaced test: `StatUtils: end-to-end monthly->ACF->block length`
 
The original test conflated two independent concerns. With the new function,
n=12 monthly returns take the small-sample fallback path and the ACF is never
computed, making the ACF shape assertions logically disconnected from the block
length result. Split into two honest tests:
 
**`StatUtils: monthly returns ACF shape`**
Tests `computeACF` correctness for a 12-month fabricated paired-return series.
Adds exact `Catch::Approx` assertions:
```
ρ[1] = 11/116 ≈  0.09482759
ρ[2] = −47/58 ≈ −0.81034483
ρ[4] = 18/29  ≈  0.62068966
```
(The old test used rounded approximations 0.095, -0.810, 0.621 which failed with
the `kACFAbsTol * 100 = 1e-4` margin.)
 
**`StatUtils: suggestStationaryBlockLength with monthly returns`**
Tests that the small-sample fallback produces `L=2` for n=12:
`floor(12^(1/3)) = floor(2.289) = 2 → clamped to [2, 6] → L=2`.
Explicitly documents that the ACF-based path is not entered for n < 100.
 
---
 
## Files Changed
 
| File | Change |
|---|---|
| `libs/statistics/StatUtils.h` | Added `suggestStationaryBlockLength`; removed `suggestStationaryBlockLengthFromACF`; removed `mkc_erfinv` (superseded by Boost) |
| `libs/timeseries/BootStrapIndicators.h` | `ComputeBootstrappedWidths` block length section replaced with delegation to `suggestStationaryBlockLength` |
| `src/palvalidator/analyzer/RobustnessAnalyzer.cpp` | `suggestHalfLfromACF_` migrated |
| `src/palvalidator/filtering/MetaStrategyAnalyzer.cpp` | `calculateBlockLengthAdaptive` migrated |
| `libs/timeseries/SyntheticTimeSeries.h` | `computeBlockSize` migrated |
| `libs/statistics/MetaLosingStreakBootstrapBound.h` | `computeUpperBound` migrated |
| `libs/statistics/test/StatUtilsTest.cpp` | Old ACF block length tests removed; 7 new `TEST_CASE` blocks added; monthly ACF test split into two |
 
---
 
## References
 
- Politis, D.N., & Romano, J.P. (1994). "The Stationary Bootstrap."
  *Journal of the American Statistical Association*, 89(428), 1303–1313.
- Politis, D.N., & White, H. (2004). "Automatic Block-Length Selection for the
  Dependent Bootstrap." *Econometric Reviews*, 23(1), 53–70.
- Efron, B. (1987). "Better Bootstrap Confidence Intervals."
  *Journal of the American Statistical Association*, 82(397), 171–185.