### PR TITLE
Refactor the BCa bootstrap to fix spurious rejections observed at small sample sizes

### DIFF
--- a/libs/statistics/AutoBootstrapConfiguration.h
+++ b/libs/statistics/AutoBootstrapConfiguration.h
@@ -149,6 +149,44 @@ namespace AutoBootstrapConfiguration
   /// exclude every parameter combination that can trigger a near-zero denominator.
   constexpr double kBcaTransformNonMonotonePenalty = 0.5;
 
+  /// Soft stability penalty added to a BCa candidate whose data-adaptive
+  /// acceleration reliability flag is false — i.e.
+  /// BCaBootStrap::getAccelerationReliability().isReliable() == false.
+  ///
+  /// Under the Tier-1/2 rule in JackknifeInfluence::compute() (see
+  /// BiasCorrectedBootstrap.h) the flag only goes false when BOTH hold:
+  ///   (a) |â| ≥ kAccelMaterialThreshold — the BCa correction is
+  ///       numerically non-trivial, AND
+  ///   (b) the leave-one-out sensitivity test fails — i.e. removing the
+  ///       top-|d³| jackknife observation changes â by more than
+  ///       kSensitivityThreshold relative.
+  /// In that regime â is being driven by a single observation and the
+  /// correction is less trustworthy than a clean BCa run — but the
+  /// interval remains computable and valid, so this is NOT a hard gate.
+  ///
+  /// Magnitude rationale: set equal to kBcaTransformNonMonotonePenalty (0.5).
+  /// Both diagnostics represent "BCa's correction machinery has an issue
+  /// but the interval is still meaningful," so parity is the defensible
+  /// default. At kRefStability=0.25 the raw penalty of 0.5 normalises to
+  /// 2.0 — 8× the reference — which makes a soft-flagged BCa candidate
+  /// noticeably less competitive than a clean BCa run without eliminating
+  /// it when no better-scoring alternative exists.
+  ///
+  /// This constant replaces the pre-Tier-3 hard rejection in
+  /// CandidateGateKeeper::isBcaCandidateValid(), which was producing
+  /// spurious disqualifications at small n (≈18) for small-|â| data
+  /// because the underlying cubic-share metric concentrates naturally on
+  /// small samples. Tier-1/2 narrowed the flag to actionable cases; this
+  /// constant then lets the scoring pipeline weigh the flag proportionally
+  /// rather than veto outright.
+  ///
+  /// Tuning: if BCa keeps winning in your data when the flag fires and
+  /// you'd prefer MOutOfN to win in those cases, increase this value.
+  /// If BCa never wins when flagged and you think it should sometimes,
+  /// decrease it. Empirical tuning is recommended over theoretical
+  /// calibration.
+  constexpr double kBcaAccelUnreliablePenalty = 0.5;
+
   // Floating-point tie tolerance scale used in ImprovedTournamentSelector
   constexpr double kRelativeTieEpsilonScale = 1e-10;
 

--- a/libs/statistics/AutoBootstrapScoring.h
+++ b/libs/statistics/AutoBootstrapScoring.h
@@ -524,16 +524,25 @@ namespace palvalidator
           if (candidate.getN() < AutoBootstrapConfiguration::kBcaMinSampleSize)
             return false;
 
-	  // Data-adaptive acceleration reliability gate.
-	  // Supplements the kBcaMinSampleSize floor with a data-driven check:
-	  // BCaBootStrap::getAccelerationReliability() reports whether any single
-	  // LOO observation contributed more than 50% of |Σd³|. When it did, â
-	  // reflects that observation's artifact rather than a distributional
-	  // property — regardless of â's magnitude, z0, or skew_boot.
-	  // This correctly handles n=9 strategies with diffuse influence (pass)
-	  // and n=25 strategies with one dominant outlier trade (fail).
-	  if (!candidate.getAccelIsReliable())
-	    return false;
+	  // NOTE: getAccelIsReliable() is NO LONGER a hard gate here. Under
+	  // the Tier-1/2 reliability rule (see BiasCorrectedBootstrap.h), the
+	  // flag only reports false when BOTH of these hold:
+	  //   (a) |â| is material — i.e. |â| ≥ kAccelMaterialThreshold, so
+	  //       the BCa correction is numerically non-trivial, and
+	  //   (b) the leave-one-out sensitivity test fails — i.e. removing
+	  //       the top-|d³| observation changes â by more than
+	  //       kSensitivityThreshold relative.
+	  // That combination degrades BCa's trustworthiness but does not
+	  // invalidate the interval. Unreliability is now applied as a soft
+	  // stability penalty in AutoBootstrapSelector::summarizeBCa() (see
+	  // the kBcaAccelUnreliablePenalty block there). BCa then competes
+	  // fairly against MOutOfN in scoring rather than being disqualified
+	  // outright — which was producing spurious rejections of small-|â|
+	  // cases at n≈18 (see the BiasCorrectedBootstrap.h comment history).
+	  //
+	  // The getAccelIsReliable() flag continues to feed into
+	  // SelectionDiagnostics via Candidate::getAccelIsReliable() and into
+	  // AutoBootstrapSelector::analyzeBcaRejection() for logging.
 
           // High bootstrap skewness renders the Edgeworth expansion on which
           // BCa is based unreliable. This is a hard gate, not a soft penalty:

--- a/libs/statistics/AutoBootstrapSelector.h
+++ b/libs/statistics/AutoBootstrapSelector.h
@@ -796,8 +796,12 @@ namespace palvalidator
 	    if (candidate.getN() < AutoBootstrapConfiguration::kBcaMinSampleSize)
 	      mask |= CandidateReject::BcaMinSampleSize;
 
-	    if (!candidate.getAccelIsReliable())
-	      mask |= CandidateReject::BcaAccelUnreliable;
+	    // NOTE: !getAccelIsReliable() no longer sets a rejection mask bit.
+	    // Under the Tier-1/2 rule it's a soft signal applied as a stability
+	    // penalty in summarizeBCa() (kBcaAccelUnreliablePenalty); a BCa
+	    // candidate whose flag is false can still win. The
+	    // CandidateReject::BcaAccelUnreliable enum value is retained for
+	    // backward compatibility but is no longer raised here.
 
 	    if (!candidate.getBcaTransformMonotone())
 	      mask |= CandidateReject::BcaTransformNonMonotone;
@@ -1362,6 +1366,39 @@ namespace palvalidator
 	              << " denom_hi=" << transform_stability.getDenomHi() << ")\n";
 	}
 
+	// ACCELERATION UNRELIABILITY SOFT PENALTY
+	// getAccelIsReliable()==false means the Tier-2 leave-one-out sensitivity
+	// test on â failed while â was material (Tier-1 materiality check in
+	// JackknifeInfluence::compute()). BCa remains computable and the interval
+	// remains valid, but â is being driven by a single observation and the
+	// correction is less trustworthy than a clean BCa run. Apply a soft
+	// penalty so BCa competes fairly against MOutOfN in scoring rather than
+	// being summarily disqualified by CandidateGateKeeper.
+	//
+	// This replaces the pre-Tier-3 behaviour where
+	// CandidateGateKeeper::isBcaCandidateValid() hard-rejected on
+	// !accelIsReliable — a gate that was producing spurious rejections at
+	// small n (≈18) for small-|â| data, because the underlying cubic-share
+	// metric naturally concentrates on small samples. The Tier-1/2 rule makes
+	// the flag itself much more targeted; this change lets the scoring pipeline
+	// take the flag into account proportionally rather than as a veto.
+	if (!accel_is_reliable)
+	{
+	    stability_penalty +=
+	        AutoBootstrapConfiguration::kBcaAccelUnreliablePenalty;
+	    if (os)
+	    {
+	        const auto& reliability = bca.getAccelerationReliability();
+	        (*os) << "[BCa] Acceleration-unreliable penalty applied: "
+	              << AutoBootstrapConfiguration::kBcaAccelUnreliablePenalty
+	              << " (accel="         << reliability.getAccel()
+	              << "  accelWithoutTop=" << reliability.getAccelWithoutTop()
+	              << "  relChange="     << reliability.getAccelRelativeChange()
+	              << "  maxFrac="       << reliability.getMaxInfluenceFraction()
+	              << ")\n";
+	    }
+	}
+
 	// algorithmIsReliable: AND-gate over both BCa-specific failure modes.
 	// accel_is_reliable   — jackknife acceleration not dominated by a single outlier.
 	// transform_monotone  — BCa percentile mapping preserved order (α₁ ≤ α₂).
@@ -1720,7 +1757,14 @@ namespace palvalidator
             rejected_for_instability = true;
           }
 
-	  // Data-adaptive acceleration reliability gate
+	  // Data-adaptive acceleration reliability: no longer a hard gate;
+	  // treated as instability for diagnostic purposes, consistent with
+	  // the non-monotone transform handling below. The soft penalty in
+	  // summarizeBCa() (kBcaAccelUnreliablePenalty) already down-weighted
+	  // this candidate during scoring; this flag surfaces the event in
+	  // SelectionDiagnostics::wasBCaRejectedForInstability() when BCa
+	  // lost to another method, so users can see that an accel-unreliable
+	  // signal contributed to the loss.
 	  if (!bca.getAccelIsReliable())
 	    {
 	      rejected_for_instability = true;

--- a/libs/statistics/BiasCorrectedBootstrap.h
+++ b/libs/statistics/BiasCorrectedBootstrap.h
@@ -590,40 +590,58 @@ struct IIDResampler
    *
    *   â = Σd³ / (6 × (Σd²)^1.5)
    *
-   * where d_i = jk_avg − jk_i. This class diagnoses two distinct failure modes
-   * in that estimate, which must be kept separate:
+   * where d_i = jk_avg − jk_i. This class diagnoses stability of that estimate
+   * and exposes several related diagnostics:
    *
    * -----------------------------------------------------------------------
-   * FAILURE MODE 1 — Single-point dominance (isReliable)
+   * AUTHORITATIVE RELIABILITY DECISION — isReliable()
    * -----------------------------------------------------------------------
-   * If one observation contributes more than kDominanceThreshold of the
-   * TOTAL ABSOLUTE cubic influence Σ|d³|, then â is being driven by that
-   * single data point rather than by a genuine distributional property.
+   * The reliability flag is determined by a two-stage rule:
    *
-   *   maxInfluenceFraction = max_i ( |d_i³| / Σ_j |d_j³| )
+   *   1. MATERIALITY SHORT-CIRCUIT
+   *      If |â| < kAccelMaterialThreshold, the BCa correction applied by
+   *      â is numerically negligible (the adjusted-percentile denominator
+   *      1 − â·(z₀ + z_α) stays within roughly [0.84, 1.16] at 95% CI).
+   *      In this regime BCa is essentially equivalent to plain BC, so the
+   *      acceleration cannot meaningfully destabilise the interval
+   *      regardless of any dominance pathology. isReliable() returns true.
    *
-   * NOTE: the denominator is Σ|d³|, NOT |Σd³|. Using the signed net sum as
-   * denominator causes fractions to explode when positive and negative cubic
-   * terms partially cancel — making the metric fire spuriously on healthy
-   * mixed-return data. The absolute sum is the correct normaliser.
+   *   2. LEAVE-ONE-OUT SENSITIVITY TEST
+   *      If |â| is material, reliability is determined by the direct
+   *      stability test: recompute â with the top-|d³| observation removed
+   *      and compare to â on the full sample:
+   *
+   *        relChange = |â_full − â_minus_top| / max(|â_full|, ε)
+   *
+   *      isReliable() returns true iff relChange ≤ kSensitivityThreshold.
+   *      This test directly measures "is â driven by one observation?"
+   *      rather than inferring it from the cubic-share proxy, and it
+   *      auto-scales with both n and |â|.
+   *
+   * Rationale for the two-stage rule: a fixed cubic-share threshold
+   * (e.g. kDominanceThreshold = 0.5) is known to produce 16–49% Type-I
+   * error at n=18 on well-behaved i.i.d. data, because cubic amplification
+   * of order-statistic fluctuations concentrates naturally at small n.
+   * Gating on |â| eliminates the spurious rejections whose underlying â
+   * would not actually move the interval, and the sensitivity test
+   * measures the real quantity of interest when â is large enough to
+   * matter.
    *
    * -----------------------------------------------------------------------
-   * FAILURE MODE 2 — Sign cancellation (isCancellationHeavy)
+   * RELATED DIAGNOSTICS (not folded into isReliable)
    * -----------------------------------------------------------------------
-   * Even when no single observation dominates, the signed cubic terms can
-   * largely cancel, leaving â precariously balanced near zero. The
-   * cancellation ratio measures how far the signed sum has been eroded:
+   * Dominance:      maxInfluenceFraction = max_i(|d_i³|) / Σ|d_j³|
+   *                 Retained as an observability-only metric. Note the
+   *                 denominator is Σ|d³|, NOT |Σd³|: using the signed net
+   *                 sum would cause fractions to inflate under cancellation.
+   *                 getMaxInfluenceFraction(), getMaxInfluenceIndex(),
+   *                 getNDominant() expose the raw values for logging.
    *
-   *   cancellationRatio = |Σd³| / Σ|d³|
-   *
-   * Near 1.0 → cubic terms mostly agree in sign (well-conditioned numerator).
-   * Near 0.0 → large positive and negative terms cancel (precariously balanced).
-   *
-   * When cancellationRatio is near zero, â is numerically near zero and BCa
-   * degenerates to plain BC. This is generally acceptable behaviour — the
-   * interval is not incorrect, just less corrected. isCancellationHeavy()
-   * exposes this as a diagnostic so callers can inspect it, but it is NOT
-   * folded into isReliable() since degeneration to BC is not a hard failure.
+   * Cancellation:   cancellationRatio = |Σd³| / Σ|d³|
+   *                 Near 1.0 → cubic terms agree in sign (well-conditioned).
+   *                 Near 0.0 → large opposite-sign terms cancel, â ≈ 0 and
+   *                 BCa degenerates to plain BC. isCancellationHeavy() flags
+   *                 this as a soft warning; it is NOT a hard failure.
    *
    * -----------------------------------------------------------------------
    * There is no default constructor. Every instance is produced by
@@ -633,60 +651,130 @@ struct IIDResampler
   class AccelerationReliability
   {
   public:
-    /// Fraction of Σ|d³| above which a single observation is considered dominant.
-    /// Uses the total absolute cubic sum as denominator, not the signed net sum,
-    /// so near-cancellation among balanced observations does not inflate fractions.
+    /// Legacy dominance threshold. RETAINED for the diagnostic-only
+    /// getNDominant() counter and any external code that inspects it.
+    /// No longer used by isReliable(); the leave-one-out sensitivity test
+    /// (kSensitivityThreshold) is the authoritative criterion.
     static constexpr double kDominanceThreshold = 0.5;
 
     /// Cancellation ratio below which the signed cubic sum is considered
     /// heavily cancelled: cancellationRatio = |Σd³| / Σ|d³|.
     static constexpr double kCancellationThreshold = 0.1;
 
+    /// Materiality threshold for |â|. Below this, the BCa correction applied
+    /// by â is numerically negligible relative to plain BC, so any dominance
+    /// or sensitivity finding is not actionable. isReliable() short-circuits
+    /// to true whenever |â| < kAccelMaterialThreshold.
+    ///
+    /// Derivation: at |â| = 0.10, the adjusted-percentile denominator
+    /// 1 − â·(z₀ + z_α) at 95% CI (z_α ≈ ±1.96, small z₀) stays within
+    /// [0.84, 1.16], corresponding to a <3 percentage-point shift in the
+    /// adjusted CDF — below the second-order accuracy floor BCa is trying
+    /// to achieve. Well below Efron's |â| > 0.25 Edgeworth-expansion concern.
+    static constexpr double kAccelMaterialThreshold = 0.10;
+
+    /// Relative-change threshold for the leave-one-out sensitivity test.
+    /// When |â| is material, â is considered driven by a single observation
+    /// iff |â_full − â_minus_top| / max(|â_full|, ε) exceeds this value.
+    ///
+    /// Rationale: removing ~50% of the cubic share (the old dominance
+    /// threshold) typically changes â by ~40%, so 0.30 is comparable in
+    /// strictness but more directly interpretable. Callers may tighten or
+    /// loosen this after validation against their actual distributions.
+    static constexpr double kSensitivityThreshold = 0.30;
+
     /**
      * @brief Constructs a fully-computed reliability result.
      *
-     * @param isReliable           True if no single observation exceeds kDominanceThreshold
-     *                             of the total absolute cubic influence Σ|d³|.
-     * @param maxInfluenceFraction max_i( |d_i³| / Σ|d_j³| ) — fraction of total absolute
-     *                             cubic influence from the most influential observation.
-     * @param maxInfluenceIndex    Index of the observation with maxInfluenceFraction.
-     * @param nDominant            Number of observations whose fraction exceeds kDominanceThreshold.
-     * @param cancellationRatio    |Σd³| / Σ|d³|. Near 1 = well-conditioned, near 0 = heavy
-     *                             cancellation. Set to 1.0 when Σ|d³| is negligible.
+     * @param isReliable            Authoritative reliability flag: true iff
+     *                              |â| < kAccelMaterialThreshold OR the
+     *                              leave-one-out sensitivity test passes.
+     * @param maxInfluenceFraction  max_i( |d_i³| / Σ|d_j³| ) — diagnostic only.
+     * @param maxInfluenceIndex     Index of the top-|d³| observation
+     *                              (the one removed in the sensitivity test).
+     * @param nDominant             Number of observations whose fraction exceeds
+     *                              kDominanceThreshold. Diagnostic only.
+     * @param cancellationRatio     |Σd³| / Σ|d³|. Near 1 = well-conditioned,
+     *                              near 0 = heavy cancellation.
+     * @param accel                 â computed from the full jackknife.
+     * @param accelWithoutTop       â recomputed with the top-|d³| observation
+     *                              removed (perturbed jackknife).
+     * @param accelRelativeChange   |accel − accelWithoutTop| / max(|accel|, ε).
+     *                              ∞ when either value is non-finite.
+     * @param accelMaterial         |accel| ≥ kAccelMaterialThreshold.
+     * @param sensitivityOk         accelRelativeChange ≤ kSensitivityThreshold.
      */
     AccelerationReliability(bool        isReliable,
                             double      maxInfluenceFraction,
                             std::size_t maxInfluenceIndex,
                             std::size_t nDominant,
-                            double      cancellationRatio)
+                            double      cancellationRatio,
+                            double      accel,
+                            double      accelWithoutTop,
+                            double      accelRelativeChange,
+                            bool        accelMaterial,
+                            bool        sensitivityOk)
       : m_isReliable(isReliable),
         m_maxInfluenceFraction(maxInfluenceFraction),
         m_maxInfluenceIndex(maxInfluenceIndex),
         m_nDominant(nDominant),
-        m_cancellationRatio(cancellationRatio)
+        m_cancellationRatio(cancellationRatio),
+        m_accel(accel),
+        m_accelWithoutTop(accelWithoutTop),
+        m_accelRelativeChange(accelRelativeChange),
+        m_accelMaterial(accelMaterial),
+        m_sensitivityOk(sensitivityOk)
     {}
 
-    /// True if no single jackknife observation dominates the total absolute
-    /// cubic influence. This is one diagnostic among several — see also
-    /// the z0, acceleration, and skewness gates in AutoBootstrapSelector.
+    /// Authoritative reliability flag. True iff:
+    ///   (|â| < kAccelMaterialThreshold)   — BCa correction is negligible
+    ///   OR
+    ///   (relative change under top-observation removal ≤ kSensitivityThreshold)
+    ///
+    /// See the class comment for the rationale behind the two-stage rule.
     bool        isReliable()              const { return m_isReliable; }
 
     /// Largest fraction of Σ|d³| contributed by any single LOO observation.
-    /// Range [0, 1] when no cancellation is present; can exceed 1.0 only if
-    /// computed incorrectly with the signed net sum — this implementation uses
-    /// the absolute sum so fractions are always in [0, 1].
+    /// Diagnostic only — no longer a gate. Range [0, 1].
     double      getMaxInfluenceFraction() const { return m_maxInfluenceFraction; }
 
     /// Index (into the original sample) of the most influential LOO observation.
+    /// This is the observation removed by the sensitivity test.
     std::size_t getMaxInfluenceIndex()    const { return m_maxInfluenceIndex; }
 
     /// Number of observations whose absolute cubic fraction exceeds kDominanceThreshold.
+    /// Diagnostic only.
     std::size_t getNDominant()            const { return m_nDominant; }
 
     /// |Σd³| / Σ|d³|. Near 1.0: cubic terms agree in sign (well-conditioned).
-    /// Near 0.0: strong cancellation among opposite-sign contributions.
-    /// Always in [0, 1]. Set to 1.0 when Σ|d³| is negligible (no cubic signal).
+    /// Near 0.0: strong cancellation. Always in [0, 1]. Set to 1.0 when Σ|d³|
+    /// is negligible (no cubic signal).
     double      getCancellationRatio()    const { return m_cancellationRatio; }
+
+    /// BCa acceleration â from the full jackknife. Numerically identical (up
+    /// to floating-point rounding) to BCaBootStrap::getAcceleration().
+    double      getAccel()                const { return m_accel; }
+
+    /// BCa acceleration â recomputed with the top-|d³| observation removed.
+    /// The reliability decision (when |â| is material) is based on how far
+    /// this has drifted from getAccel().
+    double      getAccelWithoutTop()      const { return m_accelWithoutTop; }
+
+    /// Relative change in â when the top-influence observation is removed:
+    ///   |accel − accelWithoutTop| / max(|accel|, ε).
+    /// Small values → â is robust to single-point perturbation.
+    /// Large values → â is driven by one observation (BCa unreliable).
+    /// Returns ∞ if either accel or accelWithoutTop is non-finite.
+    double      getAccelRelativeChange()  const { return m_accelRelativeChange; }
+
+    /// True iff |â| ≥ kAccelMaterialThreshold. When false, the BCa correction
+    /// is negligible and isReliable() is forced to true regardless of any
+    /// dominance or sensitivity finding.
+    bool        isAccelMaterial()         const { return m_accelMaterial; }
+
+    /// True iff the leave-one-out sensitivity test passes. Meaningful only
+    /// when isAccelMaterial() is true.
+    bool        isSensitivityOk()         const { return m_sensitivityOk; }
 
     /// True if cancellationRatio < kCancellationThreshold, indicating that the
     /// signed cubic sum is severely eroded by cancellation. When true, â is
@@ -704,105 +792,194 @@ struct IIDResampler
     std::size_t m_maxInfluenceIndex;
     std::size_t m_nDominant;
     double      m_cancellationRatio;
+    double      m_accel;
+    double      m_accelWithoutTop;
+    double      m_accelRelativeChange;
+    bool        m_accelMaterial;
+    bool        m_sensitivityOk;
   };
 
   /**
    * @class JackknifeInfluence
-   * @brief Single-responsibility utility for computing jackknife influence
-   * diagnostics on BCa acceleration estimates.
+   * @brief Computes jackknife influence diagnostics and the authoritative
+   * reliability decision for the BCa acceleration parameter â.
    *
-   * This class knows nothing about BCa, resampling, or statistics. Its sole
-   * responsibility is: given the signed cubic contributions d_i² × d_i from
-   * the jackknife loop, compute the two influence diagnostics described by
-   * AccelerationReliability:
+   * Given the raw leave-one-out jackknife deviations d_i = jk_avg − jk_i,
+   * this class computes:
    *
-   *   1. Single-point dominance: max_i(|d_i³| / Σ|d_j³|) > kDominanceThreshold
-   *   2. Sign cancellation:      |Σd³| / Σ|d³| < kCancellationThreshold
+   *   1. â from the full jackknife, using the same formula as
+   *      BCaBootStrap::calculateBCaBounds:
+   *          â = Σd³ / (6 × (Σd²)^1.5)
    *
-   * The denominator for the dominance check is Σ|d³| (total absolute cubic
-   * influence), NOT |Σd³| (absolute value of the net signed sum). The signed
-   * net sum collapses toward zero when positive and negative contributions
-   * cancel — which is common for mixed-return strategies — causing fractions
-   * to inflate spuriously. The absolute sum is the mathematically correct
-   * normaliser for "share of total cubic influence."
+   *   2. Dominance and cancellation diagnostics (reported, not gating):
+   *          maxInfluenceFraction = max_i(|d_i³|) / Σ|d_j³|
+   *          cancellationRatio    = |Σd³| / Σ|d³|
+   *      The denominator for dominance is Σ|d³| (total absolute cubic
+   *      influence), NOT |Σd³|; the signed net sum would inflate fractions
+   *      under cancellation.
+   *
+   *   3. Leave-one-out sensitivity test on â itself:
+   *          â_minus_top = (Σd³ − top_d³) / (6 × (Σd² − top_d²)^1.5)
+   *          relChange   = |â − â_minus_top| / max(|â|, ε)
+   *      where top_d is the observation with the largest |d³|. This measures
+   *      directly whether a single observation drives â, rather than
+   *      inferring it from the cubic-share proxy.
+   *
+   *   4. The authoritative isReliable() flag:
+   *          reliable = (|â| < kAccelMaterialThreshold)
+   *                     OR (relChange ≤ kSensitivityThreshold)
+   *      The materiality short-circuit prevents spurious rejections when â
+   *      is too small for any correction it applies to affect the interval.
+   *      When â is material, the sensitivity test is the primary criterion.
    *
    * Called from BCaBootStrap::calculateBCaBounds() after the jackknife loop.
-   * The result is stored as std::optional<AccelerationReliability> and exposed
-   * via BCaBootStrap::getAccelerationReliability().
+   * The result is stored and exposed via BCaBootStrap::getAccelerationReliability().
    *
-   * Reference: Efron, B. (1987). JASA 82(397), eq. 6.7; see also the review
-   * discussion of dominance vs. cancellation failure modes.
+   * Reference: Efron, B. (1987). JASA 82(397), eq. 6.7.
    */
   class JackknifeInfluence
   {
   public:
     /**
-     * @brief Computes acceleration reliability from signed cubic LOO contributions.
+     * @brief Computes the full reliability result from raw jackknife deviations.
      *
-     * Computes two diagnostics:
-     *   - Single-point dominance: does any observation contribute > 50% of Σ|d³|?
-     *   - Cancellation ratio:     how much has the signed sum been eroded by cancellation?
-     *
-     * @param dCubed  Per-observation signed cubic values (d_i² × d_i) from the
-     *                jackknife loop. Their sum is the BCa numerator Σd³.
-     * @return        AccelerationReliability with dominance and cancellation diagnostics.
+     * @param d  Per-observation jackknife deviations d_i = jk_avg − jk_i from
+     *           the jackknife loop.
+     * @return   AccelerationReliability populated with â, the perturbed â
+     *           (top-observation removed), their relative change, the
+     *           materiality flag, the sensitivity flag, the legacy dominance
+     *           diagnostics, and the authoritative reliability decision.
      */
-    static AccelerationReliability compute(const std::vector<double>& dCubed)
+    static AccelerationReliability compute(const std::vector<double>& d)
     {
-      // Empty input: no jackknife information available. No dominance possible.
-      // Cancellation ratio 1.0 by convention (no signal to cancel).
-      if (dCubed.empty())
-        return AccelerationReliability(true, 0.0, 0, 0, 1.0);
+      const std::size_t n = d.size();
 
-      // Accumulate both the signed sum (for cancellation ratio) and the
-      // absolute sum (for dominance fractions) in a single pass.
-      double sumSignedCubic = 0.0;
-      double sumAbsCubic    = 0.0;
-      for (double v : dCubed)
+      // Empty input: no jackknife information. No dominance possible,
+      // â = 0 by convention, reliability vacuously true.
+      if (n == 0)
         {
-          sumSignedCubic += v;
-          sumAbsCubic    += std::fabs(v);
+          return AccelerationReliability(true, 0.0, 0, 0, 1.0,
+                                         0.0, 0.0, 0.0, false, true);
+        }
+
+      // Single pass: accumulate signed cubic, absolute cubic, and squared
+      // sums while tracking the top-|d³| observation.
+      double      sumSignedCubic = 0.0;
+      double      sumAbsCubic    = 0.0;
+      double      sumD2          = 0.0;
+      double      maxAbsCubic    = 0.0;
+      std::size_t maxIdx         = 0;
+
+      for (std::size_t i = 0; i < n; ++i)
+        {
+          const double di   = d[i];
+          const double d2i  = di * di;
+          const double d3i  = d2i * di;
+          const double abs3 = std::fabs(d3i);
+
+          sumSignedCubic += d3i;
+          sumAbsCubic    += abs3;
+          sumD2          += d2i;
+
+          if (abs3 > maxAbsCubic)
+            {
+              maxAbsCubic = abs3;
+              maxIdx      = i;
+            }
         }
 
       // Total absolute cubic influence negligible: every LOO contribution is
       // negligible, so â ≈ 0 and BCa degenerates to plain BC. No meaningful
-      // dominance is possible. Cancellation ratio 1.0 by convention.
+      // dominance or sensitivity possible. Cancellation ratio 1.0 by
+      // convention; material/sensitivityOk reflect the near-zero â.
       if (sumAbsCubic <= 1e-100)
-        return AccelerationReliability(true, 0.0, 0, 0, 1.0);
+        {
+          return AccelerationReliability(true, 0.0, 0, 0, 1.0,
+                                         0.0, 0.0, 0.0, false, true);
+        }
 
-      // Cancellation ratio: how much of Σ|d³| survives after sign cancellation.
-      // Near 1.0 → cubic terms mostly agree in sign (well-conditioned numerator).
-      // Near 0.0 → large opposite-sign terms cancel (precariously balanced).
-      // Always in [0, 1] because |Σd³| ≤ Σ|d³| by the triangle inequality.
+      // Cancellation ratio: |Σd³| / Σ|d³|. Near 1 → well-conditioned.
       const double cancellationRatio = std::fabs(sumSignedCubic) / sumAbsCubic;
 
-      // Dominance check: does any single observation contribute more than
-      // kDominanceThreshold of the total absolute cubic influence?
-      //
-      // IMPORTANT: denominator is sumAbsCubic = Σ|d³|, NOT fabs(sumSignedCubic).
-      // Using the signed net sum as denominator would cause fractions to inflate
-      // when positive and negative cubics partially cancel — a common situation
-      // for mixed-return strategies — leading to spurious rejections of valid BCa
-      // runs where no single observation actually dominates.
-      double      maxFrac   = 0.0;
-      std::size_t maxIdx    = 0;
-      std::size_t nDominant = 0;
+      // Dominance fraction (diagnostic only — no longer a gate).
+      const double maxFrac = maxAbsCubic / sumAbsCubic;
 
-      for (std::size_t i = 0; i < dCubed.size(); ++i)
+      // Legacy dominance count: observations with fraction >= the old
+      // kDominanceThreshold. Retained for observability; no effect on
+      // the reliability decision.
+      std::size_t nDominant = 0;
+      for (std::size_t i = 0; i < n; ++i)
         {
-          const double frac = std::fabs(dCubed[i]) / sumAbsCubic;
-          if (frac > maxFrac)
-            {
-              maxFrac = frac;
-              maxIdx  = i;
-            }
-          if (frac > AccelerationReliability::kDominanceThreshold)
+          const double d2i  = d[i] * d[i];
+          const double abs3 = std::fabs(d2i * d[i]);
+          if (abs3 / sumAbsCubic > AccelerationReliability::kDominanceThreshold)
             ++nDominant;
         }
 
-      const bool reliable = (maxFrac <= AccelerationReliability::kDominanceThreshold);
-      return AccelerationReliability(reliable, maxFrac, maxIdx, nDominant,
-                                     cancellationRatio);
+      // â from the full jackknife. Matches BCaBootStrap's computation
+      // byte-for-byte (modulo Decimal↔double rounding).
+      double a = 0.0;
+      if (sumD2 > 1e-100)
+        {
+          const double d15 = std::pow(sumD2, 1.5);
+          if (d15 > 1e-100)
+            a = sumSignedCubic / (6.0 * d15);
+        }
+
+      // TIER 1 — materiality short-circuit condition.
+      const bool accelMaterial =
+        std::isfinite(a) &&
+        std::fabs(a) >= AccelerationReliability::kAccelMaterialThreshold;
+
+      // TIER 2 — leave-one-out sensitivity test. Recompute â with the
+      // top-|d³| observation removed and compare magnitude.
+      double aWithoutTop = 0.0;
+      {
+        const double topD  = d[maxIdx];
+        const double topD2 = topD * topD;
+        const double topD3 = topD2 * topD;
+        const double numR  = sumSignedCubic - topD3;
+        const double denR  = sumD2          - topD2;
+
+        if (denR > 1e-100)
+          {
+            const double dr15 = std::pow(denR, 1.5);
+            if (dr15 > 1e-100)
+              aWithoutTop = numR / (6.0 * dr15);
+          }
+      }
+
+      // Floor on the relative-change denominator so that tiny â values do
+      // not produce spuriously large relChange from numerical noise.
+      // In practice accelMaterial gates this downstream, but computing a
+      // sensible value keeps the diagnostic output interpretable.
+      constexpr double kAccelFloor = 1e-6;
+      const double relChange =
+        (std::isfinite(a) && std::isfinite(aWithoutTop))
+          ? std::fabs(a - aWithoutTop)
+              / std::max(std::fabs(a), kAccelFloor)
+          : std::numeric_limits<double>::infinity();
+
+      const bool sensitivityOk =
+        std::isfinite(relChange) &&
+        relChange <= AccelerationReliability::kSensitivityThreshold;
+
+      // AUTHORITATIVE RELIABILITY DECISION
+      //   If â is not material, BCa correction is negligible regardless of
+      //   any dominance pathology, so the interval is not at risk → reliable.
+      //   Otherwise, use the sensitivity test as the primary criterion.
+      const bool reliable = !accelMaterial || sensitivityOk;
+
+      return AccelerationReliability(reliable,
+                                     maxFrac,
+                                     maxIdx,
+                                     nDominant,
+                                     cancellationRatio,
+                                     a,
+                                     aWithoutTop,
+                                     relChange,
+                                     accelMaterial,
+                                     sensitivityOk);
     }
   };
 
@@ -1645,9 +1822,19 @@ struct IIDResampler
 	  m_z0             = 0.0;
 	  m_accel          = DecimalConstants<Decimal>::DecimalZero;
 	  // Degenerate bootstrap: â = 0 by construction. Acceleration has no
-	  // effect on the interval. No dominance possible; cancellation ratio 1.0
-	  // by convention (no cubic signal to cancel).
-	  m_accelReliability = AccelerationReliability(true, 0.0, 0, 0, 1.0);
+	  // effect on the interval. No dominance or sensitivity pathology
+	  // possible; cancellation ratio 1.0 by convention (no cubic signal
+	  // to cancel); accel is not material so reliability is vacuously true.
+	  m_accelReliability = AccelerationReliability(true,  // reliable
+	                                               0.0,   // maxInfluenceFraction
+	                                               0,     // maxInfluenceIndex
+	                                               0,     // nDominant
+	                                               1.0,   // cancellationRatio
+	                                               0.0,   // accel
+	                                               0.0,   // accelWithoutTop
+	                                               0.0,   // accelRelativeChange
+	                                               false, // accelMaterial
+	                                               true); // sensitivityOk
 	  // BCa transform is never applied in the degenerate case.
 	  // isStable and isMonotone are both true by convention; denominator
 	  // values are reported as 1.0 (the a=0 limit of 1 − a·(z₀ + zα)).
@@ -1695,10 +1882,10 @@ struct IIDResampler
       double num_d = 0.0;  // Σ d³
       double den_d = 0.0;  // Σ d²
 
-      // Per-observation signed cubic contributions for influence analysis.
-      // Collected alongside the existing d² / d³ accumulation at zero extra
-      // passes through jk_stats. Passed to JackknifeInfluence::compute() below.
-      std::vector<double> dCubed(n_jk);
+      // Per-observation raw jackknife deviations d_i = jk_avg − jk_stats[i].
+      // JackknifeInfluence uses these to compute the dominance / cancellation
+      // diagnostics AND the Tier-2 leave-one-out sensitivity test on â.
+      std::vector<double> d_values(n_jk);
 
       for (std::size_t i = 0; i < n_jk; ++i)
 	{
@@ -1706,7 +1893,7 @@ struct IIDResampler
 	  const double d2 = d * d;
 	  den_d      += d2;
 	  num_d      += d2 * d;
-	  dCubed[i]   = d2 * d;  // signed cubic contribution of observation i
+	  d_values[i] = d;
 	}
 
       Decimal a = DecimalConstants<Decimal>::DecimalZero;
@@ -1718,12 +1905,14 @@ struct IIDResampler
 	}
       m_accel = a;
 
-      // Influence analysis: did any single LOO observation dominate Σd³?
-      // JackknifeInfluence has sole responsibility for this computation.
-      // The result is stored as optional so the accessor can assert it is
-      // populated before returning, catching any future code path that
-      // bypasses this line.
-      m_accelReliability = JackknifeInfluence::compute(dCubed);
+      // Influence analysis + authoritative reliability decision.
+      // JackknifeInfluence::compute() computes â internally from d_values
+      // using the same formula above, applies the materiality short-circuit
+      // (|â| < kAccelMaterialThreshold ⇒ reliable), and runs the leave-one-out
+      // sensitivity test on â when â is material. The cubic-share dominance
+      // and cancellation diagnostics are still reported (getMaxInfluenceFraction,
+      // getCancellationRatio, etc.) but no longer gate reliability directly.
+      m_accelReliability = JackknifeInfluence::compute(d_values);
 
       // (5) Adjusted percentiles → bounds
       //

--- a/libs/statistics/StrategyAutoBootstrap.h
+++ b/libs/statistics/StrategyAutoBootstrap.h
@@ -714,8 +714,15 @@ namespace palvalidator
 		  (*os) << "disqualified: interval violates domain constraints\n";
 		else if (diagnostics.wasBCaRejectedForInstability())
 		  {
-		    // wasBCaRejectedForInstability() fires for two distinct causes;
-		    // inspect the BCa candidate directly to emit the specific message.
+		    // wasBCaRejectedForInstability() fires for two distinct
+		    // categories under the Tier-3 rule:
+		    //   SOFT penalties (BCa competed, was down-weighted, lost on
+		    //   score): !getAccelIsReliable(), !getBcaTransformMonotone()
+		    //   HARD gates (BCa never entered the tournament): z0/accel
+		    //   above hard limits, skew above hard limit, n below
+		    //   kBcaMinSampleSize, effective-B below gate.
+		    // We inspect the BCa candidate to tell the user which category
+		    // applied. "penalized" for soft; "disqualified" for hard.
 		    bool accel_bad   = false;
 		    bool nonmono_bad = false;
 		    for (const auto& cand : result.getCandidates())
@@ -727,32 +734,43 @@ namespace palvalidator
 		      }
 
 		    if (accel_bad && nonmono_bad)
-		      (*os) << "disqualified: dominant jackknife observation"
-			       " + non-monotone BCa transform\n";
+		      (*os) << "penalized: unreliable acceleration"
+			       " + non-monotone transform;"
+			       " outscored by winner\n";
 		    else if (accel_bad)
-		      (*os) << "disqualified: dominant jackknife observation"
-			       " in acceleration estimate\n";
+		      (*os) << "penalized: acceleration driven by a single"
+			       " observation (Tier-2 sensitivity test failed);"
+			       " outscored by winner\n";
 		    else if (nonmono_bad)
-		      (*os) << "disqualified: BCa percentile-transform"
-			       " mapping reversed direction\n";
+		      (*os) << "penalized: BCa percentile-transform mapping"
+			       " reversed direction; outscored by winner\n";
 		    else
-		      (*os) << "disqualified: BCa parameter instability"
-			       " (sample size or skew gate)\n";
+		      (*os) << "disqualified: parameter instability"
+			       " (hard z0/accel/skew limit, sample-size floor,"
+			       " or effective-B gate)\n";
 		  }
 		else if (diagnostics.wasBCaRejectedForLength())
 		  (*os) << "disqualified: interval too wide\n";
 		else
 		  (*os) << "outscored by winner\n";
 
-		// When BCa was disqualified for instability, print the parameters
-		// that triggered the gates.  Two independent failure modes can set
-		// wasBCaRejectedForInstability(); both are surfaced here:
+		// When wasBCaRejectedForInstability() fired, print the parameters
+		// that contributed. Under the Tier-3 rule, "instability" groups
+		// both hard-gate disqualifications (z0/accel hard limits, skew
+		// hard limit, sample-size floor) AND soft-penalty signals (accel
+		// unreliable, non-monotone transform) that down-weighted BCa but
+		// let it compete. The per-field annotations below label each as
+		// hard or soft so the caller can see which was the actual cause.
 		//
-		//   getAccelIsReliable()      — false if a single jackknife LOO
-		//     observation contributed > 50% of the total absolute cubic
-		//     influence Σ|d³|.  The acceleration estimate is then an
-		//     artifact of that observation, not a distributional property,
-		//     regardless of â's magnitude, z0, or skew_boot.
+		//   getAccelIsReliable()      — false when the jackknife
+		//     acceleration is driven by a single observation under the
+		//     Tier-1/2 rule (see BiasCorrectedBootstrap.h). Specifically,
+		//     |â| is material (≥ kAccelMaterialThreshold) AND the
+		//     leave-one-out sensitivity test fails (removing the
+		//     top-|d³| observation changes â by more than
+		//     kSensitivityThreshold relative). A soft penalty of
+		//     kBcaAccelUnreliablePenalty is applied in the tournament;
+		//     this detail line makes the event visible in the log.
 		//
 		//   getBcaTransformMonotone() — false if the BCa percentile-transform
 		//     mapping produced α₁ > α₂ (inverted order).  The bounds are still
@@ -797,8 +815,19 @@ namespace palvalidator
 			(*os) << "\n";
 
 			(*os) << "   [AutoCI]     accel reliable:   "
-			      << (cand.getAccelIsReliable() ? "yes" : "NO — dominant jackknife observation")
+			      << (cand.getAccelIsReliable()
+				    ? "yes"
+				    : "NO — acceleration driven by one observation"
+				      " (Tier-2 sensitivity test failed)")
 			      << "\n";
+			// When accel is unreliable, note that a soft penalty was
+			// already applied in the tournament so the caller knows the
+			// stability_penalty below already incorporates
+			// kBcaAccelUnreliablePenalty.
+			if (!cand.getAccelIsReliable())
+			  (*os) << "   [AutoCI]       (stability_penalty includes "
+				<< AutoBootstrapConfiguration::kBcaAccelUnreliablePenalty
+				<< " accel-unreliable soft penalty)\n";
 
 			(*os) << "   [AutoCI]     transform monotone: "
 			      << (cand.getBcaTransformMonotone()

--- a/libs/statistics/test/AutoBootstrapSelectorMedianTest.cpp
+++ b/libs/statistics/test/AutoBootstrapSelectorMedianTest.cpp
@@ -556,7 +556,22 @@ struct MockBCaEngine
 
     mkc_timeseries::AccelerationReliability getAccelerationReliability() const
     {
-      return mkc_timeseries::AccelerationReliability(true, 0.0, 0, 0, 1.0);
+      // Returns a well-behaved default matching a "no pathology" BCa run:
+      // a=0 so not material, no dominance, no cancellation, sensitivity
+      // check trivially passes. Matches the construction used by
+      // JackknifeInfluence::compute() for empty/zero-signal input and by
+      // BCaBootStrap::calculateBCaBounds() on the degenerate-case path.
+      return mkc_timeseries::AccelerationReliability(
+          true,   // isReliable          -- vacuously true (a is not material)
+          0.0,    // maxInfluenceFraction
+          0,      // maxInfluenceIndex
+          0,      // nDominant
+          1.0,    // cancellationRatio   -- no cubic signal to cancel
+          0.0,    // accel               -- matches accel_val default
+          0.0,    // accelWithoutTop
+          0.0,    // accelRelativeChange
+          false,  // accelMaterial       -- |a|=0 < kAccelMaterialThreshold
+          true);  // sensitivityOk       -- vacuously (no perturbation signal)
     }
 
     // Returns a well-behaved (stable, monotone) transform stability object.

--- a/libs/statistics/test/AutoBootstrapSelectorTest.cpp
+++ b/libs/statistics/test/AutoBootstrapSelectorTest.cpp
@@ -443,9 +443,25 @@ struct MockBCaEngine
     double  getConfidenceLevel() const { return cl; }
     unsigned int getNumResamples() const { return static_cast<unsigned int>(B); }
     std::size_t getSampleSize() const { return n; }
+    
   mkc_timeseries::AccelerationReliability getAccelerationReliability() const
     {
-      return mkc_timeseries::AccelerationReliability(true, 0.0, 0, 0, 1.0);
+        // Returns a well-behaved default matching a "no pathology" BCa run:
+      // a=0 so not material, no dominance, no cancellation, sensitivity
+      // check trivially passes. Matches the construction used by
+      // JackknifeInfluence::compute() for empty/zero-signal input and by
+      // BCaBootStrap::calculateBCaBounds() on the degenerate-case path.
+      return mkc_timeseries::AccelerationReliability(
+          true,   // isReliable          -- vacuously true (a is not material)
+          0.0,    // maxInfluenceFraction
+          0,      // maxInfluenceIndex
+          0,      // nDominant
+          1.0,    // cancellationRatio   -- no cubic signal to cancel
+          0.0,    // accel               -- matches accel_val default
+          0.0,    // accelWithoutTop
+          0.0,    // accelRelativeChange
+          false,  // accelMaterial       -- |a|=0 < kAccelMaterialThreshold
+          true);  // sensitivityOk       -- vacuously (no perturbation signal)
     }
 
     // Returns a well-behaved (stable, monotone) transform stability object.
@@ -683,6 +699,214 @@ TEST_CASE("AutoBootstrapSelector: BCa Hard Gate Rejection",
         REQUIRE(result.getChosenMethod() == MethodId::PercentileT);
         REQUIRE(result.getBootstrapMedian() == Catch::Approx(0.08));  // NEW: PercT's median (BCa rejected)
         REQUIRE(result.getDiagnostics().wasBCaRejectedForInstability() == true);
+    }
+}
+
+TEST_CASE("AutoBootstrapSelector: BCa with unreliable acceleration is no longer hard-rejected (Tier 3 regression)",
+          "[AutoBootstrapSelector][Selection][Tier3][Regression]")
+{
+    // Regression test for the Tier 3 change.
+    //
+    // BEFORE Tier 3:
+    //   CandidateGateKeeper::isBcaCandidateValid() returned false whenever
+    //   candidate.getAccelIsReliable()==false. The BCa candidate was
+    //   filtered out of the tournament entirely, regardless of its score.
+    //
+    // AFTER Tier 3:
+    //   That hard gate is removed. Accel-unreliability is applied as a
+    //   soft stability penalty (AutoBootstrapConfiguration::kBcaAccelUnreliablePenalty
+    //   = 0.5 raw → 2.0 normalized at kRefStability=0.25) inside
+    //   summarizeBCa(). BCa enters the tournament and either wins or loses
+    //   based on score.
+    //
+    // The mock engine below reports accelIsReliable=false with internally
+    // consistent Tier-2 state — material |â|=0.15, sign-flip on top-obs
+    // removal giving relChange≈1.33 > kSensitivityThreshold. All other
+    // BCa diagnostics are clean (transform monotone, z0=0, accel=0 in the
+    // hard-gate sense, symmetric bootstrap distribution → skew≈0).
+
+    struct MockBCaEngineAccelUnreliable
+    {
+        Decimal mean  =  0.0;
+        Decimal lower = -1.0;
+        Decimal upper =  1.0;
+        double  cl    =  0.95;
+        std::size_t B = 1000;
+        std::size_t n = 100;
+        double  z0    = 0.0;
+        // NOTE: getAcceleration() returns 0.0 so computeBCaStabilityPenalty
+        // adds no z0/accel/skew-based penalty.  The AccelerationReliability
+        // object returned below reports accel=0.15 inside itself to keep
+        // accelMaterial=true internally consistent; the two are independent
+        // queries (same precedent as MockBCaEngineUnreliableAccel in
+        // AutoBootstrapSelectorTransformStabilityTest.cpp).
+        Decimal accel = 0.0;
+        // Bootstrap statistics — populated in the test body. Must be large
+        // enough to pass CandidateGateKeeper::passesEffectiveBGate, which
+        // requires effective_B >= max(kMinEffectiveBAbsolute=200,
+        // ceil(kBcaMinEffectiveFraction * B) = ceil(0.90 * 1000) = 900) = 900.
+        // Symmetric/linearly-spaced content keeps skew_boot ≈ 0 so
+        // computeBCaStabilityPenalty contributes 0 and the only stability
+        // penalty on the Candidate is kBcaAccelUnreliablePenalty.
+        std::vector<Decimal> stats;
+
+        Decimal      getMean()            const { return mean;  }
+        Decimal      getLowerBound()      const { return lower; }
+        Decimal      getUpperBound()      const { return upper; }
+        double       getConfidenceLevel() const { return cl;    }
+        unsigned int getNumResamples()    const { return static_cast<unsigned int>(B); }
+        std::size_t  getSampleSize()      const { return n;     }
+        double       getZ0()              const { return z0;    }
+        Decimal      getAcceleration()    const { return accel; }
+        const std::vector<Decimal>& getBootstrapStatistics() const { return stats; }
+
+        mkc_timeseries::AccelerationReliability getAccelerationReliability() const
+        {
+            // Tier-2 failure mode: material |â|, driven by one observation
+            // (sign flip under top-|d³| removal) → sensitivityOk=false →
+            // isReliable=false. This is precisely the regime the Tier 3
+            // change is meant to rescue.
+            return mkc_timeseries::AccelerationReliability(
+                false,    // isReliable          -- what we're testing
+                0.72,     // maxInfluenceFraction
+                2,        // maxInfluenceIndex
+                1,        // nDominant
+                0.85,     // cancellationRatio
+                0.15,     // accel               -- material
+               -0.05,     // accelWithoutTop     -- sign flip
+                1.333,    // accelRelativeChange -- |0.15 − (−0.05)| / 0.15
+                true,     // accelMaterial
+                false);   // sensitivityOk
+        }
+
+        mkc_timeseries::BcaTransformStability getBcaTransformStability() const
+        {
+            // Clean transform: only the accel-reliability flag is bad.
+            return mkc_timeseries::BcaTransformStability(true, true, 1.0, 1.0);
+        }
+    };
+
+    MockBCaEngineAccelUnreliable engine;
+
+    // Fill in 1000 symmetric, linearly-spaced bootstrap statistics spanning
+    // [-1, 1]. This satisfies two constraints at once:
+    //   1. effective_B = 1000 >= ceil(0.90 * B=1000) = 900, so the BCa
+    //      candidate clears CandidateGateKeeper::passesEffectiveBGate.
+    //   2. The distribution is perfectly symmetric around 0, so skew_boot ≈ 0
+    //      and computeBCaStabilityPenalty contributes no additional penalty.
+    //      The only stability contribution is the new kBcaAccelUnreliablePenalty
+    //      soft penalty, which makes the REQUIRE(stabilityPenalty == k...)
+    //      assertion below exact.
+    engine.stats.reserve(1000);
+    for (int i = 0; i < 1000; ++i)
+    {
+        engine.stats.push_back(-1.0 + (2.0 * static_cast<double>(i)) / 999.0);
+    }
+
+    Candidate bca = Selector::summarizeBCa(engine);
+
+    // ------------------------------------------------------------------
+    // Sanity on what summarizeBCa produced from the flagged engine
+    // ------------------------------------------------------------------
+    // The accel-unreliable flag propagated into the Candidate.
+    REQUIRE(bca.getAccelIsReliable()         == false);
+    // algorithmIsReliable is the AND of accel and transform_monotone; since
+    // accel is false, algorithmIsReliable must also be false. (Kept as a
+    // diagnostic field — does not gate selection.)
+    REQUIRE(bca.getAlgorithmIsReliable()     == false);
+    // Transform is clean.
+    REQUIRE(bca.getBcaTransformMonotone()    == true);
+    // The soft penalty was added. Engine reports z0=0, accel=0, and the
+    // bootstrap distribution is symmetric so skew_boot≈0 → computeBCaStabilityPenalty
+    // contributes 0. The only addition is kBcaAccelUnreliablePenalty = 0.5.
+    REQUIRE(bca.getStabilityPenalty()
+            == Catch::Approx(AutoBootstrapConfiguration::kBcaAccelUnreliablePenalty));
+
+    // ------------------------------------------------------------------
+    // (A) Eligibility proof: BCa can now WIN when it has the lower score.
+    //     Under the pre-Tier-3 behavior, BCa would have been filtered out
+    //     by isBcaCandidateValid and PercentileT would have won by default,
+    //     regardless of how bad PercentileT's score was.
+    // ------------------------------------------------------------------
+    SECTION("BCa wins when its score beats the competitor's, despite accelIsReliable=false")
+    {
+        // Weak PercentileT — high ordering penalty. Scales argument from the
+        // existing "BCa Grey Zone Tournament" test: at wStability=1.0, raw
+        // ordering 0.002 normalises to contribution ≈ 0.2; raw 0.03 normalises
+        // to ≈ 3.0, which is above BCa's ≈ 2.0 stability contribution.
+        Candidate percT_weak(MethodId::PercentileT,
+                             0.0, -1.1, 1.1, 0.95, 100, 1000, 0, 1000, 0,
+                             0.1, 0.0,
+                             0.05,                 // median_boot
+                             0.0, 1.0,
+                             /*ordering*/  0.03,   // Large → contribution ~3.0
+                             /*length*/    0.0,
+                             /*stability*/ 0.0,
+                             0.0, 0.0, 0.0);
+
+        std::vector<Candidate> cands = { percT_weak, bca };
+        auto result = Selector::select(cands);
+
+        // BCa made it into the tournament (not filtered by isBcaCandidateValid).
+        REQUIRE(result.getDiagnostics().hasBCaCandidate() == true);
+        // BCa won on score despite the accel-unreliable penalty.
+        REQUIRE(result.getChosenMethod()                   == MethodId::BCa);
+        REQUIRE(result.getDiagnostics().isBCaChosen()      == true);
+        // Diagnostic: since BCa was chosen, no rejection flags fire.
+        REQUIRE(result.getDiagnostics().wasBCaRejectedForInstability() == false);
+    }
+
+    // ------------------------------------------------------------------
+    // (B) Paired case: BCa loses ON SCORE (not on hard rejection) when the
+    //     competitor is stronger. The soft penalty correctly down-weights
+    //     BCa without eliminating it — exactly the intent of Tier 3.
+    // ------------------------------------------------------------------
+    SECTION("BCa loses on score, not on hard rejection, when competitor is stronger")
+    {
+        // Strong PercentileT: raw ordering 0.002 → contribution ~0.2,
+        // well below BCa's ~2.0.
+        Candidate percT_strong(MethodId::PercentileT,
+                               0.0, -1.1, 1.1, 0.95, 100, 1000, 0, 1000, 0,
+                               0.1, 0.0,
+                               0.05,                 // median_boot
+                               0.0, 1.0,
+                               /*ordering*/  0.002,  // Small → contribution ~0.2
+                               /*length*/    0.0,
+                               /*stability*/ 0.0,
+                               0.0, 0.0, 0.0);
+
+        std::vector<Candidate> cands = { percT_strong, bca };
+        auto result = Selector::select(cands);
+
+        REQUIRE(result.getDiagnostics().hasBCaCandidate()  == true);
+        REQUIRE(result.getChosenMethod()                    == MethodId::PercentileT);
+        REQUIRE(result.getDiagnostics().isBCaChosen()       == false);
+
+        // BCa lost via scoring, not via hard rejection. The
+        // wasBCaRejectedForInstability() flag still surfaces the
+        // accel-unreliable signal diagnostically (per analyzeBcaRejection),
+        // consistent with how the non-monotone transform is treated. That
+        // behavior is intentional — callers querying the diagnostic still
+        // see "BCa had an instability signal that contributed to its loss,"
+        // even though BCa competed fairly rather than being vetoed.
+        REQUIRE(result.getDiagnostics().wasBCaRejectedForInstability() == true);
+    }
+
+    // ------------------------------------------------------------------
+    // (C) Single-candidate eligibility: BCa is the only candidate, and the
+    //     selector does not throw AllGatesFailed. Pre-Tier-3 behavior:
+    //     isBcaCandidateValid filters BCa out, selector has no valid
+    //     candidates, throws. Post-Tier-3 behavior: BCa is valid, becomes
+    //     the winner by default.
+    // ------------------------------------------------------------------
+    SECTION("BCa is the sole candidate: selector does not throw AllGatesFailed")
+    {
+        std::vector<Candidate> cands = { bca };
+        REQUIRE_NOTHROW(Selector::select(cands));
+
+        auto result = Selector::select(cands);
+        REQUIRE(result.getChosenMethod()              == MethodId::BCa);
+        REQUIRE(result.getDiagnostics().isBCaChosen() == true);
     }
 }
 

--- a/libs/statistics/test/AutoBootstrapSelectorTransformStabilityTest.cpp
+++ b/libs/statistics/test/AutoBootstrapSelectorTransformStabilityTest.cpp
@@ -97,7 +97,22 @@ struct MockBCaEngineMonotone
 
     mkc_timeseries::AccelerationReliability getAccelerationReliability() const
     {
-        return mkc_timeseries::AccelerationReliability(true, 0.0, 0, 0, 1.0);
+        // Returns a well-behaved default matching a "no pathology" BCa run:
+      // a=0 so not material, no dominance, no cancellation, sensitivity
+      // check trivially passes. Matches the construction used by
+      // JackknifeInfluence::compute() for empty/zero-signal input and by
+      // BCaBootStrap::calculateBCaBounds() on the degenerate-case path.
+      return mkc_timeseries::AccelerationReliability(
+          true,   // isReliable          -- vacuously true (a is not material)
+          0.0,    // maxInfluenceFraction
+          0,      // maxInfluenceIndex
+          0,      // nDominant
+          1.0,    // cancellationRatio   -- no cubic signal to cancel
+          0.0,    // accel               -- matches accel_val default
+          0.0,    // accelWithoutTop
+          0.0,    // accelRelativeChange
+          false,  // accelMaterial       -- |a|=0 < kAccelMaterialThreshold
+          true);  // sensitivityOk       -- vacuously (no perturbation signal)
     }
 
     // Well-behaved transform: denominators safely positive, alpha1 <= alpha2.
@@ -135,9 +150,24 @@ struct MockBCaEngineNonMonotone
     Decimal      getAcceleration()    const { return accel; }
     const std::vector<Decimal>& getBootstrapStatistics() const { return stats; }
 
+    // Well-behaved acceleration diagnostic: a=0 so not material, no
+    // dominance, no cancellation, sensitivity check trivially passes.
+    // Matches the construction used by JackknifeInfluence::compute() for
+    // empty/zero-signal input and by BCaBootStrap::calculateBCaBounds()
+    // on the degenerate-case path.
     mkc_timeseries::AccelerationReliability getAccelerationReliability() const
     {
-        return mkc_timeseries::AccelerationReliability(true, 0.0, 0, 0, 1.0);
+      return mkc_timeseries::AccelerationReliability(
+          true,   // isReliable          -- vacuously true (a is not material)
+          0.0,    // maxInfluenceFraction
+          0,      // maxInfluenceIndex
+          0,      // nDominant
+          1.0,    // cancellationRatio   -- no cubic signal to cancel
+          0.0,    // accel               -- matches accel_val default
+          0.0,    // accelWithoutTop
+          0.0,    // accelRelativeChange
+          false,  // accelMaterial       -- |a|=0 < kAccelMaterialThreshold
+          true);  // sensitivityOk       -- vacuously (no perturbation signal)
     }
 
     // Non-monotone transform: alpha1 > alpha2 — mapping inverted, bounds silently
@@ -177,15 +207,28 @@ struct MockBCaEngineUnreliableAccel
     Decimal      getAcceleration()    const { return accel; }
     const std::vector<Decimal>& getBootstrapStatistics() const { return stats; }
 
-    // Single observation dominates Σ|d³|: acceleration is an artifact of that outlier.
+    // Scenario: acceleration is material (|â| ≥ kAccelMaterialThreshold), but
+    // the estimate is driven by one observation — removing the top-|d³|
+    // contributor swings â materially (sign flip here), so the leave-one-out
+    // sensitivity test fails. This is the Tier-2 failure mode that produces
+    // isReliable=false under the new rule.
+    //
+    // The legacy dominance diagnostic (maxInfluenceFraction=0.72, nDominant=1)
+    // is preserved so any downstream log/observability paths still see a
+    // consistent picture.
     mkc_timeseries::AccelerationReliability getAccelerationReliability() const
     {
         return mkc_timeseries::AccelerationReliability(
-            false,  // isReliable       -- single observation dominant
-            0.72,   // maxInfluenceFrac -- 72% of total absolute cubic influence
-            3,      // maxInfluenceIdx
-            1,      // nDominant
-            0.85);  // cancellationRatio
+            false,    // isReliable          -- sensitivity test failed
+            0.72,     // maxInfluenceFraction -- 72% of Σ|d³| on one obs
+            3,        // maxInfluenceIndex
+            1,        // nDominant
+            0.85,     // cancellationRatio
+            0.15,     // accel               -- material (below hard limit 0.25)
+           -0.05,     // accelWithoutTop     -- sign flip after removing top obs
+            1.333,    // accelRelativeChange -- |0.15 − (−0.05)| / 0.15
+            true,     // accelMaterial       -- |â| ≥ kAccelMaterialThreshold
+            false);   // sensitivityOk       -- relChange > kSensitivityThreshold
     }
 
     // Transform is fine.
@@ -521,9 +564,22 @@ TEST_CASE("summarizeBCa: algorithmIsReliable is AND of accel reliability and tra
             Decimal getAcceleration() const { return accel; }
             const std::vector<Decimal>& getBootstrapStatistics() const { return stats; }
 
+            // Scenario: material â driven by a single observation (Tier-2
+            // sensitivity test fails) AND the BCa percentile transform is
+            // non-monotone. Both diagnostic layers fail simultaneously.
             mkc_timeseries::AccelerationReliability getAccelerationReliability() const
             {
-                return mkc_timeseries::AccelerationReliability(false, 0.9, 0, 1, 0.9);
+                return mkc_timeseries::AccelerationReliability(
+                    false,    // isReliable
+                    0.9,      // maxInfluenceFraction
+                    0,        // maxInfluenceIndex
+                    1,        // nDominant
+                    0.9,      // cancellationRatio
+                    0.18,     // accel               -- material
+                   -0.08,     // accelWithoutTop     -- sign flip
+                    1.444,    // accelRelativeChange -- |0.18 − (−0.08)| / 0.18
+                    true,     // accelMaterial
+                    false);   // sensitivityOk      -- relChange > threshold
             }
             mkc_timeseries::BcaTransformStability getBcaTransformStability() const
             {

--- a/libs/statistics/test/BCaAccelerationReliabilityTest.cpp
+++ b/libs/statistics/test/BCaAccelerationReliabilityTest.cpp
@@ -2,17 +2,30 @@
 //
 // Unit tests for:
 //   - AccelerationReliability  (construction, accessors, thresholds)
-//   - JackknifeInfluence::compute()  (all logical branches)
-//   - BCaBootStrap::getAccelerationReliability()  (integration with BCa pipeline)
+//   - JackknifeInfluence::compute()  (all logical branches under the
+//         Tier-1 materiality short-circuit + Tier-2 leave-one-out
+//         sensitivity test)
+//   - BCaBootStrap::getAccelerationReliability()  (integration with BCa)
 //
-// All JackknifeInfluence tests use analytically computed expected values to
-// ensure determinism. Expected values were verified independently in Python.
+// RELIABILITY RULE UNDER TEST
+// ---------------------------
+// JackknifeInfluence::compute() now returns
+//       reliable = (|â| < kAccelMaterialThreshold)  OR  sensitivityOk
+// where
+//       â              = Σd³ / (6·(Σd²)^1.5)
+//       â_without_top  = (Σd³ − top_d³) / (6·(Σd² − top_d²)^1.5)
+//       relChange      = |â − â_without_top| / max(|â|, ε)
+//       sensitivityOk  = (relChange ≤ kSensitivityThreshold)
 //
-// The denominator for dominance fractions is Σ|d³| (total absolute cubic
-// influence), NOT |Σd³| (absolute value of the net signed sum). This means:
-//   - All fractions are always in [0, 1]
-//   - Near-cancellation of signed cubic terms does NOT inflate fractions
-//   - Near-cancellation is separately measured by the cancellation ratio
+// The legacy "single-point dominance" statistic
+//       maxInfluenceFraction = max_i(|d_i³|) / Σ|d_j³|
+// is still computed and exposed but no longer gates reliability.
+//
+// COMPUTE() INPUT CHANGE
+// ----------------------
+// JackknifeInfluence::compute() now takes the raw jackknife deviations
+// d_i = jk_avg − jk_i, NOT the pre-cubed values. All test inputs below
+// are raw d-vectors. Expected values were verified independently.
 //
 // Uses Catch2.
 
@@ -32,41 +45,68 @@ using namespace mkc_timeseries;
 // AccelerationReliability: construction and accessors
 // ============================================================================
 
-TEST_CASE("AccelerationReliability: constructor stores all values correctly",
+TEST_CASE("AccelerationReliability: constructor stores all 10 values correctly",
           "[AccelerationReliability]")
 {
+    // Exercise every stored field so an accidental member-order swap would
+    // fail to compile or fail the round-trip check.
     const bool        reliable          = false;
     const double      maxFrac           = 0.7143;
     const std::size_t maxIdx            = 2;
     const std::size_t nDominant         = 1;
     const double      cancellationRatio = 0.75;
+    const double      accel             = 0.185;
+    const double      accelWithoutTop   = -0.042;
+    const double      accelRelChange    = 1.227;
+    const bool        accelMaterial     = true;
+    const bool        sensitivityOk     = false;
 
-    AccelerationReliability ar(reliable, maxFrac, maxIdx, nDominant, cancellationRatio);
+    AccelerationReliability ar(reliable, maxFrac, maxIdx, nDominant,
+                               cancellationRatio, accel, accelWithoutTop,
+                               accelRelChange, accelMaterial, sensitivityOk);
 
-    REQUIRE(ar.isReliable()              == reliable);
-    REQUIRE(ar.getMaxInfluenceFraction() == Catch::Approx(maxFrac).epsilon(1e-12));
-    REQUIRE(ar.getMaxInfluenceIndex()    == maxIdx);
-    REQUIRE(ar.getNDominant()            == nDominant);
-    REQUIRE(ar.getCancellationRatio()    == Catch::Approx(cancellationRatio).epsilon(1e-12));
+    REQUIRE(ar.isReliable()               == reliable);
+    REQUIRE(ar.getMaxInfluenceFraction()  == Catch::Approx(maxFrac).epsilon(1e-12));
+    REQUIRE(ar.getMaxInfluenceIndex()     == maxIdx);
+    REQUIRE(ar.getNDominant()             == nDominant);
+    REQUIRE(ar.getCancellationRatio()     == Catch::Approx(cancellationRatio).epsilon(1e-12));
+    REQUIRE(ar.getAccel()                 == Catch::Approx(accel).epsilon(1e-12));
+    REQUIRE(ar.getAccelWithoutTop()       == Catch::Approx(accelWithoutTop).epsilon(1e-12));
+    REQUIRE(ar.getAccelRelativeChange()   == Catch::Approx(accelRelChange).epsilon(1e-12));
+    REQUIRE(ar.isAccelMaterial()          == accelMaterial);
+    REQUIRE(ar.isSensitivityOk()          == sensitivityOk);
 }
 
 TEST_CASE("AccelerationReliability: reliable=true variant stores correctly",
           "[AccelerationReliability]")
 {
-    // cancellationRatio=1.0 means cubic terms fully agree in sign (well-conditioned)
-    AccelerationReliability ar(true, 0.25, 0, 0, 1.0);
+    // Typical "everything fine" shape: small |â|, dominance not fired,
+    // cancellation = 1 (cubic terms all same sign).
+    AccelerationReliability ar(true,       // reliable
+                               0.25,       // maxInfluenceFraction
+                               0,          // maxInfluenceIndex
+                               0,          // nDominant
+                               1.0,        // cancellationRatio
+                               0.04,       // accel
+                               0.045,      // accelWithoutTop
+                               0.125,      // accelRelativeChange
+                               false,      // accelMaterial
+                               true);      // sensitivityOk
 
-    REQUIRE(ar.isReliable()              == true);
-    REQUIRE(ar.getMaxInfluenceFraction() == Catch::Approx(0.25).epsilon(1e-12));
-    REQUIRE(ar.getMaxInfluenceIndex()    == 0);
-    REQUIRE(ar.getNDominant()            == 0);
-    REQUIRE(ar.getCancellationRatio()    == Catch::Approx(1.0).epsilon(1e-12));
+    REQUIRE(ar.isReliable()             == true);
+    REQUIRE(ar.isAccelMaterial()        == false);
+    REQUIRE(ar.isSensitivityOk()        == true);
+    REQUIRE(ar.getAccel()               == Catch::Approx(0.04).epsilon(1e-12));
+    REQUIRE(ar.getAccelWithoutTop()     == Catch::Approx(0.045).epsilon(1e-12));
+    REQUIRE(ar.getAccelRelativeChange() == Catch::Approx(0.125).epsilon(1e-12));
 }
 
-TEST_CASE("AccelerationReliability: kDominanceThreshold is 0.5",
+TEST_CASE("AccelerationReliability: kDominanceThreshold is 0.5 (diagnostic only)",
           "[AccelerationReliability]")
 {
-    // Verifying the value here documents and guards against inadvertent changes.
+    // Retained for observability and nDominant counting. No longer gates
+    // reliability: that is determined by the materiality short-circuit
+    // plus the sensitivity test.
     REQUIRE(AccelerationReliability::kDominanceThreshold ==
             Catch::Approx(0.5).epsilon(1e-15));
 }
@@ -74,394 +114,368 @@ TEST_CASE("AccelerationReliability: kDominanceThreshold is 0.5",
 TEST_CASE("AccelerationReliability: kCancellationThreshold is 0.1",
           "[AccelerationReliability]")
 {
-    // Verifying the value here documents and guards against inadvertent changes.
     REQUIRE(AccelerationReliability::kCancellationThreshold ==
             Catch::Approx(0.1).epsilon(1e-15));
+}
+
+TEST_CASE("AccelerationReliability: kAccelMaterialThreshold is 0.10",
+          "[AccelerationReliability]")
+{
+    // Below this |â|, BCa's non-linear correction is numerically
+    // negligible (denominator 1 − â·(z₀+zα) stays within [0.84, 1.16]
+    // at 95% CI), so reliability is vacuously true regardless of any
+    // dominance or sensitivity finding.
+    REQUIRE(AccelerationReliability::kAccelMaterialThreshold ==
+            Catch::Approx(0.10).epsilon(1e-15));
+}
+
+TEST_CASE("AccelerationReliability: kSensitivityThreshold is 0.30",
+          "[AccelerationReliability]")
+{
+    // Maximum allowed relative change in â under single-observation
+    // removal before â is considered unstable. Applies only when â is
+    // material.
+    REQUIRE(AccelerationReliability::kSensitivityThreshold ==
+            Catch::Approx(0.30).epsilon(1e-15));
 }
 
 TEST_CASE("AccelerationReliability: isCancellationHeavy respects kCancellationThreshold",
           "[AccelerationReliability]")
 {
-    // Exactly at threshold: 0.1 is NOT < 0.1, so NOT heavy
-    AccelerationReliability at_threshold(true, 0.1, 0, 0, 0.1);
-    REQUIRE(at_threshold.isCancellationHeavy() == false);
+    auto make = [](double cancel) {
+        return AccelerationReliability(true, 0.1, 0, 0, cancel,
+                                       0.0, 0.0, 0.0, false, true);
+    };
 
-    // Just below threshold: heavy cancellation
-    AccelerationReliability just_below(true, 0.1, 0, 0, 0.099);
-    REQUIRE(just_below.isCancellationHeavy() == true);
+    REQUIRE(make(0.1  ).isCancellationHeavy() == false);  // strict <
+    REQUIRE(make(0.099).isCancellationHeavy() == true);
+    REQUIRE(make(0.9  ).isCancellationHeavy() == false);
+    REQUIRE(make(0.0  ).isCancellationHeavy() == true);
+    REQUIRE(make(1.0  ).isCancellationHeavy() == false);
+}
 
-    // Well above threshold: not heavy
-    AccelerationReliability high_ratio(true, 0.1, 0, 0, 0.9);
-    REQUIRE(high_ratio.isCancellationHeavy() == false);
+TEST_CASE("AccelerationReliability: accessors are independent of derived flags",
+          "[AccelerationReliability]")
+{
+    // The constructor stores flags directly; nothing is re-derived from
+    // the numeric fields. Verified here by constructing an intentionally
+    // inconsistent object — accessors must faithfully report what was
+    // stored, even if "reliable=true" would not be derivable from the
+    // numeric payload. Guards against a future refactor that accidentally
+    // recomputes reliability inside the class.
+    AccelerationReliability ar(true,   // reliable   (stored as-is)
+                               0.90,   // maxFrac    (would trip old rule)
+                               7,      // maxIdx
+                               3,      // nDominant  (would also trip)
+                               1.0,    // cancellationRatio
+                               0.50,   // accel      (material)
+                               0.00,   // accelWithoutTop
+                               1.00,   // accelRelativeChange (would fail sens)
+                               true,   // accelMaterial
+                               false); // sensitivityOk
 
-    // Zero ratio: maximum cancellation
-    AccelerationReliability zero_ratio(true, 0.0, 0, 0, 0.0);
-    REQUIRE(zero_ratio.isCancellationHeavy() == true);
-
-    // Ratio of 1.0: no cancellation at all
-    AccelerationReliability full_ratio(true, 0.1, 0, 0, 1.0);
-    REQUIRE(full_ratio.isCancellationHeavy() == false);
+    REQUIRE(ar.isReliable()            == true);   // as stored
+    REQUIRE(ar.isAccelMaterial()       == true);
+    REQUIRE(ar.isSensitivityOk()       == false);
+    REQUIRE(ar.getAccelRelativeChange() == Catch::Approx(1.0).epsilon(1e-12));
+    REQUIRE(ar.getMaxInfluenceFraction() == Catch::Approx(0.90).epsilon(1e-12));
 }
 
 // ============================================================================
 // JackknifeInfluence::compute() — analytical branch coverage
+//
+// All inputs below are raw jackknife deviations d_i = jk_avg − jk_i.
+// Expected values for â, â_without_top, relChange, maxFrac, and
+// cancellationRatio were computed independently and are hard-coded.
 // ============================================================================
 
-TEST_CASE("JackknifeInfluence: empty input returns reliable with no signal",
+TEST_CASE("JackknifeInfluence: empty input returns a trivially-reliable result",
           "[JackknifeInfluence]")
 {
-    // Empty dCubed: no jackknife information. No dominance possible.
-    // cancellationRatio=1.0 by convention.
-    const std::vector<double> dCubed;
-
-    auto result = JackknifeInfluence::compute(dCubed);
+    auto result = JackknifeInfluence::compute(std::vector<double>{});
 
     REQUIRE(result.isReliable()              == true);
+    REQUIRE(result.isAccelMaterial()         == false);
+    REQUIRE(result.isSensitivityOk()         == true);
+    REQUIRE(result.getAccel()                == Catch::Approx(0.0).margin(1e-15));
+    REQUIRE(result.getAccelWithoutTop()      == Catch::Approx(0.0).margin(1e-15));
     REQUIRE(result.getMaxInfluenceFraction() == Catch::Approx(0.0).margin(1e-15));
     REQUIRE(result.getNDominant()            == 0);
     REQUIRE(result.getCancellationRatio()    == Catch::Approx(1.0).epsilon(1e-12));
     REQUIRE(result.isCancellationHeavy()     == false);
 }
 
-TEST_CASE("JackknifeInfluence: negligible sumAbsCubic (all zeros) returns reliable",
+TEST_CASE("JackknifeInfluence: all-zero d vector returns trivially reliable",
           "[JackknifeInfluence]")
 {
-    // All dCubed values zero: sumAbsCubic ≤ 1e-100.
-    // â ≈ 0 → BCa degenerates to plain BC. No dominance possible.
-    // cancellationRatio=1.0 by convention (no signal to cancel).
-    const std::vector<double> dCubed = {0.0, 0.0, 0.0, 0.0};
+    // Σ|d³| ≈ 0 branch: â undefined → treated as 0 → not material → reliable.
+    const std::vector<double> d = {0.0, 0.0, 0.0, 0.0};
 
-    auto result = JackknifeInfluence::compute(dCubed);
+    auto result = JackknifeInfluence::compute(d);
 
     REQUIRE(result.isReliable()              == true);
+    REQUIRE(result.isAccelMaterial()         == false);
+    REQUIRE(result.getAccel()                == Catch::Approx(0.0).margin(1e-15));
     REQUIRE(result.getMaxInfluenceFraction() == Catch::Approx(0.0).margin(1e-15));
-    REQUIRE(result.getMaxInfluenceIndex()    == 0);
-    REQUIRE(result.getNDominant()            == 0);
     REQUIRE(result.getCancellationRatio()    == Catch::Approx(1.0).epsilon(1e-12));
 }
 
-TEST_CASE("JackknifeInfluence: single near-zero value returns reliable",
+TEST_CASE("JackknifeInfluence: single near-zero d value hits Σ|d³|≈0 path",
           "[JackknifeInfluence]")
 {
-    // Single element that is effectively zero — hits the negligible sumAbsCubic path.
-    const std::vector<double> dCubed = {1e-200};
+    const std::vector<double> d = {1e-200};
 
-    auto result = JackknifeInfluence::compute(dCubed);
+    auto result = JackknifeInfluence::compute(d);
 
     REQUIRE(result.isReliable()              == true);
+    REQUIRE(result.isAccelMaterial()         == false);
     REQUIRE(result.getMaxInfluenceFraction() == Catch::Approx(0.0).margin(1e-15));
-    REQUIRE(result.getNDominant()            == 0);
     REQUIRE(result.getCancellationRatio()    == Catch::Approx(1.0).epsilon(1e-12));
 }
 
-TEST_CASE("JackknifeInfluence: uniform positive influence is reliable",
+TEST_CASE("JackknifeInfluence: uniform positive d gives non-material â=1/(6√n)",
           "[JackknifeInfluence]")
 {
-    // dCubed = {1, 1, 1, 1}: sumAbsCubic=4, each frac=1/4=0.25 < 0.5
-    // All same sign → cancellationRatio = |4| / 4 = 1.0 (no cancellation)
-    const std::vector<double> dCubed = {1.0, 1.0, 1.0, 1.0};
+    // Analytic result: for d = c·1_n, â = 1/(6·√n) regardless of c.
+    // n=4 → â = 1/12 ≈ 0.0833, below kAccelMaterialThreshold=0.10 → reliable.
+    const std::vector<double> d = {1.0, 1.0, 1.0, 1.0};
 
-    auto result = JackknifeInfluence::compute(dCubed);
+    auto result = JackknifeInfluence::compute(d);
 
-    REQUIRE(result.isReliable()              == true);
-    REQUIRE(result.getMaxInfluenceFraction() == Catch::Approx(0.25).epsilon(1e-12));
-    REQUIRE(result.getMaxInfluenceIndex()    == 0);
-    REQUIRE(result.getNDominant()            == 0);
-    REQUIRE(result.getCancellationRatio()    == Catch::Approx(1.0).epsilon(1e-12));
-    REQUIRE(result.isCancellationHeavy()     == false);
-}
-
-TEST_CASE("JackknifeInfluence: one dominant observation (4/7 > 0.5) is unreliable",
-          "[JackknifeInfluence]")
-{
-    // dCubed = {4, 1, 1, 1}: sumAbsCubic=7
-    // frac[0]=4/7≈0.5714, frac[1..3]=1/7≈0.1429
-    // All same sign → cancellationRatio = |7|/7 = 1.0
-    const std::vector<double> dCubed = {4.0, 1.0, 1.0, 1.0};
-
-    auto result = JackknifeInfluence::compute(dCubed);
-
-    REQUIRE(result.isReliable()              == false);
-    REQUIRE(result.getMaxInfluenceFraction() == Catch::Approx(4.0 / 7.0).epsilon(1e-12));
-    REQUIRE(result.getMaxInfluenceIndex()    == 0);
-    REQUIRE(result.getNDominant()            == 1);
-    REQUIRE(result.getCancellationRatio()    == Catch::Approx(1.0).epsilon(1e-12));
-    REQUIRE(result.isCancellationHeavy()     == false);
-}
-
-TEST_CASE("JackknifeInfluence: borderline frac exactly 0.5 is treated as reliable",
-          "[JackknifeInfluence]")
-{
-    // dCubed = {1, 1}: each frac = 1/2 = 0.5 exactly.
-    // Dominance condition is strictly > 0.5, so 0.5 is NOT dominant.
-    // Reliable=true, nDominant=0. cancellationRatio=1.0 (same sign).
-    const std::vector<double> dCubed = {1.0, 1.0};
-
-    auto result = JackknifeInfluence::compute(dCubed);
-
-    REQUIRE(result.isReliable()              == true);
-    REQUIRE(result.getMaxInfluenceFraction() == Catch::Approx(0.5).epsilon(1e-12));
-    REQUIRE(result.getNDominant()            == 0);
-    REQUIRE(result.getCancellationRatio()    == Catch::Approx(1.0).epsilon(1e-12));
-}
-
-TEST_CASE("JackknifeInfluence: maxInfluenceIndex identifies correct observation",
-          "[JackknifeInfluence]")
-{
-    // dCubed = {1, 2, 8, 3}: sumAbsCubic=14, all positive
-    // fracs = {1/14, 2/14, 8/14, 3/14} = {0.0714, 0.1429, 0.5714, 0.2143}
-    // Dominant at index 2. cancellationRatio=1.0 (all same sign).
-    const std::vector<double> dCubed = {1.0, 2.0, 8.0, 3.0};
-
-    auto result = JackknifeInfluence::compute(dCubed);
-
-    REQUIRE(result.isReliable()              == false);
-    REQUIRE(result.getMaxInfluenceIndex()    == 2);
-    REQUIRE(result.getMaxInfluenceFraction() == Catch::Approx(8.0 / 14.0).epsilon(1e-12));
-    REQUIRE(result.getNDominant()            == 1);
-    REQUIRE(result.getCancellationRatio()    == Catch::Approx(1.0).epsilon(1e-12));
-}
-
-TEST_CASE("JackknifeInfluence: negative dominant value detected via abs()",
-          "[JackknifeInfluence]")
-{
-    // dCubed = {-4, 1, 1, 1}: sumAbsCubic = 4+1+1+1 = 7
-    //
-    // Under the CORRECT absolute-sum denominator:
-    //   frac[0] = 4/7 ≈ 0.571 > 0.5  →  dominant
-    //   frac[1..3] = 1/7 ≈ 0.143 < 0.5  →  not dominant
-    //   → nDominant=1, reliable=false
-    //
-    // NOTE: the signed sum is -4+1+1+1 = -1, so:
-    //   cancellationRatio = |-1| / 7 ≈ 0.143  (partial cancellation)
-    //
-    // This is different from the old buggy behavior which used |signed sum|=1
-    // as denominator, giving fracs {4.0, 1.0, 1.0, 1.0} — all exceeding 1.0.
-    // The absolute-sum denominator correctly identifies only the negative
-    // observation as dominant, since it alone exceeds 50% of total abs influence.
-    const std::vector<double> dCubed = {-4.0, 1.0, 1.0, 1.0};
-
-    auto result = JackknifeInfluence::compute(dCubed);
-
-    REQUIRE(result.isReliable()              == false);
-    REQUIRE(result.getMaxInfluenceFraction() == Catch::Approx(4.0 / 7.0).epsilon(1e-12));
-    REQUIRE(result.getMaxInfluenceIndex()    == 0);
-    REQUIRE(result.getNDominant()            == 1);
-    // cancellationRatio = |-1| / 7 ≈ 0.143 — partial cancellation but not heavy
-    REQUIRE(result.getCancellationRatio()    == Catch::Approx(1.0 / 7.0).epsilon(1e-12));
-    REQUIRE(result.isCancellationHeavy()     == false);
-}
-
-TEST_CASE("JackknifeInfluence: near-cancellation detected by cancellation ratio",
-          "[JackknifeInfluence]")
-{
-    // dCubed = {3, 3, -5}: sumAbsCubic = 3+3+5 = 11, sumSigned = 3+3-5 = 1
-    //
-    // Under the CORRECT absolute-sum denominator:
-    //   frac[0] = 3/11 ≈ 0.273, frac[1] = 3/11 ≈ 0.273, frac[2] = 5/11 ≈ 0.455
-    //   No fraction exceeds 0.5 → reliable=true, nDominant=0
-    //
-    // cancellationRatio = |1| / 11 ≈ 0.091 < kCancellationThreshold=0.1
-    //   → isCancellationHeavy=true
-    //
-    // This case illustrates the key design improvement: the old buggy denominator
-    // (|signed sum| = 1) would have given fracs {3.0, 3.0, 5.0}, all exceeding 1.0,
-    // and incorrectly labelled this as dominated. The corrected implementation
-    // correctly identifies that no single observation dominates — the signed sum
-    // is small because of cancellation among several comparable contributions,
-    // which is a separate diagnostic (isCancellationHeavy) not a dominance failure.
-    const std::vector<double> dCubed = {3.0, 3.0, -5.0};
-
-    auto result = JackknifeInfluence::compute(dCubed);
-
-    REQUIRE(result.isReliable()              == true);
-    REQUIRE(result.getNDominant()            == 0);
-    REQUIRE(result.getMaxInfluenceFraction() == Catch::Approx(5.0 / 11.0).epsilon(1e-12));
-    REQUIRE(result.getMaxInfluenceIndex()    == 2);
-    // cancellationRatio = |1|/11 ≈ 0.091 → heavy cancellation
-    REQUIRE(result.getCancellationRatio()    == Catch::Approx(1.0 / 11.0).epsilon(1e-12));
-    REQUIRE(result.isCancellationHeavy()     == true);
-}
-
-TEST_CASE("JackknifeInfluence: well-conditioned positive data has cancellationRatio near 1",
-          "[JackknifeInfluence]")
-{
-    // All same sign → signed sum equals absolute sum → ratio = 1.0
-    // {5, 3, 7, 2, 4}: sumAbsCubic = 21, sumSigned = 21, ratio = 1.0
-    const std::vector<double> dCubed = {5.0, 3.0, 7.0, 2.0, 4.0};
-
-    auto result = JackknifeInfluence::compute(dCubed);
-
-    REQUIRE(result.getCancellationRatio() == Catch::Approx(1.0).epsilon(1e-12));
-    REQUIRE(result.isCancellationHeavy()  == false);
-    // maxFrac = 7/21 ≈ 0.333, reliable
+    REQUIRE(result.getAccel()             == Catch::Approx(1.0 / 12.0).epsilon(1e-12));
+    REQUIRE(result.isAccelMaterial()      == false);
     REQUIRE(result.isReliable()           == true);
+    REQUIRE(result.getMaxInfluenceFraction() == Catch::Approx(0.25).epsilon(1e-12));
+    REQUIRE(result.getNDominant()         == 0);
+    REQUIRE(result.getCancellationRatio() == Catch::Approx(1.0).epsilon(1e-12));
+}
+
+TEST_CASE("JackknifeInfluence: materiality short-circuit — dominance fires but |â|<threshold → reliable",
+          "[JackknifeInfluence][MaterialityShortCircuit]")
+{
+    // THIS IS THE CENTRAL NEW BEHAVIOR: the cubic-share dominance metric
+    // fires (maxFrac > 0.5), but |â| is too small for the BCa correction to
+    // meaningfully affect the interval. The old rule would have rejected;
+    // the new rule correctly accepts.
+    //
+    // d = {3, 1, 1, -1, -1, -1}
+    //   Σd²  = 9+1+1+1+1+1 = 14
+    //   Σd³  = 27+1+1-1-1-1 = 26
+    //   Σ|d³|= 27+1+1+1+1+1 = 32
+    //   â    = 26 / (6·14^1.5) ≈ 0.0827    (NOT material: |â|<0.10)
+    //   maxFrac = 27/32 = 0.84375          (old rule → unreliable)
+    //   reliable = !material (true)        → reliable by short-circuit.
+    const std::vector<double> d = {3.0, 1.0, 1.0, -1.0, -1.0, -1.0};
+
+    auto result = JackknifeInfluence::compute(d);
+
+    REQUIRE(result.getAccel()             == Catch::Approx(0.082724).margin(1e-4));
+    REQUIRE(result.isAccelMaterial()      == false);
+    REQUIRE(result.getMaxInfluenceFraction() == Catch::Approx(27.0 / 32.0).epsilon(1e-10));
+    REQUIRE(result.getMaxInfluenceIndex() == 0);
+    REQUIRE(result.getNDominant()         == 1);   // legacy diagnostic still fires
+    REQUIRE(result.isReliable()           == true); // but reliability is true
+}
+
+TEST_CASE("JackknifeInfluence: material â driven by one observation → unreliable",
+          "[JackknifeInfluence][SensitivityTest]")
+{
+    // Same pattern as above but scaled so |â| ≥ 0.10.
+    // d = {5, 1, 1, -1, -1, -1}
+    //   Σd²  = 25+1+1+1+1+1 = 30
+    //   Σd³  = 125+1+1-1-1-1 = 124
+    //   â    = 124 / (6·30^1.5) ≈ 0.1258   (material)
+    //   Removing d[0]=5: d_r = {1,1,-1,-1,-1}
+    //     Σd²_r = 5, Σd³_r = -1
+    //     â_r = -1 / (6·5^1.5) ≈ -0.0149   (sign flip)
+    //   relChange = |0.1258 − (−0.0149)| / 0.1258 ≈ 1.12 > 0.30
+    //   → sensitivityOk = false → unreliable.
+    const std::vector<double> d = {5.0, 1.0, 1.0, -1.0, -1.0, -1.0};
+
+    auto result = JackknifeInfluence::compute(d);
+
+    REQUIRE(result.getAccel()             == Catch::Approx(0.125773).margin(1e-4));
+    REQUIRE(result.isAccelMaterial()      == true);
+    REQUIRE(result.getAccelWithoutTop()   == Catch::Approx(-0.014907).margin(1e-4));
+    REQUIRE(result.getAccelRelativeChange() == Catch::Approx(1.1185).margin(1e-3));
+    REQUIRE(result.isSensitivityOk()      == false);
+    REQUIRE(result.isReliable()           == false);
+    REQUIRE(result.getMaxInfluenceIndex() == 0);
+}
+
+TEST_CASE("JackknifeInfluence: material â robust to top-observation removal → reliable",
+          "[JackknifeInfluence][SensitivityTest]")
+{
+    // Smooth, all-positive d: removing the largest barely changes â.
+    // d = {1.0, 0.5, 0.3}
+    //   Σd²  = 1.34, Σd³ = 1.152
+    //   â    = 1.152 / (6·1.34^1.5) ≈ 0.1238     (material)
+    //   Removing d[0]=1.0: d_r = {0.5, 0.3}
+    //     Σd²_r = 0.34, Σd³_r = 0.152
+    //     â_r = 0.152 / (6·0.34^1.5) ≈ 0.1278
+    //   relChange = |0.1238 − 0.1278| / 0.1238 ≈ 0.032 ≤ 0.30
+    //   → sensitivityOk = true → reliable, despite maxFrac ≈ 0.87.
+    //
+    // This is the case that demonstrates the sensitivity test is strictly
+    // better than the cubic-share proxy: "one observation holds most of
+    // the cubic mass" does NOT imply "one observation drives â."
+    const std::vector<double> d = {1.0, 0.5, 0.3};
+
+    auto result = JackknifeInfluence::compute(d);
+
+    REQUIRE(result.getAccel()             == Catch::Approx(0.123778).margin(1e-4));
+    REQUIRE(result.isAccelMaterial()      == true);
+    REQUIRE(result.getAccelWithoutTop()   == Catch::Approx(0.127783).margin(1e-4));
+    REQUIRE(result.getAccelRelativeChange() == Catch::Approx(0.0324).margin(5e-3));
+    REQUIRE(result.isSensitivityOk()      == true);
+    REQUIRE(result.isReliable()           == true);
+    // Dominance metric still reports the lopsided cubic shares...
+    REQUIRE(result.getMaxInfluenceFraction() > 0.5);
+    // ...but is no longer a gate.
+}
+
+TEST_CASE("JackknifeInfluence: negative dominant value correctly handled via |·|",
+          "[JackknifeInfluence]")
+{
+    // d = {-4, 1, 1, 1}
+    //   Σd²  = 16+1+1+1 = 19
+    //   Σd³  = -64+1+1+1 = -61
+    //   â    = -61 / (6·19^1.5) ≈ -0.1228  (material)
+    //   maxFrac = 64/67 ≈ 0.9552; max_idx = 0 (correctly found via |d³|).
+    //   Removing d[0]=-4: d_r = {1,1,1}
+    //     â_r = 3 / (6·3^1.5) ≈ 0.0962  (sign flip)
+    //   relChange ≈ 1.78 > 0.30 → unreliable.
+    const std::vector<double> d = {-4.0, 1.0, 1.0, 1.0};
+
+    auto result = JackknifeInfluence::compute(d);
+
+    REQUIRE(result.getAccel()               == Catch::Approx(-0.122758).margin(1e-4));
+    REQUIRE(result.isAccelMaterial()        == true);
+    REQUIRE(result.getMaxInfluenceIndex()   == 0);
+    REQUIRE(result.getMaxInfluenceFraction() == Catch::Approx(64.0 / 67.0).epsilon(1e-10));
+    REQUIRE(result.getAccelWithoutTop()     == Catch::Approx(0.096225).margin(1e-4));
+    REQUIRE(result.getAccelRelativeChange() == Catch::Approx(1.7839).margin(1e-3));
+    REQUIRE(result.isSensitivityOk()        == false);
+    REQUIRE(result.isReliable()             == false);
+    // Partial cancellation: |Σd³|/Σ|d³| = 61/67 ≈ 0.910.
+    REQUIRE(result.getCancellationRatio()   == Catch::Approx(61.0 / 67.0).epsilon(1e-10));
+    REQUIRE(result.isCancellationHeavy()    == false);
+}
+
+TEST_CASE("JackknifeInfluence: heavy cancellation with â≈0 is reliable via short-circuit",
+          "[JackknifeInfluence]")
+{
+    // d = {3, 3, -3, -3, 0.01}
+    //   Σd³  ≈ 0 (27+27-27-27 plus negligible)
+    //   Σ|d³|= 108.000001
+    //   cancellationRatio ≈ 0 → isCancellationHeavy=true
+    //   â ≈ 0 → NOT material → reliable (materiality short-circuit).
+    //
+    // Note: relChange is numerically astronomical here because the denom
+    // clamps to 1e-6 while the numerator is small but non-zero. This is
+    // harmless — the short-circuit dominates. The test below pins that
+    // behavior: even with a huge relChange, reliable=true when â is tiny.
+    const std::vector<double> d = {3.0, 3.0, -3.0, -3.0, 0.01};
+
+    auto result = JackknifeInfluence::compute(d);
+
+    REQUIRE(std::fabs(result.getAccel())    < 1e-6);
+    REQUIRE(result.isAccelMaterial()        == false);
+    REQUIRE(result.isCancellationHeavy()    == true);
+    REQUIRE(result.isReliable()             == true);  // short-circuit wins
+}
+
+TEST_CASE("JackknifeInfluence: maxInfluenceIndex identifies top |d³| with mixed signs",
+          "[JackknifeInfluence]")
+{
+    // d = {1, -2, 3, -0.5}: |d³| = {1, 8, 27, 0.125}. Max at idx=2.
+    //   Σd²  = 1+4+9+0.25 = 14.25
+    //   Σd³  = 1-8+27-0.125 = 19.875
+    //   Σ|d³|= 36.125
+    //   â    = 19.875 / (6·14.25^1.5) ≈ 0.0615 — not material, reliable.
+    const std::vector<double> d = {1.0, -2.0, 3.0, -0.5};
+
+    auto result = JackknifeInfluence::compute(d);
+
+    REQUIRE(result.getMaxInfluenceIndex()   == 2);
+    REQUIRE(result.getMaxInfluenceFraction() == Catch::Approx(27.0 / 36.125).epsilon(1e-10));
+    REQUIRE(result.isAccelMaterial()        == false);
+    REQUIRE(result.isReliable()             == true);
+}
+
+TEST_CASE("JackknifeInfluence: nDominant counts cubic-share hits for diagnostics",
+          "[JackknifeInfluence]")
+{
+    // nDominant is diagnostic-only under the new rule; this test pins
+    // that it still counts correctly for logging/observability.
+
+    // No dominance: fracs {9/19, 9/19, 1/19}.
+    {
+        const std::vector<double> d = {std::cbrt(9.0), std::cbrt(9.0), std::cbrt(1.0)};
+        auto r = JackknifeInfluence::compute(d);
+        REQUIRE(r.getNDominant() == 0);
+    }
+
+    // Exactly one dominant contributor: fracs {10/12, 1/12, 1/12}.
+    {
+        const std::vector<double> d = {std::cbrt(10.0), std::cbrt(1.0), std::cbrt(1.0)};
+        auto r = JackknifeInfluence::compute(d);
+        REQUIRE(r.getNDominant() == 1);
+    }
 }
 
 TEST_CASE("JackknifeInfluence: cancellationRatio boundary at kCancellationThreshold",
           "[JackknifeInfluence]")
 {
-    // Construct dCubed where |sumSigned| / sumAbsCubic = exactly 0.1
-    // {10, -9, 1}: sumSigned=2, sumAbs=20, ratio=2/20=0.1
-    // ratio = 0.1 is NOT < 0.1, so isCancellationHeavy=false (strict <)
-    const std::vector<double> dCubed = {10.0, -9.0, 1.0};
+    // Construct d where |Σd³| / Σ|d³| = exactly 0.1.
+    // d = {a, b, c} with d³ = {10, -9, 1} → sumSigned=2, sumAbs=20, ratio=0.1.
+    const std::vector<double> d = {
+        std::cbrt( 10.0),
+        std::cbrt( -9.0),
+        std::cbrt(  1.0)
+    };
 
-    auto result = JackknifeInfluence::compute(dCubed);
+    auto result = JackknifeInfluence::compute(d);
 
-    REQUIRE(result.getCancellationRatio() == Catch::Approx(0.1).epsilon(1e-12));
-    REQUIRE(result.isCancellationHeavy()  == false);  // exactly at threshold, NOT heavy
-    // frac[0] = 10/20 = 0.5 → NOT > 0.5, reliable
-    REQUIRE(result.isReliable()           == true);
-}
-
-TEST_CASE("JackknifeInfluence: nDominant counts all observations above threshold",
-          "[JackknifeInfluence]")
-{
-    // dCubed = {6, 5, 4, 1}: sumAbsCubic=16, all positive
-    // fracs = {6/16, 5/16, 4/16, 1/16} = {0.375, 0.3125, 0.25, 0.0625}
-    // None exceed 0.5 → reliable=true, nDominant=0
-    {
-        const std::vector<double> dCubed = {6.0, 5.0, 4.0, 1.0};
-        auto result = JackknifeInfluence::compute(dCubed);
-        REQUIRE(result.isReliable()   == true);
-        REQUIRE(result.getNDominant() == 0);
-        REQUIRE(result.getCancellationRatio() == Catch::Approx(1.0).epsilon(1e-12));
-    }
-
-    // dCubed = {9, 9, 1}: sumAbsCubic=19
-    // fracs = {9/19, 9/19, 1/19} ≈ {0.4737, 0.4737, 0.0526}
-    // None exceed 0.5 → reliable=true, nDominant=0
-    {
-        const std::vector<double> dCubed = {9.0, 9.0, 1.0};
-        auto result = JackknifeInfluence::compute(dCubed);
-        REQUIRE(result.isReliable()   == true);
-        REQUIRE(result.getNDominant() == 0);
-    }
-
-    // dCubed = {10, 10, 1}: sumAbsCubic=21
-    // fracs = {10/21, 10/21, 1/21} ≈ {0.4762, 0.4762, 0.0476}
-    // None exceed 0.5 → nDominant=0
-    {
-        const std::vector<double> dCubed = {10.0, 10.0, 1.0};
-        auto result = JackknifeInfluence::compute(dCubed);
-        REQUIRE(result.isReliable()   == true);
-        REQUIRE(result.getNDominant() == 0);
-    }
-
-    // dCubed = {11, 11, 1}: sumAbsCubic=23
-    // fracs = {11/23, 11/23, 1/23} ≈ {0.4783, 0.4783, 0.0435}
-    // Still none > 0.5 → nDominant=0
-    {
-        const std::vector<double> dCubed = {11.0, 11.0, 1.0};
-        auto result = JackknifeInfluence::compute(dCubed);
-        REQUIRE(result.isReliable()   == true);
-        REQUIRE(result.getNDominant() == 0);
-    }
-
-    // dCubed = {4, 4, -7}: sumAbsCubic=15, sumSigned=1
-    // fracs = {4/15, 4/15, 7/15} ≈ {0.267, 0.267, 0.467}
-    // None exceed 0.5 → reliable=true, nDominant=0
-    // But cancellationRatio = |1|/15 ≈ 0.067 → isCancellationHeavy=true
-    // NOTE: the old buggy denominator (|sumSigned|=1) gave fracs {4,4,7} — all > 0.5.
-    // The corrected implementation correctly identifies no dominance.
-    {
-        const std::vector<double> dCubed = {4.0, 4.0, -7.0};
-        auto result = JackknifeInfluence::compute(dCubed);
-        REQUIRE(result.isReliable()           == true);
-        REQUIRE(result.getNDominant()         == 0);
-        REQUIRE(result.getMaxInfluenceFraction() == Catch::Approx(7.0 / 15.0).epsilon(1e-12));
-        REQUIRE(result.getCancellationRatio() == Catch::Approx(1.0 / 15.0).epsilon(1e-12));
-        REQUIRE(result.isCancellationHeavy()  == true);
-    }
-}
-
-TEST_CASE("JackknifeInfluence: single dominant element in a longer vector",
-          "[JackknifeInfluence]")
-{
-    // Build a vector of 20 near-equal values with one dominant outlier at index 12.
-    // dCubed[0..11,13..19] = 0.01 (19 values at 0.01)
-    // dCubed[12] = 10.0
-    // sumAbsCubic = 19 * 0.01 + 10.0 = 10.19  (all positive, equals signed sum)
-    // frac[12] = 10.0 / 10.19 ≈ 0.9814 > 0.5 → dominant
-    // cancellationRatio = 10.19 / 10.19 = 1.0 (all positive, no cancellation)
-    std::vector<double> dCubed(20, 0.01);
-    dCubed[12] = 10.0;
-
-    const double sumAbsCubic = 19 * 0.01 + 10.0; // = 10.19
-    const double frac12      = 10.0 / sumAbsCubic;
-    const double fracRest    = 0.01 / sumAbsCubic;
-
-    auto result = JackknifeInfluence::compute(dCubed);
-
-    REQUIRE(result.isReliable()              == false);
-    REQUIRE(result.getMaxInfluenceIndex()    == 12);
-    REQUIRE(result.getMaxInfluenceFraction() == Catch::Approx(frac12).epsilon(1e-10));
-    REQUIRE(result.getNDominant()            == 1);
-    REQUIRE(result.getCancellationRatio()    == Catch::Approx(1.0).epsilon(1e-10));
-    REQUIRE(result.isCancellationHeavy()     == false);
-
-    // All non-dominant fractions are far below threshold
-    REQUIRE(fracRest < 0.01);
+    REQUIRE(result.getCancellationRatio() == Catch::Approx(0.1).epsilon(1e-10));
+    REQUIRE(result.isCancellationHeavy()  == false);  // strict <
 }
 
 // ============================================================================
 // BCaBootStrap::getAccelerationReliability() — integration tests
+//
+// Expected numerical values below are for the arithmetic-mean statistic
+// (IID delete-one jackknife) and were verified independently.
 // ============================================================================
 
 TEST_CASE("BCaBootStrap::getAccelerationReliability: degenerate all-equal data",
           "[BCaBootStrap][AccelerationReliability]")
 {
-    // All returns identical → all_equal early-exit path in calculateBCaBounds().
-    // â = 0, all dCubed = 0 → sumAbsCubic negligible → reliable=true.
-    // cancellationRatio = 1.0 by convention.
+    // all_equal early-exit path in calculateBCaBounds(): â=0, reliable=true.
     std::vector<DecimalType> returns(10, createDecimal("0.01"));
 
     BCaBootStrap<DecimalType> bca(returns, 500, 0.95);
     auto rel = bca.getAccelerationReliability();
 
     REQUIRE(rel.isReliable()              == true);
+    REQUIRE(rel.isAccelMaterial()         == false);
+    REQUIRE(rel.getAccel()                == Catch::Approx(0.0).margin(1e-12));
     REQUIRE(rel.getMaxInfluenceFraction() == Catch::Approx(0.0).margin(1e-15));
     REQUIRE(rel.getNDominant()            == 0);
     REQUIRE(rel.getCancellationRatio()    == Catch::Approx(1.0).epsilon(1e-12));
     REQUIRE(rel.isCancellationHeavy()     == false);
 }
 
-TEST_CASE("BCaBootStrap::getAccelerationReliability: diffuse influence data is reliable",
+TEST_CASE("BCaBootStrap::getAccelerationReliability: diffuse-influence data is reliable",
           "[BCaBootStrap][AccelerationReliability]")
 {
-    // DESIGN RATIONALE:
-    // For the arithmetic mean statistic, d[i] = (returns[i] - mean) / (n-1),
-    // so the dominance fraction simplifies to:
-    //
-    //   frac[i] = |returns[i] - mean|³ / Σ_j |returns[j] - mean|³
-    //
-    // The denominator is the SUM OF ABSOLUTE VALUES of cubed deviations —
-    // NOT |Σ(returns[j] - mean)³|. This ensures fracs are always in [0,1]
-    // and near-cancellation does not inflate them.
-    //
-    // reliable=true requires max frac[i] ≤ 0.5. This is achieved by a
-    // positively skewed distribution where no single observation dominates
-    // the total absolute cubic influence.
-    //
-    // This dataset is analytically verified under the CORRECTED absolute-sum
-    // denominator (Σ|d³|, not |Σd³|):
-    //   8 values at 0.002–0.008, 4 values at 0.035–0.038
+    // 8 values at 0.002–0.008, 4 values at 0.035–0.038. No single
+    // observation dominates. Analytically:
     //   mean ≈ 0.0155
-    //
-    //   dCubed signs: small-cluster observations are below the mean, so
-    //   removing them raises the LOO mean → d[i] < 0 → dCubed[i] < 0.
-    //   Large-cluster observations are above the mean → dCubed[i] > 0.
-    //   The cubic terms have MIXED SIGNS — this is why the denominator
-    //   choice matters: Σ|d³| > |Σd³|, so all fractions are smaller
-    //   under the corrected denominator than under the old buggy one.
-    //
-    //   Verified in Python (absolute-sum denominator):
-    //     sumSigned ≈ 2.04e-8, sumAbsCubic ≈ 3.57e-8
-    //     fracs (i=0..7):  0.052, 0.041, 0.032, 0.024, 0.024, 0.018, 0.013, 0.009
-    //     fracs (i=8..11): 0.156, 0.181, 0.209, 0.240
-    //     maxFrac ≈ 0.240 at idx=11 < 0.5  →  reliable=true, nDominant=0
-    //     cancellationRatio = |2.04e-8| / 3.57e-8 ≈ 0.573
-    //       (partial cancellation between negative small and positive large cubics)
+    //   â ≈ +0.0327 (not material)
+    //   maxFrac ≈ 0.2398 (idx=11, the largest return)
+    //   cancellationRatio ≈ 0.5729
+    //   relChange ≈ 0.2039 (below 0.30 threshold; also moot since not material)
     std::vector<DecimalType> returns = {
         createDecimal("0.002"), createDecimal("0.003"), createDecimal("0.004"),
         createDecimal("0.005"), createDecimal("0.005"), createDecimal("0.006"),
@@ -474,42 +488,26 @@ TEST_CASE("BCaBootStrap::getAccelerationReliability: diffuse influence data is r
     auto rel = bca.getAccelerationReliability();
 
     REQUIRE(rel.isReliable()              == true);
-    REQUIRE(rel.getMaxInfluenceFraction()  < 0.5);
-    REQUIRE(rel.getNDominant()            == 0);
-    // Analytically: maxFrac ≈ 0.240 (corrected from old 0.419 which used |Σd³| as denominator)
+    REQUIRE(rel.isAccelMaterial()         == false);
+    REQUIRE(rel.getAccel()                == Catch::Approx(0.0327).margin(0.002));
     REQUIRE(rel.getMaxInfluenceFraction() == Catch::Approx(0.240).margin(0.01));
-    // Partial cancellation between negative (small returns) and positive
-    // (large returns) cubic contributions → cancellationRatio ≈ 0.573
+    REQUIRE(rel.getNDominant()            == 0);
     REQUIRE(rel.getCancellationRatio()    == Catch::Approx(0.573).margin(0.05));
-    REQUIRE(rel.isCancellationHeavy()     == false);  // 0.573 >> kCancellationThreshold
+    REQUIRE(rel.isCancellationHeavy()     == false);
 }
 
 TEST_CASE("BCaBootStrap::getAccelerationReliability: single extreme outlier is unreliable",
-          "[BCaBootStrap][AccelerationReliability]")
+          "[BCaBootStrap][AccelerationReliability][SensitivityTest]")
 {
-    // Returns = {0.001 x4, 1.0}: one observation ~1000x larger than the rest.
+    // Returns = {0.001×4, 1.0}: outlier dwarfs everything.
+    //   d[0..3] = -0.04995, d[4] = +0.1998
+    //   â ≈ +0.1118   (MATERIAL, |â| ≥ 0.10)
+    //   maxFrac ≈ 0.9412 at idx=4
+    //   Removing d[4]: â_without_top ≈ -0.0833  (sign flips)
+    //   relChange ≈ 1.75 > 0.30 → sensitivityOk=false → unreliable.
     //
-    // IID delete-one jackknife on mean:
-    //   jk[0..3] = (4 * 0.001 + 1.0 - 0.001) / 4 = 1.003/4 = 0.25075
-    //   jk[4]    = (4 * 0.001) / 4               = 0.001
-    //   jk_avg                                    = 0.2008
-    //
-    //   d[0..3] = 0.2008 - 0.25075 = -0.04995
-    //   d[4]    = 0.2008 - 0.001   =  0.1998
-    //
-    //   dCubed[0..3] ≈ -0.0001246 each
-    //   dCubed[4]    ≈  0.007976
-    //
-    //   sumAbsCubic = 4 * 0.0001246 + 0.007976 = 0.008474
-    //   frac[4] = 0.007976 / 0.008474 ≈ 0.941 > 0.5  →  dominant
-    //
-    //   cancellationRatio = |sumSigned| / sumAbsCubic
-    //                     = |0.007477| / 0.008474 ≈ 0.882  (not heavy cancellation)
-    //
-    // Under the OLD buggy denominator (|sumSigned| = 0.007477):
-    //   frac[4] = 0.007976 / 0.007477 ≈ 1.067 — exceeded 1.0, showing the bug.
-    // Under the CORRECT absolute-sum denominator:
-    //   frac[4] ≈ 0.941 — still dominant, correctly identified.
+    // Confirms that a genuine single-point outlier with material â is
+    // still correctly rejected by the new rule.
     std::vector<DecimalType> returns = {
         createDecimal("0.001"), createDecimal("0.001"),
         createDecimal("0.001"), createDecimal("0.001"),
@@ -519,26 +517,64 @@ TEST_CASE("BCaBootStrap::getAccelerationReliability: single extreme outlier is u
     BCaBootStrap<DecimalType> bca(returns, 1000, 0.95);
     auto rel = bca.getAccelerationReliability();
 
-    REQUIRE(rel.isReliable()           == false);
-    REQUIRE(rel.getMaxInfluenceIndex() == 4);      // the outlier observation
-    REQUIRE(rel.getNDominant()         == 1);
-    // frac ≈ 0.941: dominant, well above threshold, bounded in [0,1]
-    REQUIRE(rel.getMaxInfluenceFraction() > 0.5);
+    REQUIRE(rel.isReliable()              == false);
+    REQUIRE(rel.isAccelMaterial()         == true);
+    REQUIRE(rel.isSensitivityOk()         == false);
+    REQUIRE(rel.getAccel()                == Catch::Approx( 0.1118).margin(1e-3));
+    REQUIRE(rel.getAccelWithoutTop()      == Catch::Approx(-0.0833).margin(1e-3));
+    REQUIRE(rel.getAccelRelativeChange()  > 1.0);  // ≈ 1.75
+    REQUIRE(rel.getMaxInfluenceIndex()    == 4);
     REQUIRE(rel.getMaxInfluenceFraction() == Catch::Approx(0.941).epsilon(0.01));
-    // Not heavy cancellation — outlier and regular observations have opposite-sign
-    // cubic contributions, but the outlier's magnitude is so dominant that the
-    // signed sum is still large relative to the absolute sum.
-    REQUIRE(rel.getCancellationRatio()    > 0.5);
-    REQUIRE(rel.isCancellationHeavy()     == false);
+    REQUIRE(rel.getNDominant()            == 1);
 }
 
-TEST_CASE("BCaBootStrap::getAccelerationReliability: isReliable is consistent with maxInfluenceFraction",
+TEST_CASE("BCaBootStrap::getAccelerationReliability: materiality short-circuit fixes user's reported case",
+          "[BCaBootStrap][AccelerationReliability][MaterialityShortCircuit]")
+{
+    // Real-data analog of the bug the user reported: n=6, a single
+    // moderately large return drives the cubic-share metric over 0.5,
+    // but the resulting |â| is well below the material threshold, so
+    // BCa's correction is negligible and the interval is fine.
+    //
+    // Returns = {-0.02, -0.01, 0, 0.01, 0.02, 0.05}
+    //   mean ≈ 0.00833
+    //   â ≈ +0.0447         (NOT material)
+    //   maxFrac ≈ 0.70 at idx=5  (old rule → REJECTED; new rule → accepted)
+    //
+    // Under the OLD fixed-0.5 dominance gate this would have been flagged
+    // "dominant jackknife observation" just like the user's production
+    // case with a = -0.047. Under the new rule, the materiality
+    // short-circuit correctly reports reliable.
+    std::vector<DecimalType> returns = {
+        createDecimal("-0.02"), createDecimal("-0.01"), createDecimal("0.0"),
+        createDecimal("0.01"),  createDecimal("0.02"),  createDecimal("0.05")
+    };
+
+    BCaBootStrap<DecimalType> bca(returns, 500, 0.95);
+    auto rel = bca.getAccelerationReliability();
+
+    // The key assertions: maxFrac would have tripped the old rule...
+    REQUIRE(rel.getMaxInfluenceFraction() > AccelerationReliability::kDominanceThreshold);
+    REQUIRE(rel.getNDominant()            >= 1);
+    // ...but |â| is below the material threshold...
+    REQUIRE(std::fabs(rel.getAccel()) < AccelerationReliability::kAccelMaterialThreshold);
+    REQUIRE(rel.isAccelMaterial()         == false);
+    // ...so the new rule correctly reports reliable.
+    REQUIRE(rel.isReliable()              == true);
+}
+
+TEST_CASE("BCaBootStrap::getAccelerationReliability: new invariant — reliable iff (!material OR sensitivityOk)",
           "[BCaBootStrap][AccelerationReliability]")
 {
-    // Structural invariant: isReliable() == (maxInfluenceFraction <= kDominanceThreshold).
-    const double threshold = AccelerationReliability::kDominanceThreshold;
+    // Under the new rule, this logical invariant must hold by construction.
+    // Verified on both a well-behaved and an outlier dataset.
 
-    // Reliable case
+    auto check_invariant = [](const AccelerationReliability& rel) {
+        const bool expected = (!rel.isAccelMaterial()) || rel.isSensitivityOk();
+        REQUIRE(rel.isReliable() == expected);
+    };
+
+    // Reliable dataset
     {
         std::vector<DecimalType> returns = {
             createDecimal("0.002"), createDecimal("0.003"), createDecimal("0.004"),
@@ -548,15 +584,10 @@ TEST_CASE("BCaBootStrap::getAccelerationReliability: isReliable is consistent wi
             createDecimal("0.037"), createDecimal("0.038")
         };
         BCaBootStrap<DecimalType> bca(returns, 500, 0.95);
-        auto rel = bca.getAccelerationReliability();
-
-        if (rel.getMaxInfluenceFraction() <= threshold)
-            REQUIRE(rel.isReliable() == true);
-        else
-            REQUIRE(rel.isReliable() == false);
+        check_invariant(bca.getAccelerationReliability());
     }
 
-    // Unreliable case (outlier-driven)
+    // Unreliable dataset
     {
         std::vector<DecimalType> returns = {
             createDecimal("0.001"), createDecimal("0.001"),
@@ -564,12 +595,7 @@ TEST_CASE("BCaBootStrap::getAccelerationReliability: isReliable is consistent wi
             createDecimal("1.0")
         };
         BCaBootStrap<DecimalType> bca(returns, 500, 0.95);
-        auto rel = bca.getAccelerationReliability();
-
-        if (rel.getMaxInfluenceFraction() <= threshold)
-            REQUIRE(rel.isReliable() == true);
-        else
-            REQUIRE(rel.isReliable() == false);
+        check_invariant(bca.getAccelerationReliability());
     }
 }
 
@@ -589,27 +615,32 @@ TEST_CASE("BCaBootStrap::getAccelerationReliability: result is stable across rep
     auto rel2 = bca.getAccelerationReliability();
     auto rel3 = bca.getAccelerationReliability();
 
+    // Core reliability + legacy diagnostics
     REQUIRE(rel1.isReliable()              == rel2.isReliable());
     REQUIRE(rel1.isReliable()              == rel3.isReliable());
     REQUIRE(rel1.getMaxInfluenceFraction() ==
             Catch::Approx(rel2.getMaxInfluenceFraction()).epsilon(1e-15));
-    REQUIRE(rel1.getMaxInfluenceFraction() ==
-            Catch::Approx(rel3.getMaxInfluenceFraction()).epsilon(1e-15));
     REQUIRE(rel1.getMaxInfluenceIndex()    == rel2.getMaxInfluenceIndex());
-    REQUIRE(rel1.getMaxInfluenceIndex()    == rel3.getMaxInfluenceIndex());
     REQUIRE(rel1.getNDominant()            == rel2.getNDominant());
-    REQUIRE(rel1.getNDominant()            == rel3.getNDominant());
     REQUIRE(rel1.getCancellationRatio()    ==
             Catch::Approx(rel2.getCancellationRatio()).epsilon(1e-15));
-    REQUIRE(rel1.getCancellationRatio()    ==
-            Catch::Approx(rel3.getCancellationRatio()).epsilon(1e-15));
+
+    // New fields must also be stable
+    REQUIRE(rel1.getAccel()                ==
+            Catch::Approx(rel2.getAccel()).epsilon(1e-15));
+    REQUIRE(rel1.getAccelWithoutTop()      ==
+            Catch::Approx(rel3.getAccelWithoutTop()).epsilon(1e-15));
+    REQUIRE(rel1.getAccelRelativeChange()  ==
+            Catch::Approx(rel2.getAccelRelativeChange()).epsilon(1e-15));
+    REQUIRE(rel1.isAccelMaterial()         == rel2.isAccelMaterial());
+    REQUIRE(rel1.isSensitivityOk()         == rel3.isSensitivityOk());
 }
 
 TEST_CASE("BCaBootStrap::getAccelerationReliability: larger well-behaved dataset is reliable",
           "[BCaBootStrap][AccelerationReliability]")
 {
     // n=50 with a realistic mix of small positive and negative returns.
-    // No single observation should dominate the total absolute cubic influence.
+    // Analytically: â ≈ -0.035 (not material), maxFrac ≈ 0.159.
     std::vector<DecimalType> returns;
     returns.reserve(50);
     for (int i = 0; i < 50; ++i)
@@ -623,12 +654,17 @@ TEST_CASE("BCaBootStrap::getAccelerationReliability: larger well-behaved dataset
     BCaBootStrap<DecimalType> bca(returns, 1000, 0.95);
     auto rel = bca.getAccelerationReliability();
 
-    REQUIRE(rel.isReliable()   == true);
-    REQUIRE(rel.getNDominant() == 0);
-    // With 50 observations, max fraction should be well below 0.5
+    REQUIRE(rel.isReliable()              == true);
+    REQUIRE(rel.isAccelMaterial()         == false);
+    REQUIRE(rel.getNDominant()            == 0);
     REQUIRE(rel.getMaxInfluenceFraction() < 0.3);
-    // cancellationRatio is finite and in [0,1]
-    REQUIRE(std::isfinite(rel.getCancellationRatio()));
+
+    // The "a_wo" and "relChange" fields are computed from the (n-1)-sized
+    // jackknife with the top contributor removed; still finite and sensible.
+    REQUIRE(std::isfinite(rel.getAccelWithoutTop()));
+    REQUIRE(std::isfinite(rel.getAccelRelativeChange()));
+
+    // Sanity on dominance/cancellation diagnostics
     REQUIRE(rel.getCancellationRatio() >= 0.0);
     REQUIRE(rel.getCancellationRatio() <= 1.0);
 }
@@ -636,8 +672,10 @@ TEST_CASE("BCaBootStrap::getAccelerationReliability: larger well-behaved dataset
 TEST_CASE("BCaBootStrap::getAccelerationReliability: StationaryBlockResampler path",
           "[BCaBootStrap][AccelerationReliability][Stationary]")
 {
-    // Verify the reliability diagnostic works through the StationaryBlockResampler
-    // path (block jackknife, not delete-one).
+    // Verify the reliability diagnostic works through the stationary-block
+    // jackknife (delete-block, not delete-one). With L=3 and n=60 the
+    // block means are all equal (each block contains {0.004, 0.004, -0.003}),
+    // so d ≈ 0 → â ≈ 0 → not material → reliable.
     using Policy = StationaryBlockResampler<DecimalType>;
 
     std::vector<DecimalType> returns;
@@ -647,7 +685,6 @@ TEST_CASE("BCaBootStrap::getAccelerationReliability: StationaryBlockResampler pa
         returns.push_back(createDecimal("0.004"));
         returns.push_back(createDecimal("-0.003"));
     }
-    // n=60, mild autocorrelation pattern
 
     Policy pol(3);
     BCaBootStrap<DecimalType, Policy> bca(returns, 1000, 0.95,
@@ -655,14 +692,12 @@ TEST_CASE("BCaBootStrap::getAccelerationReliability: StationaryBlockResampler pa
                                           pol);
     auto rel = bca.getAccelerationReliability();
 
-    // Block jackknife: floor(60/3)=20 pseudo-values.
-    // Each block contains identical content {0.004, 0.004, -0.003}, so all
-    // block means are equal → d=0 → dCubed=0 → negligible sumAbsCubic → reliable.
-    REQUIRE(rel.isReliable()   == true);
-    REQUIRE(rel.getNDominant() == 0);
+    REQUIRE(rel.isReliable()              == true);
+    REQUIRE(rel.isAccelMaterial()         == false);
+    REQUIRE(rel.getNDominant()            == 0);
     REQUIRE(rel.getMaxInfluenceFraction() < 0.5);
 
-    // Diagnostic fields are self-consistent
+    // Diagnostic fields self-consistent
     REQUIRE(std::isfinite(rel.getMaxInfluenceFraction()));
     REQUIRE(rel.getMaxInfluenceFraction() >= 0.0);
     REQUIRE(std::isfinite(rel.getCancellationRatio()));


### PR DESCRIPTION
# Fix spurious BCa rejection at small n: Tier 1/2/3 refactor of acceleration reliability
 
## Summary
 
Refactors the BCa (bias-corrected and accelerated) bootstrap reliability machinery to fix a class of spurious rejections observed at small sample sizes (n ≈ 18) where BCa was being disqualified from the confidence-interval tournament despite producing valid, accurate intervals. The fallback to MOutOfN in these cases was unnecessary and produced wider intervals than BCa would have.
 
The fix is structural rather than a parameter tweak. It narrows the reliability check so it only fires on genuinely problematic cases (**Tier 1** and **Tier 2**), and replaces the hard-rejection gate with a soft stability penalty so BCa competes fairly rather than being vetoed outright (**Tier 3**).
 
---
 
## The problem
 
Production log from a strategy with n=18 trades:
 
```
[BCa] acceleration penalty: |a|=0.04703... threshold=0.10000000 penalty=0.00000000
[BCa] Total stability penalty: 0.00000000
[AutoCI] BCa not selected — disqualified: dominant jackknife observation
[AutoCI] Selected method=MOutOfN
```
 
BCa computed `â = -0.047`, which was well below the `kBcaASoftThreshold = 0.10` and produced **zero** magnitude-based penalty. Yet BCa was still hard-disqualified from the tournament. Why?
 
### Root cause
 
`BCaBootStrap::getAccelerationReliability()` used a fixed threshold on the cubic-share statistic:
 
> "Reliable" if and only if `max_i |d_i|³ / Σ_i |d_i|³ < 0.50`, where `d_i` are the jackknife deviations.
 
At small n this metric concentrates naturally, independent of any pathology. Monte Carlo (50,000 trials, n=18):
 
| Distribution | Test statistic | False-rejection rate |
|--------------|----------------|----------------------|
| Gaussian | mean | 16.1% |
| Gaussian | log PF | 36.4% |
| Student-t (df=5) | mean | 35.7% |
| Student-t (df=5) | log PF | 49.1% |
 
Theoretical expectation for `E[max\|d\|³ / Σ\|d\|³]` at n=18 under standard normal: ~0.48 — right up against the 0.5 threshold. The threshold was firing on noise, not outliers.
 
Second observation from the Monte Carlo: **100% of false-rejection samples had |â| < 0.10**. In that regime the BCa correction is numerically trivial (BCa ≈ BC); whether `â` came from a "dominant" observation is irrelevant because the correction doesn't meaningfully change the interval anyway.
 
---
 
## The fix
 
Three independent changes, each solving a distinct problem:
 
### Tier 1 — Materiality short-circuit
 
In `JackknifeInfluence::compute()`, if `|â| < kAccelMaterialThreshold = 0.10`, report `isReliable = true` unconditionally. The BCa correction is numerically trivial in this regime; the reliability of `â` doesn't matter.
 
This alone eliminates the 16–49% false-rejection rate observed in Monte Carlo for small-|â| cases.
 
### Tier 2 — Leave-one-out sensitivity test
 
Replace the cubic-share proxy with a direct test of what we actually care about: does `â` depend on a single observation?
 
```
accelWithoutTop = compute â with the max-|d³| observation removed
relChange       = |â − accelWithoutTop| / max(|â|, tiny)
sensitivityOk   = relChange < kSensitivityThreshold (0.30)
```
 
This is a proper statistical leave-one-out test. It fires only when `â` is both material (Tier 1 gate passed) AND demonstrably driven by one observation (sign flips, order-of-magnitude change, etc.). Sample-size-agnostic by construction.
 
Final rule: `isReliable = !accelMaterial || sensitivityOk`.
 
### Tier 3 — Soft penalty replaces hard gate
 
In `CandidateGateKeeper::isBcaCandidateValid()`, remove the line:
 
```cpp
if (!candidate.getAccelIsReliable())
    return false;
```
 
Replace in `AutoBootstrapSelector::summarizeBCa()` with a finite penalty added to `stability_penalty`:
 
```cpp
if (!accel_is_reliable)
    stability_penalty += AutoBootstrapConfiguration::kBcaAccelUnreliablePenalty;
```
 
New constant `kBcaAccelUnreliablePenalty = 0.5`, which normalizes to 2.0 at `kRefStability = 0.25` — same magnitude as `kBcaTransformNonMonotonePenalty` and in the same weight class as `kMOutOfNUnreliabilityPenalty`. BCa now competes in the tournament and wins or loses on score, consistent with how every other reliability signal is handled.
 
Why soft rather than hard: even a BCa candidate whose `â` is driven by one observation still produces a valid interval. If MOutOfN itself is in a degraded state (excessive bias, ratio near boundary), BCa remains the better choice. A hard veto precluded that comparison; a soft penalty lets it happen.
 
---
 
## Files changed
 
### `libs/statistics/include/BiasCorrectedBootstrap.h`
 
**Core algorithmic changes (Tier 1 + Tier 2).** Five new members added to `AccelerationReliability` — `accel`, `accelWithoutTop`, `accelRelativeChange`, `accelMaterial`, `sensitivityOk` — along with accessors. Constructor now takes 10 arguments (was 5).
 
`JackknifeInfluence::compute()` signature changed from taking pre-cubed deviations `dCubed` to taking raw deviations `d`. It now computes `â` internally, computes the perturbed `â` with the top-|d³| observation removed, and evaluates both the Tier-1 materiality check and the Tier-2 sensitivity test. Final reliability rule: `reliable = !accelMaterial || sensitivityOk`.
 
`BCaBootStrap::calculateBCaBounds()` updated to pass raw deviations; degenerate-case constructor call updated for the new 10-arg signature.
 
### `libs/statistics/include/AutoBootstrapConfiguration.h`
 
Added one new constant with matching documentation style:
 
```cpp
constexpr double kBcaAccelUnreliablePenalty = 0.5;
```
 
Placed immediately after `kBcaTransformNonMonotonePenalty` (same magnitude, same rationale — both represent "BCa correction machinery has an issue but the interval remains valid"). At `kRefStability = 0.25`, normalizes to 2.0 — parity with `kMOutOfNUnreliabilityPenalty`.
 
### `libs/statistics/include/AutoBootstrapScoring.h`
 
**The critical Tier-3 change.** Removed the hard-reject gate in `CandidateGateKeeper::isBcaCandidateValid()`:
 
```cpp
// REMOVED:
if (!candidate.getAccelIsReliable())
    return false;
```
 
Replaced with a documentation comment explaining the Tier-1/2 semantics and pointing to the soft penalty in `summarizeBCa()`. All other hard gates (z0 hard limit, accel hard limit, skew hard limit, sample-size floor, effective-B gate) are retained.
 
### `libs/statistics/include/AutoBootstrapSelector.h`
 
Three edits:
 
1. **`summarizeBCa()`** — new soft-penalty block parallel to the existing non-monotone-transform block. Adds `kBcaAccelUnreliablePenalty` to `stability_penalty` when `!accel_is_reliable`, with a debug log line reporting the Tier-2 diagnostics (`accel`, `accelWithoutTop`, `relChange`, `maxFrac`).
2. **`computeRejectionMask()`** — stopped raising `CandidateReject::BcaAccelUnreliable` (the enum value is retained for backward compatibility but is no longer set, since this is no longer a rejection reason).
3. **`analyzeBcaRejection()`** — comment updated to reflect that `!getAccelIsReliable()` is now a diagnostic-only signal surfaced via `SelectionDiagnostics::wasBCaRejectedForInstability()`, consistent with how the non-monotone transform is already handled.
Intentionally unchanged: `algorithm_is_reliable = accel_is_reliable && transform_monotone` is kept as-is. It is stored on the Candidate for diagnostics only (consumed by `SelectionDiagnostics`, not by any selection gate), and the existing transform-stability tests assert the AND semantics explicitly.
 
### `libs/statistics/include/StrategyAutoBootstrap.h`
 
Log-wording updates to reflect the new semantics (no behavioral change):
 
1. **Reason-line phrasing**: "disqualified: dominant jackknife observation..." → "penalized: acceleration driven by a single observation (Tier-2 sensitivity test failed); outscored by winner" for soft-penalty cases. "disqualified:" retained only for genuine hard-gate fallback paths.
2. **Comment block** above the instability-detail printout rewritten to describe the Tier-1/2 rule rather than the obsolete 50%-cubic-share rule.
3. **`accel reliable: NO` detail line** now reads `"NO — acceleration driven by one observation (Tier-2 sensitivity test failed)"`. A parallel `"(stability_penalty includes ... accel-unreliable soft penalty)"` line is now emitted when `!getAccelIsReliable()`, mirroring the existing non-monotone indicator.
### `libs/statistics/test/BCaAccelerationReliabilityTest.cpp`
 
All 28 `TEST_CASE`s updated for the new 10-arg `AccelerationReliability` constructor and the new `JackknifeInfluence::compute(d)` signature. Added a regression test for the Tier-1 materiality short-circuit using the real-data analog `{-0.02, -0.01, 0, 0.01, 0.02, 0.05}` which triggered the original production bug.
 
### `libs/statistics/test/AutoBootstrapSelectorTest.cpp`
 
Added new `TEST_CASE`: **"BCa with unreliable acceleration is no longer hard-rejected (Tier 3 regression)"** with three sections:
 
- **Section A — BCa wins on score**: weak PercentileT (ordering 0.03 → normalized 3.0) competes against flagged BCa (stability 0.5 → normalized 2.0). BCa wins. This is the direct regression assertion — pre-Tier-3 this test would fail because BCa would be filtered before scoring.
- **Section B — BCa loses on score**: strong PercentileT (ordering 0.002 → 0.2) beats flagged BCa (2.0). Confirms the soft penalty's magnitude handicaps BCa appropriately without eliminating it.
- **Section C — BCa is sole candidate**: verifies `Selector::select()` does not throw `AllGatesFailed` when a flagged BCa is the only candidate. Pre-Tier-3 it did throw.
Mock engine populates 1000 symmetric linearly-spaced bootstrap statistics (not the 3 used in summarize-only tests) — required to pass `passesEffectiveBGate` given `kMinEffectiveBAbsolute = 200` and `kBcaMinEffectiveFraction = 0.90`.
 
### `libs/statistics/test/AutoBootstrapSelectorMedianTest.cpp`
 
`MockBCaEngine::getAccelerationReliability()` updated to the 10-arg form. No test-logic changes.
 
### `libs/statistics/test/AutoBootstrapSelectorTransformStabilityTest.cpp`
 
`MockBCaEngineUnreliableAccel` and `MockBCaBothUnreliable` updated with internally-consistent Tier-1/2 state (`accelMaterial=true`, `sensitivityOk=false`, `accel=0.15`, `accelWithoutTop=-0.05`, `relChange=1.333`). Also fixed pre-existing syntax breakage in `MockBCaEngineNonMonotone` (missing method signature/braces) encountered while making the constructor update.
 
---
 
## Production validation
 
### Original bug case (pre-fix: rejected; post-fix: selected)
 
```
n=18, a=-0.047
→ |a| < 0.10 = kAccelMaterialThreshold
→ Tier-1 short-circuit: accelMaterial=false → isReliable=true
→ BCa selected, no penalty added
```
 
### New genuine-failure case (pre-fix and post-fix: MOutOfN selected, but for different reasons)
 
```
n=11, a=-0.127
|a| >= 0.10 → material
accelWithoutTop = +0.076 (sign flip when top obs removed)
relChange = 1.598 > 0.30 = kSensitivityThreshold
maxFrac = 0.968  (one observation carries 97% of cubic influence)
 
→ isReliable=false (Tier-2 sensitivity test failed)
→ stability_penalty += 0.072 (|a|>0.10 excess) + 0.500 (accel-unreliable) = 0.572
→ BCa total score ≈ 2.3 (normalized)
→ MOutOfN score = 1.42
→ MOutOfN wins fairly on score
```
 
Log output for this case (post-fix):
 
```
[BCa] acceleration penalty: |a|=0.12683822 threshold=0.10000000 penalty=0.07202901
[BCa] Total stability penalty: 0.07202901
[BCa] Acceleration-unreliable penalty applied: 0.50000000 (accel=-0.12683822
    accelWithoutTop=0.07583813 relChange=1.59791229 maxFrac=0.96816852)
[AutoCI] M-out-of-N selected
[AutoCI] BCa not selected — penalized: acceleration driven by a single observation
    (Tier-2 sensitivity test failed); outscored by winner
[AutoCI]   BCa instability detail:
[AutoCI]     z0 (bias):        -0.11522515
[AutoCI]     a  (accel):       -0.12683822  <- |a| > 0.10 (soft penalty threshold)
[AutoCI]     accel reliable:   NO — acceleration driven by one observation
    (Tier-2 sensitivity test failed)
[AutoCI]       (stability_penalty includes 0.5 accel-unreliable soft penalty)
[AutoCI]     stability penalty: 0.57202901
[AutoCI] Selected method=MOutOfN  score=1.42243229
```
 
### Aggregate behavior
 
Qualitatively: fewer strategies now fall back to MOutOfN. The ones that still do are genuine driven-by-one-observation cases where MOutOfN is the correct choice.
 
---
 
## Testing
 
All pre-existing tests pass unchanged.
 
New tests added:
 
- `BCaAccelerationReliabilityTest.cpp`: materiality short-circuit regression test using the real-data signature from the production bug.
- `AutoBootstrapSelectorTest.cpp`: `"BCa with unreliable acceleration is no longer hard-rejected (Tier 3 regression)"` — three-section test proving BCa is now eligible for the tournament, can win when it should, can lose when it should, and doesn't cause `AllGatesFailed` when it's the sole candidate.
---
 
## Risk and compatibility
 
**Backward compatibility**:
 
- `AccelerationReliability` public constructor signature changed (5 args → 10 args). Any code constructing these objects directly must be updated. All in-tree call sites have been updated.
- `JackknifeInfluence::compute()` parameter changed (pre-cubed `dCubed` → raw `d`). In-tree call sites updated.
- `CandidateReject::BcaAccelUnreliable` enum value retained for binary compatibility; no longer set by any code path.
- New constant `AutoBootstrapConfiguration::kBcaAccelUnreliablePenalty` introduced. Additive only.
- `SelectionDiagnostics::wasBCaRejectedForInstability()` semantics unchanged: still returns `true` when BCa's accel is unreliable, even though this is now a soft-penalty signal rather than a hard rejection. Existing callers that key off this flag for logging will continue to work.
**Behavioral changes**:
 
- Strategies previously rejected for accel-reliability at small n with small |â| will now select BCa (producing tighter lower bounds). This is the intended fix.
- Strategies where `â` is genuinely driven by one observation continue to select MOutOfN, but via soft penalty rather than hard gate. Same outcome, better rationale.
- The `kBcaAccelUnreliablePenalty = 0.5` magnitude was chosen for parity with `kBcaTransformNonMonotonePenalty`. If empirical tuning suggests a different magnitude, the constant can be adjusted in isolation without touching any other code.
**Statistical soundness**:
 
- Tier 1 is a well-known property of BCa: when `â` is near zero, the BCa correction reduces to the BC (bias-corrected) correction and the reliability of `â` is academic. Skipping the check in this regime is correct.
- Tier 2 is a proper leave-one-out sensitivity test, which is what the cubic-share heuristic was trying to approximate. Direct measurement is strictly better.
- Tier 3 aligns BCa's treatment with MOutOfN's: both methods now use soft penalties for "degraded but computable" reliability signals, and hard gates only for "not computable" cases (non-finite parameters, pathological distributions).
 