### PR TITLE
Palvalidator version 2.5.2 notes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(PalValidator VERSION 2.5.1 LANGUAGES CXX)
+project(PalValidator VERSION 2.5.2 LANGUAGES CXX)
 
 # Extract Git information for version header
 find_package(Git QUIET)


### PR DESCRIPTION
# Release Notes
 
This release bundles a major statistical correctness fix to the stationary
bootstrap block length selection, an internal refactor and documentation pass
over the new algorithm, a set of `MetaStrategyAnalyzer` correctness fixes
surfaced by code review, and diagnostic logging for profit target / stop
computations.
 
**Included pull requests:** [#308](https://github.com/testhound/palvalidator/pull/308),
[#309](https://github.com/testhound/palvalidator/pull/309),
[#310](https://github.com/testhound/palvalidator/pull/310),
[#311](https://github.com/testhound/palvalidator/pull/311)
 
---
 
## Highlights
 
- **Bug fix (critical):** Replaced the ACF threshold-based stationary bootstrap
  block length algorithm with a smooth dependence-mass estimator, eliminating
  a ~22% family-wise false-positive rate that was assigning maximum block
  lengths to white-noise-like series.
- **Bug fix (medium-high):** Corrected an upward-biased median in the
  `MetaStrategyAnalyzer` multi-split validation gate for even split counts.
- **Refactor:** Extracted the new block length algorithm into named, documented,
  independently testable helpers and added a streamable debug output channel.
- **Observability:** Profit target / stop computations now emit full ACF
  diagnostics to stdout, including raw and absolute log-return ACFs, dependence
  masses, tau values, and the suggested block length.
---
 
## Stationary Bootstrap Block Length — Algorithm Fix ([#308](https://github.com/testhound/palvalidator/pull/308))
 
The stationary block bootstrap requires a block length `L` that preserves the
autocorrelation structure of the input series. The previous implementation
estimated `L` by applying a pointwise `2/√n` significance threshold to the ACF
and selecting the largest significant lag. Two compounding bugs were fixed:
 
**Multiple testing inflated block lengths for white-noise data.** The pointwise
band has a ~1.2% false-positive rate per lag; testing 20 lags simultaneously
gave a family-wise error rate of ~22%. In production, n=2982 and n=3230 daily
ROC series consistent with white noise were being assigned `L=12` (the cap)
purely from noise exceedances.
 
**Binary threshold caused discontinuous jumps.** One ACF value moving 0.002
across the threshold could cause `L` to jump from 2 to 12 between runs on
slightly different sample windows (e.g. the FXI 70% vs 65% in-sample split).
 
### Fix
 
A new public function replaces the old one:
 
```cpp
static unsigned
suggestStationaryBlockLength(const std::vector<Decimal>& decimalReturns,
                             std::size_t maxLag = 20,
                             unsigned    minL   = 2,
                             unsigned    maxL   = 12);
```
 
It computes two tapered Bartlett dependence masses — one from the signed raw
log-return ACF (captures trend/mean-reversion), one from the absolute log-return
ACF (captures volatility clustering) — converts each to an effective dependence
horizon `τ = 1 + 2·mass`, clamps to `[minL, maxL]`, and takes the maximum.
For `n < 100` it falls back to the standard Politis–White `floor(cbrt(n))`
heuristic.
 
Using signed ρ for the raw channel is deliberate: a mean-reverting series
(ρ[1] < 0) produces negative mass, correctly reducing τ toward 1 rather than
inflating the block length as `|ρ|` would.
 
### Migration
 
`suggestStationaryBlockLengthFromACF` has been removed from the public API.
All call sites were migrated to the new function:
 
| Location | Migration |
| --- | --- |
| `BootStrapIndicators.h` / `ComputeBootstrappedWidths` | Delegates to `suggestStationaryBlockLength` |
| `RobustnessAnalyzer::suggestHalfLfromACF_` | Passes `rHalf` directly |
| `calculateBlockLengthAdaptive` | Passes `returns` directly |
| `computeBlockSize` | Converts percent ROC to decimal and passes directly |
| `BootstrapUpperBoundEstimator::computeUpperBound` | Passes `loss01` indicator directly |
 
A new `boost::math::erf_inv` dependency was used for the interim Bonferroni
fix; the portable `mkc_erfinv` helper that was developed as a fallback was
removed when the threshold approach was superseded.
 
### Observed impact (n=3230 FXI dataset)
 
| Metric | Old L=12 (wrong) | New L=8 (correct) |
| --- | --- | --- |
| Effective bootstrap blocks | ~269 | ~1615 |
| Long profit target | 2.37% | 2.42% |
| Long stop loss | 2.91% | 2.84% |
| Long CI spread | 0.54% | 0.42% |
| Short profit target | 2.50% | 2.56% |
| Short stop loss | 2.70% | 2.64% |
| Short CI spread | 0.20% | 0.08% |
 
The tighter intervals are the correct result: with ~6× more effective
independent blocks the bootstrap has substantially lower variance.
 
### Tests
 
Old tests for `suggestStationaryBlockLengthFromACF` were removed and replaced
with seven new `TEST_CASE` blocks covering input validation, small-sample
fallback, white-noise behaviour, mean-reverting series, volatility clustering,
`maxLag` parameter behaviour, and input format. The conflated
"monthly → ACF → block length" test was split into two honest tests.
 
---
 
## Stationary Bootstrap Block Length — Refactor & Docs ([#309](https://github.com/testhound/palvalidator/pull/309))
 
No behavioural changes. The new algorithm was extracted into three named,
independently testable helpers with full documentation:
 
- `computeSmallSampleBlockLength(n, minL, maxL)` — the `floor(cbrt(n))`
  fallback, using `std::cbrt` rather than `std::pow(x, 1.0/3.0)` because the
  latter returns `3.999…` for `n=64` and causes `floor` to produce 3 instead
  of 4. The unit test documents this with an explicit n=64 case.
- `computeSignedTaperedMass(acf)` — signed tapered Bartlett mass used for the
  raw-return channel. K is derived from `acf.size() - 1`, not from the
  caller's `maxLag`, so the taper reaches zero correctly when `computeACF`
  truncates to fewer lags than requested.
- `computeAbsTaperedMass(acf)` — absolute tapered Bartlett mass used for the
  absolute-return channel. `fabs` also guards against tiny negative
  finite-sample ACF estimates pulling the mass below zero.
### New debug output parameter
 
`suggestStationaryBlockLength` gained an optional trailing `std::ostream*`
parameter:
 
```cpp
static unsigned
suggestStationaryBlockLength(const std::vector<Decimal>& decimalReturns,
                             std::size_t   maxLag  = 20,
                             unsigned      minL    = 2,
                             unsigned      maxL    = 12,
                             std::ostream* debugOs = nullptr);
```
 
`nullptr` (the default) produces zero overhead — all existing call sites
compile unchanged. Passing `&std::cout`, a log-file stream, or a
`std::ostringstream` routes the ACF diagnostics accordingly. This mirrors the
pattern already used by `calculateBlockLengthAdaptive` elsewhere in the
codebase.
 
### Documentation
 
The `suggestStationaryBlockLength` doc comment was rewritten with three new
sections before the step-by-step algorithm: the intuitive volatility-clustering
story, the dependence-horizon framing (IID / momentum / mean-reversion), and a
"direction vs magnitude" explanation of the two-channel design with a worked
FXI example. Each helper has its own doc comment, and a standalone
`BACKGROUND: Tapered Bartlett Dependence Mass` block covers the algorithm
end-to-end for maintainers without a spectral-analysis background.
 
### Tests
 
Three new `TEST_CASE` blocks (25 sections total) cover the new helpers:
perfect-cube `cbrt` correctness, minL/maxL clamping, signed vs absolute
divergence for negative lags, the taper vs naive-sum inequality, and the
non-negativity invariant of the absolute mass.
 
---
 
## MetaStrategyAnalyzer Bug Fixes ([#310](https://github.com/testhound/palvalidator/pull/310))
 
Four correctness issues surfaced by code review were fixed. No algorithms or
public signatures changed.
 
**Upward-biased median in the multi-split gate (medium-high).** Both
`runMultiSplitGate` overloads computed the median slice lower bound as
`lbs[lbs.size() / 2]`, which for even `K` selects the upper-middle element.
For `K=2` — common when OOS history is short — this made the "median" actually
the maximum of the two slices, biasing the gate upward. Fixed to match the
correct even-count handling already used in `runRegimeMixGate`.
 
**"Best Performance" report included non-passers (low).** Both
`outputPyramidComparison` and `writeComprehensivePerformanceReport` selected
the best pyramid level from all results, including configurations that failed
validation gates — contradicting `selectBestPassingConfiguration`, the
authoritative selection path. Both sites now filter to passing configurations
first; if none passed, no "Best Performance" recommendation is printed.
 
**Hardcoded cost message after auto-tuning (low).** `outputPyramidComparison`
always printed a fixed "0.10% slippage/spread per side" message even when
`determineEffectiveSlippageFloor` had auto-tuned the floor to 0 bps or 2 bps
for micro-target strategies. The cost summary now reflects the actual
`mEffectiveSlippageFloor`.
 
**Removed dead `reportFinalResults` method (cleanup).** Declared and
implemented but never called — the unified pipeline uses
`selectBestPassingConfiguration` with direct member assignment instead.
Removed from both the header and the source file.
 
---
 
## ACF Diagnostic Logging for Profit Target / Stop Computations ([#311](https://github.com/testhound/palvalidator/pull/311))
 
`ComputeBootstrappedWidths` in `BootStrapIndicators.h` now passes `&std::cout`
as the new `debugOs` argument to `suggestStationaryBlockLength`, so the ACF
diagnostics introduced in #309 are written to the console whenever profit
targets / stops are computed.
 
For each call with `n >= 100` the output includes the raw and absolute
log-return ACF values, the raw (signed) and absolute (`|ρ|`) dependence
masses, both `τ` values with the `L` derived from each, and the final
`L = max(L_raw, L_abs)`. The small-sample fallback path prints nothing
because there are no ACF values to show.
 
---
 
## Files Changed (across all four PRs)
 
- `libs/statistics/StatUtils.h`
- `libs/statistics/test/StatUtilsTest.cpp`
- `libs/statistics/MetaLosingStreakBootstrapBound.h`
- `libs/timeseries/BootStrapIndicators.h`
- `libs/timeseries/SyntheticTimeSeries.h`
- `src/palvalidator/analyzer/RobustnessAnalyzer.cpp`
- `src/palvalidator/filtering/MetaStrategyAnalyzer.cpp`
- `src/palvalidator/filtering/MetaStrategyAnalyzer.h`
## References
 
- Politis, D.N., & Romano, J.P. (1994). "The Stationary Bootstrap."
  *Journal of the American Statistical Association*, 89(428), 1303–1313.
- Politis, D.N., & White, H. (2004). "Automatic Block-Length Selection for the
  Dependent Bootstrap." *Econometric Reviews*, 23(1), 53–70.
- Efron, B. (1987). "Better Bootstrap Confidence Intervals."
  *Journal of the American Statistical Association*, 82(397), 171–185.