### PR TITLE
Throw exceptions on API violations,new unit tests

### DIFF
--- a/libs/timeseries/RandomMersenne.h
+++ b/libs/timeseries/RandomMersenne.h
@@ -13,6 +13,8 @@
 #include "BoundedRandom.h"
 #include <random>
 #include <array>
+#include <limits>
+#include <stdexcept>
 
 using uint32 = unsigned int;
 
@@ -129,31 +131,45 @@ static RandomMersenne withSeed(uint64_t seed)
   }
 
   /**
-     * @brief Draws a random unsigned 32-bit integer within the exclusive upper
-     *        bound range [0, exclusiveUpperBound - 1].
-     *
-     * This method is particularly useful for generating indices for zero-based
-     * containers like vectors.
-     *
-     * @param exclusiveUpperBound The exclusive upper bound of the range.
-     *        The generated number will be less than this value.
-     *
-     * @return A random unsigned 32-bit integer within the specified range.
-     * @throws std::invalid_argument if exclusiveUpperBound == 0.
-     */
-    uint32 DrawNumberExclusive(size_t exclusiveUpperBound)
-    {
-      assert(exclusiveUpperBound <= std::numeric_limits<uint32_t>::max()
-             && "exclusiveUpperBound exceeds uint32 range");
-      return mkc::random_util::bounded_rand(mRandGen.engine(),
-					    static_cast<uint32_t>(exclusiveUpperBound));
-    }
+   * @brief Draws a random unsigned 32-bit integer within the exclusive upper
+   *        bound range [0, exclusiveUpperBound - 1].
+   *
+   * This method is particularly useful for generating indices for zero-based
+   * containers like vectors.
+   *
+   * @param exclusiveUpperBound The exclusive upper bound of the range.
+   *        The generated number will be less than this value.
+   *
+   * @return A random unsigned 32-bit integer within the specified range.
+   *
+   * @throws std::out_of_range if exclusiveUpperBound exceeds the maximum value
+   *         representable as uint32_t. This check was previously a debug-only
+   *         assertion; in release builds (NDEBUG) the assert vanished and an
+   *         out-of-range size_t silently truncated to uint32_t, which would
+   *         introduce non-uniform bias when indexing into containers larger
+   *         than 2^32 elements. Promoted to an unconditional throw so the
+   *         failure mode is identical across build configurations.
+   * @throws std::invalid_argument if exclusiveUpperBound == 0 (propagated
+   *         from mkc::random_util::bounded_rand).
+   */
+  uint32 DrawNumberExclusive(size_t exclusiveUpperBound)
+  {
+    if (exclusiveUpperBound > std::numeric_limits<uint32_t>::max())
+      {
+	throw std::out_of_range(
+				"RandomMersenne::DrawNumberExclusive: exclusiveUpperBound exceeds uint32 range");
+      }
 
-    void seed_stream(uint64_t seed, uint64_t stream_id)
-{
+    return mkc::random_util::bounded_rand(mRandGen.engine(),
+					  static_cast<uint32_t>(exclusiveUpperBound));
+  }
+
+  void seed_stream(uint64_t seed, uint64_t stream_id)
+  {
     // PCG32 stream is controlled by the increment (must be odd)
     mRandGen.engine().seed(seed, stream_id | 1ULL);
-}
+  }
+
 private:
   randutils::random_generator<pcg32> mRandGen;
   };

--- a/libs/timeseries/SyntheticTimeSeries.h
+++ b/libs/timeseries/SyntheticTimeSeries.h
@@ -13,6 +13,7 @@
 #include <numeric>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <boost/thread/mutex.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include "TimeSeries.h"
@@ -131,23 +132,34 @@ namespace mkc_timeseries
      * Elements at indices [0 .. firstShufflable-1] are left untouched (anchor).
      * Passing firstShufflable = 1 is the standard "keep index 0 fixed" case used
      * throughout this file.
+     *
+     * @throws std::out_of_range if firstShufflable > v.size(). Passing a start
+     *         index past the end of the vector is a caller bug rather than a
+     *         meaningful request; we fail loudly rather than silently no-op.
      */
     template <class T>
     void fisherYatesSubrange(std::vector<T>& v,
-                             size_t          firstShufflable,
-                             RandomMersenne& rng)
+			     size_t          firstShufflable,
+			     RandomMersenne& rng)
     {
       const size_t n = v.size();
+      if (firstShufflable > n)
+	{
+	  throw std::out_of_range(
+				  "fisherYatesSubrange: firstShufflable exceeds vector size");
+	}
+
       if (n < firstShufflable + 2)
-      {
-        return; // nothing to shuffle
-      }
+	{
+	  return; // nothing to shuffle
+	}
+
       for (size_t i = n - 1; i > firstShufflable; --i)
-      {
-        // j uniformly in [firstShufflable .. i]
-        const size_t j = rng.DrawNumberExclusive(i - firstShufflable + 1) + firstShufflable;
-        std::swap(v[i], v[j]);
-      }
+	{
+	  // j uniformly in [firstShufflable .. i]
+	  const size_t j = rng.DrawNumberExclusive(i - firstShufflable + 1) + firstShufflable;
+	  std::swap(v[i], v[j]);
+	}
     }
 
     /**
@@ -163,15 +175,7 @@ namespace mkc_timeseries
     {
       std::vector<size_t> idx(n);
       std::iota(idx.begin(), idx.end(), size_t{0});
-      if (n < firstShufflable + 2)
-      {
-        return idx;
-      }
-      for (size_t i = n - 1; i > firstShufflable; --i)
-      {
-        const size_t j = rng.DrawNumberExclusive(i - firstShufflable + 1) + firstShufflable;
-        std::swap(idx[i], idx[j]);
-      }
+      fisherYatesSubrange(idx, firstShufflable, rng);
       return idx;
     }
 

--- a/libs/timeseries/test/RandomMersenneTest.cpp
+++ b/libs/timeseries/test/RandomMersenneTest.cpp
@@ -501,3 +501,24 @@ TEST_CASE("Move assignment transfers state to moved-to instance",
                 == reference.DrawNumberExclusive(bound));
     }
 }
+
+TEST_CASE("RandomMersenne::DrawNumberExclusive: throws when bound exceeds uint32 range",
+          "[RandomMersenne]")
+{
+  RandomMersenne rng;
+  // On 32-bit platforms size_t == uint32_t and this precondition cannot be
+  // violated, so the test is meaningful only on 64-bit builds.
+  if constexpr (sizeof(size_t) > sizeof(uint32_t))
+  {
+    const size_t tooLarge = static_cast<size_t>(std::numeric_limits<uint32_t>::max()) + 1u;
+    REQUIRE_THROWS_AS(rng.DrawNumberExclusive(tooLarge), std::out_of_range);
+  }
+}
+
+TEST_CASE("RandomMersenne::DrawNumberExclusive: uint32 max boundary does not throw",
+          "[RandomMersenne]")
+{
+  RandomMersenne rng;
+  const size_t atMax = static_cast<size_t>(std::numeric_limits<uint32_t>::max());
+  REQUIRE_NOTHROW(rng.DrawNumberExclusive(atMax));
+}

--- a/libs/timeseries/test/SyntheticTimeSeriesPoliciesTest.cpp
+++ b/libs/timeseries/test/SyntheticTimeSeriesPoliciesTest.cpp
@@ -778,3 +778,45 @@ TEST_CASE("SyntheticTimeSeries N0 vs N1: structural policy difference (OHLC tupl
     REQUIRE(tupleBroken);
   }
 }
+
+// --- Section 2 additions: fisherYatesSubrange precondition ---
+
+TEST_CASE("shuffle_detail::fisherYatesSubrange: throws when firstShufflable > v.size()",
+          "[detail][FisherYates]")
+{
+  std::vector<int> v = {1, 2, 3};
+  RandomMersenne rng;
+  // firstShufflable == 4, size == 3 → strict misuse
+  REQUIRE_THROWS_AS(shuffle_detail::fisherYatesSubrange(v, 4u, rng), std::out_of_range);
+}
+
+TEST_CASE("shuffle_detail::fisherYatesSubrange: firstShufflable == v.size() is a valid no-op",
+          "[detail][FisherYates]")
+{
+  // Boundary case: firstShufflable equal to size means "everything is anchored,
+  // nothing to shuffle" — this is a well-defined request and must NOT throw.
+  std::vector<int> v = {1, 2, 3};
+  const auto expected = v;
+  RandomMersenne rng;
+  REQUIRE_NOTHROW(shuffle_detail::fisherYatesSubrange(v, 3u, rng));
+  REQUIRE(v == expected);
+}
+
+// --- Section 3 addition: generatePermutation precondition ---
+
+TEST_CASE("shuffle_detail::generatePermutation: throws when firstShufflable > n",
+          "[detail][generatePermutation]")
+{
+  RandomMersenne rng;
+  // n = 3, firstShufflable = 5 → strict misuse
+  REQUIRE_THROWS_AS(shuffle_detail::generatePermutation(3u, 5u, rng), std::out_of_range);
+}
+
+TEST_CASE("shuffle_detail::generatePermutation: firstShufflable == n is a valid identity return",
+          "[detail][generatePermutation]")
+{
+  RandomMersenne rng;
+  auto perm = shuffle_detail::generatePermutation(3u, 3u, rng);
+  REQUIRE(perm == std::vector<size_t>({0u, 1u, 2u}));
+}
+


### PR DESCRIPTION
# Harden bounded-draw and shuffle preconditions
 
## Summary
 
Promotes two latent debug-only preconditions in the Monte Carlo
permutation-testing stack to unconditional runtime throws, eliminates a
duplicated Fisher-Yates loop, and adds matching test coverage. No shuffle
policy's statistical behavior is altered on well-formed input; these changes
only affect how malformed input is surfaced.
 
## Motivation
 
Two precondition checks in the random-number and shuffle primitives used by
`SyntheticTimeSeries` were previously enforced only by `assert`, which is
compiled out under `NDEBUG`. Because this codebase builds release binaries
with `NDEBUG` defined, an `assert` that "documents a precondition" is
effectively a comment that never fires in the builds that actually run.
 
This creates two silent-failure modes worth hardening:
 
1. `RandomMersenne::DrawNumberExclusive(size_t)` with a bound greater than
   `UINT32_MAX` silently truncates to `uint32_t`, producing biased draws
   against any container larger than 2^32 elements.
2. `shuffle_detail::fisherYatesSubrange(v, firstShufflable, rng)` with
   `firstShufflable > v.size()` was absorbed by the existing early-return
   guard and became a silent no-op — hiding caller bugs where a permutation
   was meant to happen but silently didn't.
Runtime throws fire in every build configuration, so debug and release now
have identical failure modes.
 
## Production changes
 
### 1. `RandomMersenne::DrawNumberExclusive` — throw on out-of-range bound
 
File: `RandomMersenne.h`
 
```cpp
/**
 * @throws std::out_of_range if exclusiveUpperBound exceeds the maximum value
 *         representable as uint32_t. This check was previously a debug-only
 *         assertion; in release builds (NDEBUG) the assert vanished and an
 *         out-of-range size_t silently truncated to uint32_t, introducing
 *         non-uniform bias when indexing into containers larger than 2^32
 *         elements. Promoted to an unconditional throw so the failure mode
 *         is identical across build configurations.
 * @throws std::invalid_argument if exclusiveUpperBound == 0 (propagated
 *         from mkc::random_util::bounded_rand).
 */
uint32 DrawNumberExclusive(size_t exclusiveUpperBound)
{
  if (exclusiveUpperBound > std::numeric_limits<uint32_t>::max())
  {
    throw std::out_of_range(
      "RandomMersenne::DrawNumberExclusive: exclusiveUpperBound exceeds uint32 range");
  }
  return mkc::random_util::bounded_rand(mRandGen.engine(),
                                        static_cast<uint32_t>(exclusiveUpperBound));
}
```
 
The branch is a single compare against a compile-time constant, perfectly
predicted in the hot-path Monte Carlo loop. Overhead is unmeasurable against
the cost of the `bounded_rand` call itself.
 
### 2. `shuffle_detail::fisherYatesSubrange` — throw on `firstShufflable > v.size()`
 
File: `SyntheticTimeSeries.h`
 
```cpp
/**
 * @brief Fisher-Yates in-place shuffle of v[firstShufflable .. v.size()-1].
 *
 * Elements at indices [0 .. firstShufflable-1] are left untouched (anchor).
 * Passing firstShufflable = 1 is the standard "keep index 0 fixed" case used
 * throughout this file.
 *
 * @throws std::out_of_range if firstShufflable > v.size(). Passing a start
 *         index past the end of the vector is a caller bug rather than a
 *         meaningful request; we fail loudly rather than silently no-op.
 */
template <class T>
void fisherYatesSubrange(std::vector<T>& v,
                         size_t          firstShufflable,
                         RandomMersenne& rng)
{
  const size_t n = v.size();
  if (firstShufflable > n)
  {
    throw std::out_of_range(
      "fisherYatesSubrange: firstShufflable exceeds vector size");
  }
  if (n < firstShufflable + 2)
  {
    return; // nothing to shuffle
  }
  for (size_t i = n - 1; i > firstShufflable; --i)
  {
    // j uniformly in [firstShufflable .. i]
    const size_t j = rng.DrawNumberExclusive(i - firstShufflable + 1) + firstShufflable;
    std::swap(v[i], v[j]);
  }
}
```
 
The check uses strict `>` rather than `>=`, so `firstShufflable == v.size()`
remains a valid "everything is anchored, nothing to shuffle" no-op — this
falls through to the existing early-return guard. Only strictly-past-the-end
is a caller bug.
 
### 3. `shuffle_detail::generatePermutation` — delegate to `fisherYatesSubrange`
 
File: `SyntheticTimeSeries.h`
 
Previously, `generatePermutation` contained a duplicated copy of the
Fisher-Yates loop. Folded into `fisherYatesSubrange` so any future fix or
optimization to the shuffle logic lives in one place. Behavior is unchanged
and the throw from `fisherYatesSubrange` is inherited automatically.
 
```cpp
/**
 * @brief Returns a uniformly random permutation of [0..n-1] that fixes
 *        the sub-range [0 .. firstShufflable-1].
 *
 * @throws std::out_of_range (via fisherYatesSubrange) if firstShufflable > n.
 */
inline std::vector<size_t> generatePermutation(size_t          n,
                                               size_t          firstShufflable,
                                               RandomMersenne& rng)
{
  std::vector<size_t> idx(n);
  std::iota(idx.begin(), idx.end(), size_t{0});
  fisherYatesSubrange(idx, firstShufflable, rng);
  return idx;
}
```
 
## Test additions
 
All existing tests in both files continue to pass unchanged. The new tests
lock in the exception contracts so a future refactor cannot silently
regress them back to no-ops.
 
### `RandomMersenneTest.cpp` — Section B (Exception contracts)
 
```cpp
TEST_CASE("DrawNumberExclusive: bound exceeding uint32_t range throws out_of_range",
          "[RandomMersenne][ErrorHandling]")
{
    // Was a debug-only assertion that vanished under NDEBUG, silently
    // truncating a size_t > UINT32_MAX to uint32_t and biasing draws
    // against any container larger than 2^32 elements. Promoted to an
    // unconditional runtime throw for uniform behavior across all build
    // configurations.
    //
    // Only meaningful on platforms where size_t is strictly wider than
    // uint32_t (64-bit targets). On 32-bit targets size_t == uint32_t
    // and the precondition cannot be violated from user code.
    if constexpr (sizeof(std::size_t) > sizeof(uint32_t))
    {
        RandomMersenne rng;
        const std::size_t tooLarge =
            static_cast<std::size_t>(std::numeric_limits<uint32_t>::max()) + 1u;
        REQUIRE_THROWS_AS(rng.DrawNumberExclusive(tooLarge), std::out_of_range);
    }
}
```
 
The `if constexpr` guard is load-bearing: on a 32-bit platform the
`UINT32_MAX + 1` expression wraps to `0`, which would trigger the
*different* `std::invalid_argument` throw and fail the test with the wrong
exception type. The whole clause is dead-stripped on 32-bit builds.
 
The companion "boundary does not throw at `UINT32_MAX`" case is already
covered by the existing `DrawNumberExclusive(UINT32_MAX) produces values in
[0, UINT32_MAX)` test in Section C, which calls the function 1000 times at
the boundary inside `REQUIRE`.
 
### `SyntheticTimeSeriesPoliciesTest.cpp` — Sections 2 and 3
 
```cpp
// --- Section 2: fisherYatesSubrange precondition ---
 
TEST_CASE("shuffle_detail::fisherYatesSubrange: throws when firstShufflable > v.size()",
          "[detail][FisherYates]")
{
  std::vector<int> v = {1, 2, 3};
  RandomMersenne rng;
  REQUIRE_THROWS_AS(shuffle_detail::fisherYatesSubrange(v, 4u, rng), std::out_of_range);
}
 
TEST_CASE("shuffle_detail::fisherYatesSubrange: firstShufflable == v.size() is a valid no-op",
          "[detail][FisherYates]")
{
  // Boundary case: firstShufflable equal to size means "everything is anchored,
  // nothing to shuffle" — this is a well-defined request and must NOT throw.
  std::vector<int> v = {1, 2, 3};
  const auto expected = v;
  RandomMersenne rng;
  REQUIRE_NOTHROW(shuffle_detail::fisherYatesSubrange(v, 3u, rng));
  REQUIRE(v == expected);
}
 
// --- Section 3: generatePermutation precondition ---
 
TEST_CASE("shuffle_detail::generatePermutation: throws when firstShufflable > n",
          "[detail][generatePermutation]")
{
  RandomMersenne rng;
  REQUIRE_THROWS_AS(shuffle_detail::generatePermutation(3u, 5u, rng), std::out_of_range);
}
```
 
## Behavior change reviewers should verify
 
One subtle behavior change merits a quick manual check before merge:
 
Previously, `fisherYatesSubrange(emptyVec, 1, rng)` was a silent no-op (the
`n < firstShufflable + 2` guard absorbed it because `0 < 3` is true). With
the new throw, this now raises `std::out_of_range` since `1 > 0` is also
true.
 
The concrete call site to inspect is `IndependentShufflePolicy::apply`,
which invokes `shuffle_detail::fisherYatesSubrange(open, 1, rng)` without
a preceding `if (n == 0) return orig;` guard. Compare to
`PairedDayShufflePolicy::apply` and `BlockShufflePolicy::apply`, both of
which have `if (n <= 2) return orig;` up front.
 
If any test fixture or production path ever constructs an `EodFactors`
with size 0 and runs it through `IndependentShufflePolicy`, it will now
throw where it previously silently produced an empty result. Options:
 
- **If empty `EodFactors` is legitimate input**: add `if (n == 0) return orig;`
  to the top of `IndependentShufflePolicy::apply` for symmetry with the
  other two policies.
- **If empty `EodFactors` is always a construction bug**: leave as-is; the
  throw surfaces the bug loudly, which is the intent of the change.
In practice, producing valid relative-factor arrays requires at least two
bars of source data, so this path should not be reachable from legitimate
time-series input.
 
## Include hygiene
 
The new throws reference `std::out_of_range`, which requires
`<stdexcept>`. It is currently pulled in transitively through Boost and
Catch2 headers in both files, but explicit inclusion insulates against
future transitive-include pruning. Recommended additions:
 
```cpp
// RandomMersenne.h
#include <limits>
#include <stdexcept>
 
// SyntheticTimeSeries.h
#include <stdexcept>
```
 
## Files changed
 
| File | Change |
|------|--------|
| `RandomMersenne.h` | `DrawNumberExclusive` promotes `assert` to `throw std::out_of_range` |
| `SyntheticTimeSeries.h` | `fisherYatesSubrange` throws on `firstShufflable > v.size()`; `generatePermutation` delegates to `fisherYatesSubrange` |
| `RandomMersenneTest.cpp` | Adds one exception-contract test |
| `SyntheticTimeSeriesPoliciesTest.cpp` | Adds three precondition tests |
 
## Risk assessment
 
**Statistical correctness.** Unchanged. No shuffle is altered on any
well-formed input. The randomness properties of the bounded-draw routine
and Fisher-Yates are identical to before.
 
**Performance.** Negligible. The `DrawNumberExclusive` check is one compare
against a compile-time constant per call. The `fisherYatesSubrange` check
is one compare per invocation — not per loop iteration — so even at
10,000 permutation-test iterations it adds a single-digit microsecond
total across the entire run.
 
**API surface.** `noexcept` was never declared on any of these functions,
so adding a throw does not violate any `noexcept` specification or break
any exception-guarantee contract exposed to callers.
 
**Build-configuration uniformity.** Improved. Debug and release now have
identical failure modes on precondition violation, eliminating a class of
"works on my debug build, silently wrong in production" bugs.