### PR TITLE
Palvalidator version 2.5.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(PalValidator VERSION 2.5.2 LANGUAGES CXX)
+project(PalValidator VERSION 2.5.3 LANGUAGES CXX)
 
 # Extract Git information for version header
 find_package(Git QUIET)


### PR DESCRIPTION
# Release Notes
 
**Release Date:** April 22, 2026
**Repository:** [testhound/palvalidator](https://github.com/testhound/palvalidator)
 
This release delivers a major reliability fix to the BCa bootstrap confidence-interval machinery, a significant performance improvement to the random-number generation pipeline, hardening of precondition checks in the permutation-test primitives, and a new batch-level diagnostic aggregator for the bootstrap tournament.
 
---
 
## Highlights
 
- **Fixes spurious BCa rejections at small sample sizes** — BCa is no longer disqualified on noise at n ≈ 18, replacing a false-positive-prone heuristic with a direct leave-one-out sensitivity test and a soft penalty.
- **1.5–2× faster bounded random integer generation** — a new optimized `bounded_rand` with a fast path for full-width zero-based engines (pcg32, pcg64, MT19937, xoshiro).
- **Hardened preconditions** — debug-only `assert`s on bounded-draw and Fisher-Yates shuffle preconditions are promoted to unconditional runtime throws so debug and release builds share identical failure modes.
- **New batch-level BCa diagnostics** — a new `BCaSelectionAggregator` records every bootstrap-tournament outcome across a full `filterByPerformance()` run and emits a rich summary report.
---
 
## 🐛 Bug Fixes
 
### BCa bootstrap reliability: eliminate spurious rejections at small *n* ([#313](https://github.com/testhound/palvalidator/pull/313))
 
Refactors the BCa (bias-corrected and accelerated) bootstrap reliability logic to fix a class of spurious rejections observed at small sample sizes (n ≈ 18), where BCa was being disqualified from the confidence-interval tournament despite producing valid, accurate intervals. The fallback to MOutOfN was unnecessary and produced wider intervals than BCa would have.
 
The previous cubic-share heuristic (`max |d|³ / Σ |d|³ < 0.50`) was firing on noise rather than pathology. A 50,000-trial Monte Carlo showed false-rejection rates between **16% and 49%** at n = 18 across Gaussian and Student-t distributions — with 100% of the false-rejection samples having `|â| < 0.10`, a regime where the BCa correction is numerically trivial anyway.
 
**Three-tier structural fix:**
 
- **Tier 1 — Materiality short-circuit.** If `|â| < 0.10`, report reliability as `true` unconditionally. The BCa correction reduces to BC in this regime, so the reliability of `â` is academic.
- **Tier 2 — Leave-one-out sensitivity test.** Replace the cubic-share proxy with a direct test: recompute `â` with the max-|d³| observation removed and flag it only if the relative change exceeds 30%. Sample-size-agnostic by construction.
- **Tier 3 — Soft penalty replaces hard gate.** The `CandidateGateKeeper` hard-reject is removed and replaced with a finite `kBcaAccelUnreliablePenalty = 0.5` added to `stability_penalty`, bringing BCa into parity with how every other reliability signal is handled.
**Impact:** Strategies previously rejected for accel-reliability at small *n* with small `|â|` now select BCa, producing tighter lower bounds. Genuine driven-by-one-observation cases still fall back to MOutOfN, but via a soft penalty rather than a hard gate.
 
**Backward compatibility:** `AccelerationReliability` constructor signature expanded from 5 args to 10; `JackknifeInfluence::compute()` now takes raw deviations instead of pre-cubed. All in-tree call sites updated. The `CandidateReject::BcaAccelUnreliable` enum value is retained for binary compatibility but no longer set. A new regression test (`"BCa with unreliable acceleration is no longer hard-rejected (Tier 3 regression)"`) with three sections locks in the new behavior.
 
---
 
## ⚡ Performance
 
### Optimized `bounded_rand` for permutation testing ([#314](https://github.com/testhound/palvalidator/pull/314))
 
Replaces the previous `bounded_rand` implementation with an optimized version drawing on the Lemire (2018) and O'Neill (2018) techniques for bias-free bounded random integer generation. Expected **1.5–2× speedup** on representative permutation-test workloads.
 
**Key details:**
 
- **Fast-path detection** via `is_full_width_zero_based_generator_v`, which SFINAE-selects the Lemire-style multiply-and-shift path for generators with `min() == 0` and `max() == numeric_limits::max()`. Covered engines include `pcg32`, `pcg64`, `std::mt19937`, `std::mt19937_64`, and the xoshiro family. Engines with non-zero `min()` (e.g., `std::ranlux48_base`) route to a correct fallback.
- **`__int128` handling** for the 64-bit `pcg64` fast path, guarded by `#if defined(__SIZEOF_INT128__)`. An internal `is_unsigned_or_uint128_v` trait works around the fact that `std::is_unsigned_v<unsigned __int128>` evaluates to `false` under the GCC extension, so the fallback compiles cleanly for any 128-bit-wide generator.
- **New unit tests** covering the fast and fallback paths.
**References:** M.E. O'Neill, "[Efficiently Generating a Number in a Range](https://www.pcg-random.org/posts/bounded-rands.html)" (2018); D. Lemire, "[Fast Random Integer Generation in an Interval](https://arxiv.org/abs/1805.10941)" (2018).
 
---
 
## 🛡️ Reliability & API Hardening
 
### Throw exceptions on API violations in bounded-draw and shuffle primitives ([#315](https://github.com/testhound/palvalidator/pull/315))
 
Promotes two latent debug-only `assert` checks in the Monte Carlo permutation-testing stack to unconditional runtime throws, eliminates a duplicated Fisher-Yates loop, and adds matching test coverage. Because release builds define `NDEBUG`, the old `assert`s were effectively comments that never fired in production.
 
**Changes:**
 
- **`RandomMersenne::DrawNumberExclusive(size_t)`** now throws `std::out_of_range` if the bound exceeds `UINT32_MAX`. Previously, a `size_t > UINT32_MAX` silently truncated to `uint32_t`, biasing draws against any container larger than 2³² elements.
- **`shuffle_detail::fisherYatesSubrange`** now throws `std::out_of_range` if `firstShufflable > v.size()`. Previously, this condition was silently absorbed by an early-return guard, hiding caller bugs where a permutation was meant to happen but didn't. Note: `firstShufflable == v.size()` remains a valid no-op.
- **`shuffle_detail::generatePermutation`** now delegates to `fisherYatesSubrange`, removing a duplicated copy of the Fisher-Yates loop.
**Behavior to verify:** `IndependentShufflePolicy::apply` does not guard against an empty `EodFactors` input. With the new throw, this case would raise where it previously no-oped. In practice, valid relative-factor arrays require at least two bars of source data, so this path should not be reachable from legitimate time-series input — but reviewers should confirm against their fixtures.
 
**Risk:** No shuffle's statistical behavior changes on well-formed input. The new checks add one compare per call against a compile-time constant — unmeasurable against the cost of the bounded-draw itself. Four new tests (one in `RandomMersenneTest.cpp`, three in `SyntheticTimeSeriesPoliciesTest.cpp`) lock in the exception contracts.
 
---
 
## 📊 Diagnostics & Observability
 
### Cross-strategy BCa selection aggregator for batch-level bootstrap diagnostics ([#316](https://github.com/testhound/palvalidator/pull/316))
 
Adds a new `BCaSelectionAggregator<Decimal>` class that records every BCa tournament outcome across a complete `filterByPerformance()` run and emits a summary report at the end. The report answers batch-level questions that were previously impossible to answer from the per-strategy logs alone:
 
- How many strategies chose BCa vs. something else, and at what percentage?
- Why did BCa lose when it lost (clean score, Tier-2 soft penalty, hard gate)?
- Who won when BCa lost (PercentileT, MOutOfN, other)?
- Does the selection rate vary with trade count?
- What do the BCa diagnostics (z0, â, skewness, stability penalty) look like across the losing population?
**Summary report has five sections:** overall breakdown, per-statistic breakdown (GeoMean vs. PF), head-to-head results when BCa lost, BCa selection rate bucketed by trade count (tests the "BCa struggles at low n" hypothesis), and five-number summaries of BCa diagnostics across losing cases.
 
**Production validation on a 333-strategy batch (652 strategy-statistic pairs):**
 
| Metric | Value |
| --- | --- |
| Overall BCa selection rate | 96.3% (628/652) |
| Hard-rejections | 0 (0.0%) |
| BCa-chosen rate at n < 10 | 93.5% |
| BCa-chosen rate at n ≥ 20 | 100% |
| Median \|â\| in losing cases | 0.1231 (just above materiality threshold) |
| Head-to-head losses to MOutOfN | 24 (100% of losses, all at n < 20) |
 
Every BCa loss in this run was a legitimate Tier-2 soft-penalty outcome — no pre-refactor-style spurious rejections anywhere. The "BCa struggles at low *n*" theory is directionally correct but modest in magnitude (a 6.5pp spread from n < 10 to n ≥ 20).
 
**Design notes:**
 
- Thread-safe: `record()` is mutex-guarded so a single aggregator can be safely shared across a thread pool. Contention is negligible (microseconds per strategy).
- Non-intrusive: all new parameters through the pipeline default to `nullptr`, so existing callers compile unchanged. Per-strategy log output is byte-identical to the pre-PR behavior.
- Owned by `PerformanceFilter` as a value member; `FilteringPipeline`, `BootstrapAnalysisStage`, and `StrategyAutoBootstrap` hold non-owning raw pointers.
**Also includes** a stream-formatting bug fix: an RAII `StreamStateGuard` in `summarize()` saves and restores the caller's stream state (flags, precision, width, fill), protecting the summary from upstream `std::setfill('0')` contamination that was filling padded columns with zeros.
 
---
 
## Backward Compatibility
 
Most changes in this release are backward compatible at the source level:
 
- **#313** changes the `AccelerationReliability` constructor (5 → 10 args) and the `JackknifeInfluence::compute()` parameter (pre-cubed `dCubed` → raw `d`). All in-tree call sites have been updated. Downstream consumers constructing these objects directly will need to adapt.
- **#315** adds runtime throws where previously-undefined-in-release behavior existed. Any code that relied on the silent-truncation or silent-no-op paths will now surface a `std::out_of_range` — this is a behavior change but reflects the intended API contract.
- **#314** and **#316** are additive. No source-level breakage expected.
---
 
## Full Changelog
 
- [#313 — Refactor the BCa bootstrap to fix spurious rejections observed at small sample sizes](https://github.com/testhound/palvalidator/pull/313)
- [#314 — Performance / optimized bounded rand](https://github.com/testhound/palvalidator/pull/314)
- [#315 — Throw exceptions on API violations, new unit tests](https://github.com/testhound/palvalidator/pull/315)
- [#316 — Add new class BCaSelectionAggregator and use it for summary reporting](https://github.com/testhound/palvalidator/pull/316)