### PR TITLE
Log autocorrelation when computing profit targets/stops

### DIFF
--- a/libs/timeseries/BootStrapIndicators.h
+++ b/libs/timeseries/BootStrapIndicators.h
@@ -542,11 +542,11 @@ namespace mkc_timeseries
           for (const auto& roc_pct : rocVec)
             decimalReturns.push_back(roc_pct / hundred);
  
-          L = StatUtils<Decimal>::suggestStationaryBlockLength(
-                  decimalReturns,
-                  kMaxACFLag,
-                  kMinBlockL,
-                  kMaxBlockL);
+          L = StatUtils<Decimal>::suggestStationaryBlockLength(decimalReturns,
+							       kMaxACFLag,
+							       kMinBlockL,
+							       kMaxBlockL,
+							       &std::cout);
  
           std::cout << "  ACF-suggested block length: L=" << L << "\n";
         }


### PR DESCRIPTION
# Enable ACF Diagnostic Logging in `ComputeBootstrappedWidths`
 
## Summary
 
`ComputeBootstrappedWidths` now passes `&std::cout` to
`suggestStationaryBlockLength` so that the ACF diagnostic output — raw and
absolute log-return ACF values, dependence masses, tau values, and the
suggested block length — is printed to the console when the function runs.
 
## Change
 
```cpp
// Before — no debug output from suggestStationaryBlockLength
L = StatUtils<Decimal>::suggestStationaryBlockLength(
        decimalReturns, kMaxACFLag, kMinBlockL, kMaxBlockL);
 
// After — ACF diagnostics printed to stdout
L = StatUtils<Decimal>::suggestStationaryBlockLength(
        decimalReturns, kMaxACFLag, kMinBlockL, kMaxBlockL,
        &std::cout);
```
 
## What is now printed
 
For each call with `n >= 100` the following is written to stdout:
 
```
[suggestStationaryBlockLength] n=3449, maxLag=20
  Raw log-return ACF:
    rho_raw[0] = 1.00000000
    rho_raw[1] = -0.13678718
    ...
  Absolute log-return ACF:
    rho_abs[0] = 1.00000000
    rho_abs[1] = 0.34560115
    ...
  Raw dependence mass (signed) = -0.402534
  Abs dependence mass (|rho|)  = 3.38916
  tau_raw = max(1, 1 + 2*-0.402534) = 1.00  ->  L_raw = 2
  tau_abs = 1 + 2*3.38916 = 7.77832         ->  L_abs = 8
  Final L = max(2, 8) = 8
```
 
Nothing is printed for the small-sample fallback path (`n < 100`) since there
are no ACF values to show.
 
## Files Changed
 
| File | Change |
|---|---|
| `libs/timeseries/BootStrapIndicators.h` | Pass `&std::cout` as the `debugOs` argument to `suggestStationaryBlockLength` in `ComputeBootstrappedWidths` |