### PR TITLE
Feature/backtesting mae mfe

### DIFF
--- a/libs/backtesting/ExcursionTrajectory.h
+++ b/libs/backtesting/ExcursionTrajectory.h
@@ -1,0 +1,313 @@
+// Copyright (C) MKC Associates, LLC - All Rights Reserved
+// Unauthorized copying of this file, via any medium is strictly prohibited
+// Proprietary and confidential
+
+/**
+ * @file ExcursionTrajectory.h
+ *
+ * @brief Per-bar MFE/MAE trajectory construction and query for a trading
+ *        position, computed from the position's preserved bar history.
+ *
+ * Provides:
+ *   - ExcursionTrajectoryPoint<Decimal>: immutable value object representing
+ *     running MFE and MAE at a single bar.
+ *   - ExcursionTrajectory<Decimal>: sequence of trajectory points plus
+ *     domain-meaningful queries (indexed access, terminal values, threshold
+ *     scans).
+ *
+ * The trajectory is built by iterating a TradingPosition's bar history,
+ * maintaining running high and low water marks initialized to the entry
+ * price (the "purist" first-bar convention documented alongside the MFE/MAE
+ * accessors on TradingPosition). Under this convention the trajectory point
+ * at bar 1 (the entry bar) always has MFE = MAE = 0.
+ *
+ * Running MFE and MAE are monotonically non-decreasing across the trajectory
+ * by construction, which is an invariant the threshold queries depend on.
+ *
+ * Threshold-query semantics ("exceeds") use strict greater-than (>). A
+ * threshold equal to a trajectory value is not considered exceeded.
+ */
+
+#ifndef __EXCURSION_TRAJECTORY_H
+#define __EXCURSION_TRAJECTORY_H 1
+
+#include <vector>
+#include <stdexcept>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include "TradingPosition.h"
+#include "TradingPositionException.h"
+#include "DecimalConstants.h"
+
+namespace mkc_timeseries
+{
+  using boost::posix_time::ptime;
+
+  /**
+   * @class ExcursionTrajectoryPoint
+   * @brief Immutable value object carrying running MFE and MAE at a single bar.
+   *
+   * Invariants enforced at construction:
+   *   - barNumber >= 1 (bar numbers are 1-indexed; bar 1 is the entry bar)
+   *   - mfe >= 0
+   *   - mae >= 0
+   *
+   * Construction violations throw TradingPositionException.
+   */
+  template <class Decimal>
+  class ExcursionTrajectoryPoint
+  {
+  public:
+    ExcursionTrajectoryPoint(unsigned int barNumber,
+                             const ptime& barDateTime,
+                             const Decimal& mfe,
+                             const Decimal& mae)
+      : mBarNumber(barNumber),
+        mBarDateTime(barDateTime),
+        mMfe(mfe),
+        mMae(mae)
+    {
+      if (barNumber == 0)
+        throw TradingPositionException(
+            "ExcursionTrajectoryPoint: barNumber must be >= 1 (bar 1 is the entry bar)");
+      if (mfe < DecimalConstants<Decimal>::DecimalZero)
+        throw TradingPositionException(
+            "ExcursionTrajectoryPoint: MFE must be non-negative");
+      if (mae < DecimalConstants<Decimal>::DecimalZero)
+        throw TradingPositionException(
+            "ExcursionTrajectoryPoint: MAE must be non-negative");
+    }
+
+    ExcursionTrajectoryPoint(const ExcursionTrajectoryPoint&) = default;
+    ExcursionTrajectoryPoint& operator=(const ExcursionTrajectoryPoint&) = default;
+    ExcursionTrajectoryPoint(ExcursionTrajectoryPoint&&) = default;
+    ExcursionTrajectoryPoint& operator=(ExcursionTrajectoryPoint&&) = default;
+
+    unsigned int getBarNumber() const { return mBarNumber; }
+    const ptime& getBarDateTime() const { return mBarDateTime; }
+    const Decimal& getMfe() const { return mMfe; }
+    const Decimal& getMae() const { return mMae; }
+
+  private:
+    unsigned int mBarNumber;
+    ptime        mBarDateTime;
+    Decimal      mMfe;
+    Decimal      mMae;
+  };
+
+  template <class Decimal>
+  bool operator==(const ExcursionTrajectoryPoint<Decimal>& lhs,
+                  const ExcursionTrajectoryPoint<Decimal>& rhs)
+  {
+    return lhs.getBarNumber()   == rhs.getBarNumber()   &&
+           lhs.getBarDateTime() == rhs.getBarDateTime() &&
+           lhs.getMfe()         == rhs.getMfe()         &&
+           lhs.getMae()         == rhs.getMae();
+  }
+
+  template <class Decimal>
+  bool operator!=(const ExcursionTrajectoryPoint<Decimal>& lhs,
+                  const ExcursionTrajectoryPoint<Decimal>& rhs)
+  {
+    return !(lhs == rhs);
+  }
+
+  /**
+   * @class ExcursionTrajectory
+   * @brief Ordered sequence of ExcursionTrajectoryPoint objects, one per bar
+   *        of a trading position, with threshold and terminal-value queries.
+   *
+   * Constructed eagerly from a TradingPosition: construction is O(N) in the
+   * position's bar count. All queries are O(1) or O(N) linear scan, which is
+   * adequate for trajectories that are short relative to data volume.
+   *
+   * Works for both open and closed positions — the underlying bar history
+   * is preserved across the open->closed state transition.
+   */
+  template <class Decimal>
+  class ExcursionTrajectory
+  {
+  public:
+    using PointVector    = std::vector<ExcursionTrajectoryPoint<Decimal>>;
+    using const_iterator = typename PointVector::const_iterator;
+
+    /**
+     * Build the trajectory by iterating the position's bar history,
+     * maintaining running water marks initialized to entry price (purist
+     * convention), and resolving favorable/adverse direction via
+     * position.isLongPosition().
+     *
+     * Throws TradingPositionException if the position's bar history is
+     * empty (which should not occur for any position constructed through
+     * the normal API, since OpenPositionHistory always inserts the entry
+     * bar). The check is defensive.
+     */
+    explicit ExcursionTrajectory(const TradingPosition<Decimal>& position)
+    {
+      auto it  = position.beginPositionBarHistory();
+      auto end = position.endPositionBarHistory();
+
+      if (it == end)
+        throw TradingPositionException(
+            "ExcursionTrajectory: cannot build trajectory from a position with no bar history");
+
+      const Decimal entryPrice = position.getEntryPrice();
+      const bool    isLong     = position.isLongPosition();
+
+      // Running water marks, initialized to entry price. Under the purist
+      // convention the entry bar's own high and low do not contribute; only
+      // subsequent bars' extremes do. This is enforced below by the
+      // barNumber > 1 guard around the update step.
+      Decimal highWaterMark = entryPrice;
+      Decimal lowWaterMark  = entryPrice;
+
+      unsigned int barNumber = 1;
+      for (; it != end; ++it, ++barNumber)
+      {
+        const OpenPositionBar<Decimal>& bar = it->second;
+
+        if (barNumber > 1)
+        {
+          const Decimal& barHigh = bar.getHighValue();
+          const Decimal& barLow  = bar.getLowValue();
+          if (barHigh > highWaterMark) highWaterMark = barHigh;
+          if (barLow  < lowWaterMark)  lowWaterMark  = barLow;
+        }
+
+        Decimal mfe;
+        Decimal mae;
+        if (isLong)
+        {
+          mfe = (highWaterMark > entryPrice)
+                  ? ((highWaterMark - entryPrice) / entryPrice)
+                      * DecimalConstants<Decimal>::DecimalOneHundred
+                  : DecimalConstants<Decimal>::DecimalZero;
+          mae = (lowWaterMark < entryPrice)
+                  ? ((entryPrice - lowWaterMark) / entryPrice)
+                      * DecimalConstants<Decimal>::DecimalOneHundred
+                  : DecimalConstants<Decimal>::DecimalZero;
+        }
+        else
+        {
+          // Short position: favorable = price drop, adverse = price rise.
+          mfe = (lowWaterMark < entryPrice)
+                  ? ((entryPrice - lowWaterMark) / entryPrice)
+                      * DecimalConstants<Decimal>::DecimalOneHundred
+                  : DecimalConstants<Decimal>::DecimalZero;
+          mae = (highWaterMark > entryPrice)
+                  ? ((highWaterMark - entryPrice) / entryPrice)
+                      * DecimalConstants<Decimal>::DecimalOneHundred
+                  : DecimalConstants<Decimal>::DecimalZero;
+        }
+
+        mPoints.emplace_back(barNumber, bar.getDateTime(), mfe, mae);
+      }
+    }
+
+    ExcursionTrajectory(const ExcursionTrajectory&) = default;
+    ExcursionTrajectory& operator=(const ExcursionTrajectory&) = default;
+    ExcursionTrajectory(ExcursionTrajectory&&) = default;
+    ExcursionTrajectory& operator=(ExcursionTrajectory&&) = default;
+
+    // --- Structural access -------------------------------------------------
+
+    size_t size() const { return mPoints.size(); }
+    bool   empty() const { return mPoints.empty(); }
+
+    const_iterator begin() const { return mPoints.begin(); }
+    const_iterator end()   const { return mPoints.end(); }
+
+    // --- Indexed access ----------------------------------------------------
+
+    /**
+     * Zero-indexed access into the underlying sequence. Throws std::out_of_range
+     * if index >= size().
+     */
+    const ExcursionTrajectoryPoint<Decimal>& at(size_t index) const
+    {
+      if (index >= mPoints.size())
+        throw std::out_of_range(
+            "ExcursionTrajectory::at: index out of range");
+      return mPoints[index];
+    }
+
+    /**
+     * One-indexed access by bar number, matching the semantics of
+     * ExcursionTrajectoryPoint::getBarNumber(). atBar(1) returns the entry
+     * bar point, atBar(size()) returns the last. Throws std::out_of_range
+     * for barNumber == 0 or barNumber > size().
+     */
+    const ExcursionTrajectoryPoint<Decimal>& atBar(unsigned int barNumber) const
+    {
+      if (barNumber == 0 || barNumber > mPoints.size())
+        throw std::out_of_range(
+            "ExcursionTrajectory::atBar: barNumber out of range (must be in [1, size()])");
+      return mPoints[barNumber - 1];
+    }
+
+    // --- Terminal values ---------------------------------------------------
+
+    /**
+     * MFE at the final bar of the trajectory. Agrees with
+     * TradingPosition::getMaxFavorableExcursion() on the same position.
+     * Throws if trajectory is empty (which construction forbids; this check
+     * is defensive for move-from states).
+     */
+    const Decimal& terminalMfe() const
+    {
+      if (mPoints.empty())
+        throw std::out_of_range("ExcursionTrajectory::terminalMfe: trajectory is empty");
+      return mPoints.back().getMfe();
+    }
+
+    /**
+     * MAE at the final bar of the trajectory. Agrees with
+     * TradingPosition::getMaxAdverseExcursion() on the same position.
+     */
+    const Decimal& terminalMae() const
+    {
+      if (mPoints.empty())
+        throw std::out_of_range("ExcursionTrajectory::terminalMae: trajectory is empty");
+      return mPoints.back().getMae();
+    }
+
+    // --- Threshold queries -------------------------------------------------
+
+    /**
+     * Return the bar number of the first point whose running MFE strictly
+     * exceeds the given threshold (i.e. point.getMfe() > threshold).
+     * Returns 0 if no point exceeds the threshold.
+     *
+     * "Exceeds" is strict: a trajectory whose MFE touches the threshold but
+     * does not surpass it returns 0 for that threshold.
+     */
+    unsigned int firstBarWhereMfeExceeds(const Decimal& threshold) const
+    {
+      for (const auto& p : mPoints)
+      {
+        if (p.getMfe() > threshold)
+          return p.getBarNumber();
+      }
+      return 0;
+    }
+
+    /**
+     * Return the bar number of the first point whose running MAE strictly
+     * exceeds the given threshold. Returns 0 if no point exceeds it.
+     */
+    unsigned int firstBarWhereMaeExceeds(const Decimal& threshold) const
+    {
+      for (const auto& p : mPoints)
+      {
+        if (p.getMae() > threshold)
+          return p.getBarNumber();
+      }
+      return 0;
+    }
+
+  private:
+    PointVector mPoints;
+  };
+
+} // namespace mkc_timeseries
+
+#endif // __EXCURSION_TRAJECTORY_H

--- a/libs/backtesting/TradingPosition.h
+++ b/libs/backtesting/TradingPosition.h
@@ -406,6 +406,23 @@ namespace mkc_timeseries
     virtual const Decimal& getProfitTarget() const = 0;
     virtual const Decimal& getStopLoss() const = 0;
 
+    // Maximum Favorable Excursion (MFE): non-negative percentage move from entry
+    // price in the direction favorable to the position. For a long position this
+    // is the highest percent gain observed since entry. For a short position this
+    // is the largest percent drop below entry observed since entry.
+    //
+    // Maximum Adverse Excursion (MAE): non-negative percentage move from entry
+    // price in the direction adverse to the position. For a long this is the
+    // largest percent drop below entry. For a short this is the largest percent
+    // rise above entry.
+    //
+    // Both quantities are returned as non-negative values (zero if no favorable
+    // or adverse movement has occurred). Under the purist first-bar convention
+    // used by this library, the entry bar's own high and low do not contribute
+    // to MFE or MAE; only post-entry bars do.
+    virtual Decimal getMaxFavorableExcursion() const = 0;
+    virtual Decimal getMaxAdverseExcursion() const = 0;
+
     // NOTE: To implement these in the ClosePositonState pass the open position to closed
     // position at creation time
     virtual TradingPositionState::ConstPositionBarIterator beginPositionBarHistory() const = 0;
@@ -444,7 +461,9 @@ namespace mkc_timeseries
       mBarsInPosition(1),
       mNumBarsSinceEntry(0),
       mProfitTarget(DecimalConstants<Decimal>::DecimalZero),
-      mStopLoss(DecimalConstants<Decimal>::DecimalZero)
+      mStopLoss(DecimalConstants<Decimal>::DecimalZero),
+      mHighWaterMark(entryPrice),
+      mLowWaterMark(entryPrice)
     {
       if (entryPrice <= DecimalConstants<Decimal>::DecimalZero)
 	throw TradingPositionException (std::string("OpenPosition constructor: entry price < 0"));
@@ -568,12 +587,42 @@ namespace mkc_timeseries
 	return mStopLoss;
       }
 
+    // Raw-price water marks maintained across the life of the position.
+    // - mHighWaterMark is initialized to the entry price and updated to the
+    //   maximum bar High observed across all post-entry bars (purist
+    //   convention: the entry bar's own High does not contribute).
+    // - mLowWaterMark is initialized to the entry price and updated to the
+    //   minimum bar Low observed across all post-entry bars.
+    //
+    // These are direction-agnostic; OpenLongPosition and OpenShortPosition
+    // interpret them into MFE/MAE via getMaxFavorableExcursion() and
+    // getMaxAdverseExcursion().
+    const Decimal& getHighWaterMark() const
+      {
+	return mHighWaterMark;
+      }
+
+    const Decimal& getLowWaterMark() const
+      {
+	return mLowWaterMark;
+      }
+
   private:
     void addBar(const OpenPositionBar<Decimal>& positionBar)
     {
       mPositionBarHistory.addBar(positionBar);
       mBarsInPosition++;
       mNumBarsSinceEntry++;
+
+      // Maintain water marks using the new bar's High and Low.
+      // Because water marks were initialized to the entry price and this
+      // function is only called for post-entry bars (the entry bar is
+      // inserted by OpenPositionHistory's constructor), the purist
+      // first-bar convention is preserved automatically.
+      const Decimal& barHigh = positionBar.getHighValue();
+      const Decimal& barLow  = positionBar.getLowValue();
+      if (barHigh > mHighWaterMark) mHighWaterMark = barHigh;
+      if (barLow  < mLowWaterMark)  mLowWaterMark  = barLow;
     }
 
   private:
@@ -585,6 +634,8 @@ namespace mkc_timeseries
     unsigned int mNumBarsSinceEntry;
     Decimal mProfitTarget;
     Decimal mStopLoss;
+    Decimal mHighWaterMark;
+    Decimal mLowWaterMark;
   };
 
   /**
@@ -648,6 +699,29 @@ namespace mkc_timeseries
     bool isLosingPosition() const
     {
       return !isWinningPosition();
+    }
+
+    // MFE for a long: percent rise of the high water mark above the entry
+    // price. Returns zero if the water mark never rose above entry.
+    Decimal getMaxFavorableExcursion() const override
+    {
+      const Decimal& entry = OpenPosition<Decimal>::getEntryPrice();
+      const Decimal& hwm   = OpenPosition<Decimal>::getHighWaterMark();
+      if (hwm > entry)
+	return ((hwm - entry) / entry) * DecimalConstants<Decimal>::DecimalOneHundred;
+      return DecimalConstants<Decimal>::DecimalZero;
+    }
+
+    // MAE for a long: percent drop of the low water mark below the entry
+    // price, expressed as a non-negative number. Returns zero if the water
+    // mark never fell below entry.
+    Decimal getMaxAdverseExcursion() const override
+    {
+      const Decimal& entry = OpenPosition<Decimal>::getEntryPrice();
+      const Decimal& lwm   = OpenPosition<Decimal>::getLowWaterMark();
+      if (lwm < entry)
+	return ((entry - lwm) / entry) * DecimalConstants<Decimal>::DecimalOneHundred;
+      return DecimalConstants<Decimal>::DecimalZero;
     }
 
     void ClosePosition (TradingPosition<Decimal>* position,
@@ -729,6 +803,30 @@ namespace mkc_timeseries
     bool isLosingPosition() const
     {
       return !isWinningPosition();
+    }
+
+    // MFE for a short: percent drop of the low water mark below the entry
+    // price (favorable for a short). Returns zero if the water mark never
+    // fell below entry.
+    Decimal getMaxFavorableExcursion() const override
+    {
+      const Decimal& entry = OpenPosition<Decimal>::getEntryPrice();
+      const Decimal& lwm   = OpenPosition<Decimal>::getLowWaterMark();
+      if (lwm < entry)
+	return ((entry - lwm) / entry) * DecimalConstants<Decimal>::DecimalOneHundred;
+      return DecimalConstants<Decimal>::DecimalZero;
+    }
+
+    // MAE for a short: percent rise of the high water mark above the entry
+    // price (adverse for a short). Returns zero if the water mark never
+    // rose above entry.
+    Decimal getMaxAdverseExcursion() const override
+    {
+      const Decimal& entry = OpenPosition<Decimal>::getEntryPrice();
+      const Decimal& hwm   = OpenPosition<Decimal>::getHighWaterMark();
+      if (hwm > entry)
+	return ((hwm - entry) / entry) * DecimalConstants<Decimal>::DecimalOneHundred;
+      return DecimalConstants<Decimal>::DecimalZero;
     }
 
     void ClosePosition (TradingPosition<Decimal>* position,
@@ -852,6 +950,21 @@ namespace mkc_timeseries
       {
 	return mOpenPosition->getStopLoss();
       }
+
+    // MFE/MAE on a closed position are delegated to the stored open position
+    // state, which in turn resolves direction via polymorphism on the
+    // concrete OpenLongPosition / OpenShortPosition type. The values reflect
+    // the full life of the trade since the bar history and water marks are
+    // preserved on the open state after close.
+    Decimal getMaxFavorableExcursion() const override
+    {
+      return mOpenPosition->getMaxFavorableExcursion();
+    }
+
+    Decimal getMaxAdverseExcursion() const override
+    {
+      return mOpenPosition->getMaxAdverseExcursion();
+    }
 
     void setProfitTarget(const Decimal& /* profitTarget */)
       {
@@ -1335,6 +1448,25 @@ namespace mkc_timeseries
 	return mPositionState->getStopLoss();
       }
 
+    // Maximum Favorable Excursion: non-negative percent move from entry in
+    // the direction favorable to this position. For a long, this is the
+    // highest percent gain observed since entry. For a short, the largest
+    // percent drop below entry observed since entry. Zero if no favorable
+    // move has occurred yet.
+    Decimal getMaxFavorableExcursion() const
+    {
+      return mPositionState->getMaxFavorableExcursion();
+    }
+
+    // Maximum Adverse Excursion: non-negative percent move from entry in
+    // the direction adverse to this position. For a long, this is the
+    // largest percent drop below entry. For a short, the largest percent
+    // rise above entry. Zero if no adverse move has occurred yet.
+    Decimal getMaxAdverseExcursion() const
+    {
+      return mPositionState->getMaxAdverseExcursion();
+    }
+
     // NOTE: To implement these in the ClosePositonState pass the open position to closed
     // position at creation time
     ConstPositionBarIterator beginPositionBarHistory() const
@@ -1726,5 +1858,3 @@ namespace mkc_timeseries
 
 }
 #endif
-
-

--- a/libs/backtesting/test/ExcursionTest.cpp
+++ b/libs/backtesting/test/ExcursionTest.cpp
@@ -1,0 +1,658 @@
+// Copyright (C) MKC Associates, LLC - All Rights Reserved
+// Unauthorized copying of this file, via any medium is strictly prohibited
+// Proprietary and confidential
+
+/**
+ * @file ExcursionTest.cpp
+ *
+ * @brief Unit tests for Phase 1 MFE/MAE functionality:
+ *
+ *   1. Terminal MFE/MAE accessors on TradingPosition (long and short).
+ *   2. ExcursionTrajectoryPoint value-object invariants.
+ *   3. ExcursionTrajectory construction, indexed access, terminal values,
+ *      monotonicity invariant, and threshold-query semantics.
+ *
+ * Test style follows Catch2 v2 (TEST_CASE / SECTION / REQUIRE). The single
+ * ADAPTATION NOTE at the top of the file isolates the project-specific
+ * factory helpers that construct OHLC entries and TradingVolume values;
+ * if the existing test suite already exposes equivalents with different
+ * names, point the aliases in that section at them and the assertions
+ * below should compile unchanged.
+ */
+
+#include <catch2/catch_test_macros.hpp>  // or <catch.hpp> for Catch2 v2 single-header
+
+#include "TradingPosition.h"
+#include "ExcursionTrajectory.h"
+#include "DecimalConstants.h"
+#include "TimeSeriesEntry.h"
+#include "TimeFrame.h"
+#include "TradingVolume.h"
+#include "number.h"
+
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/date_time/gregorian/gregorian.hpp>
+#include <sstream>
+#include <iomanip>
+#include <string>
+#include <tuple>
+#include <vector>
+#include <memory>
+
+using namespace mkc_timeseries;
+using boost::posix_time::ptime;
+using boost::gregorian::date;
+
+// ============================================================================
+// ADAPTATION NOTE
+// ----------------------------------------------------------------------------
+// The following three helpers isolate the project's type choices:
+//
+//   - DecimalType == num::DefaultNumber == dec::decimal<8> (from number.h).
+//   - D(double) constructs a DecimalType via num::fromString, the canonical
+//     string-based path. This avoids any ambiguity over whether dec::decimal<8>
+//     accepts a direct double constructor in the project's build configuration.
+//   - makeBar(...) constructs an OHLCTimeSeriesEntry using the (date, O, H, L,
+//     C, volume, timeframe) overload confirmed in TimeSeriesEntry.h.
+//   - oneShare() constructs a one-unit TradingVolume confirmed in
+//     TradingVolume.h.
+//
+// If the project's existing backtester test suite already exposes equivalents
+// of these helpers, it's safe to swap them in here; everything below depends
+// only on D(...), makeBar(...), and oneShare().
+// ============================================================================
+
+using DecimalType = num::DefaultNumber;
+
+/**
+ * Construct a DecimalType from a double by serializing through a string.
+ * Uses fixed-point notation with enough decimal places to cover the 8-digit
+ * scale of DefaultNumber.
+ */
+static DecimalType D(double v)
+{
+  std::ostringstream oss;
+  oss << std::fixed << std::setprecision(10) << v;
+  return num::fromString<DecimalType>(oss.str());
+}
+
+/** Build an OHLCTimeSeriesEntry at daily time frame. Defaults volume to zero. */
+static OHLCTimeSeriesEntry<DecimalType>
+makeBar(const date& d,
+        double o, double h, double l, double c,
+        double vol = 0.0)
+{
+  return OHLCTimeSeriesEntry<DecimalType>(
+      d,
+      D(o), D(h), D(l), D(c),
+      D(vol),
+      TimeFrame::DAILY);
+}
+
+/** One unit of TradingVolume for share-denominated assets. */
+static TradingVolume oneShare()
+{
+  return TradingVolume(1, TradingVolume::SHARES);
+}
+
+// ============================================================================
+// Test fixtures and helpers (not project-specific)
+// ============================================================================
+
+/**
+ * Build a closed long position with a scripted sequence of post-entry bars
+ * and a given exit price/date. Bars are added in order. The entry price
+ * equals the entry bar's Open. Each subsequent bar's OHLC is taken from the
+ * provided vector, one bar per day starting the day after entry.
+ */
+struct LongTradeScript
+{
+  date         entryDate;
+  double       entryPrice;
+  double       entryBarHigh;
+  double       entryBarLow;
+  std::vector<std::tuple<double,double,double,double>> postEntryOHLC; // O,H,L,C
+  date         exitDate;
+  double       exitPrice;
+};
+
+static std::shared_ptr<TradingPositionLong<DecimalType>>
+buildClosedLong(const LongTradeScript& s)
+{
+  auto entryBar = makeBar(s.entryDate,
+                          s.entryPrice, s.entryBarHigh,
+                          s.entryBarLow,  s.entryPrice);
+  auto pos = std::make_shared<TradingPositionLong<DecimalType>>(
+      std::string("TEST"), D(s.entryPrice), entryBar, oneShare());
+
+  date d = s.entryDate;
+  for (const auto& ohlc : s.postEntryOHLC)
+  {
+    d = d + boost::gregorian::days(1);
+    auto bar = makeBar(d,
+                       std::get<0>(ohlc), std::get<1>(ohlc),
+                       std::get<2>(ohlc), std::get<3>(ohlc));
+    pos->addBar(bar);
+  }
+  pos->ClosePosition(s.exitDate, D(s.exitPrice));
+  return pos;
+}
+
+struct ShortTradeScript
+{
+  date         entryDate;
+  double       entryPrice;
+  double       entryBarHigh;
+  double       entryBarLow;
+  std::vector<std::tuple<double,double,double,double>> postEntryOHLC;
+  date         exitDate;
+  double       exitPrice;
+};
+
+static std::shared_ptr<TradingPositionShort<DecimalType>>
+buildClosedShort(const ShortTradeScript& s)
+{
+  auto entryBar = makeBar(s.entryDate,
+                          s.entryPrice, s.entryBarHigh,
+                          s.entryBarLow,  s.entryPrice);
+  auto pos = std::make_shared<TradingPositionShort<DecimalType>>(
+      std::string("TEST"), D(s.entryPrice), entryBar, oneShare());
+
+  date d = s.entryDate;
+  for (const auto& ohlc : s.postEntryOHLC)
+  {
+    d = d + boost::gregorian::days(1);
+    auto bar = makeBar(d,
+                       std::get<0>(ohlc), std::get<1>(ohlc),
+                       std::get<2>(ohlc), std::get<3>(ohlc));
+    pos->addBar(bar);
+  }
+  pos->ClosePosition(s.exitDate, D(s.exitPrice));
+  return pos;
+}
+
+// Compare Decimal values with a tolerance. Decimal arithmetic is exact for
+// the ratios in these tests, but if the project's Decimal type is a
+// fixed-precision wrapper the comparison still survives trailing digits.
+static bool approxEqual(const DecimalType& a, const DecimalType& b, double tol = 1e-6)
+{
+  DecimalType diff = (a > b) ? (a - b) : (b - a);
+  return num::to_long_double(diff) <= tol;
+}
+
+
+// ============================================================================
+// 1. Terminal MFE/MAE on TradingPosition (Long)
+// ============================================================================
+
+TEST_CASE("TradingPositionLong terminal MFE/MAE", "[trading_position][mfe_mae]")
+{
+  // Entry at 100. Bar 2 reaches high=105, low=99. Bar 3 pulls back to
+  // low=97, high=103. Exit at 102.
+  // Running high water mark across post-entry bars: max(105, 103) = 105
+  // Running low water mark across post-entry bars:  min(99,  97)  = 97
+  // Long MFE = (105 - 100)/100 * 100 = 5.0
+  // Long MAE = (100 - 97)/100  * 100 = 3.0
+  LongTradeScript s{
+    date(2024,  1,  8), 100.0, 100.0, 100.0,  // entry-bar OHLC (high/low = entry per purist convention)
+    {
+      std::make_tuple(100.0, 105.0, 99.0, 104.0),
+      std::make_tuple(103.0, 103.0, 97.0, 102.0)
+    },
+    date(2024, 1, 10), 102.0
+  };
+  auto pos = buildClosedLong(s);
+
+  SECTION("MFE reflects the highest post-entry high")
+  {
+    REQUIRE(approxEqual(pos->getMaxFavorableExcursion(), D(5.0)));
+  }
+  SECTION("MAE reflects the lowest post-entry low")
+  {
+    REQUIRE(approxEqual(pos->getMaxAdverseExcursion(),  D(3.0)));
+  }
+  SECTION("MFE and MAE are non-negative")
+  {
+    REQUIRE(pos->getMaxFavorableExcursion() >= DecimalConstants<DecimalType>::DecimalZero);
+    REQUIRE(pos->getMaxAdverseExcursion()  >= DecimalConstants<DecimalType>::DecimalZero);
+  }
+}
+
+TEST_CASE("TradingPositionLong: winning trade with adverse excursion first",
+          "[trading_position][mfe_mae]")
+{
+  // Price dips to 95 before rallying to 110. Exit at 108.
+  // MFE = 10.0, MAE = 5.0 — MAE must capture the dip even though the
+  // trade closes winning.
+  LongTradeScript s{
+    date(2024, 2, 1), 100.0, 100.0, 100.0,
+    {
+      std::make_tuple(100.0, 101.0,  95.0,  96.0),  // dip first
+      std::make_tuple( 96.0, 110.0,  96.0, 108.0)   // then rally
+    },
+    date(2024, 2, 3), 108.0
+  };
+  auto pos = buildClosedLong(s);
+  REQUIRE(approxEqual(pos->getMaxFavorableExcursion(), D(10.0)));
+  REQUIRE(approxEqual(pos->getMaxAdverseExcursion(),   D( 5.0)));
+  REQUIRE(pos->isWinningPosition());
+}
+
+TEST_CASE("TradingPositionLong: closed on entry bar has zero MFE/MAE",
+          "[trading_position][mfe_mae][purist_convention]")
+{
+  // No post-entry bars. Under the purist convention the entry bar's own
+  // high/low do not contribute — MFE and MAE are both zero even if the
+  // entry bar had a large range.
+  auto entryBar = makeBar(date(2024, 3, 1), 100.0, 110.0, 90.0, 100.0);
+  auto pos = std::make_shared<TradingPositionLong<DecimalType>>(
+      std::string("TEST"), D(100.0), entryBar, oneShare());
+  pos->ClosePosition(date(2024, 3, 1), D(100.0));
+
+  REQUIRE(pos->getMaxFavorableExcursion() == DecimalConstants<DecimalType>::DecimalZero);
+  REQUIRE(pos->getMaxAdverseExcursion()  == DecimalConstants<DecimalType>::DecimalZero);
+}
+
+
+// ============================================================================
+// 2. Terminal MFE/MAE on TradingPosition (Short)
+// ============================================================================
+
+TEST_CASE("TradingPositionShort terminal MFE/MAE", "[trading_position][mfe_mae]")
+{
+  // Entry at 100 short. Bar 2 reaches low=95 (favorable), high=101 (adverse).
+  // Bar 3 high=103, low=97.
+  // Running low water mark: min(95, 97) = 95
+  // Running high water mark: max(101, 103) = 103
+  // Short MFE = (100 - 95)/100 * 100 = 5.0
+  // Short MAE = (103 - 100)/100 * 100 = 3.0
+  ShortTradeScript s{
+    date(2024, 1, 8), 100.0, 100.0, 100.0,
+    {
+      std::make_tuple(100.0, 101.0,  95.0,  96.0),
+      std::make_tuple( 98.0, 103.0, 97.0, 98.0)
+    },
+    date(2024, 1, 10), 98.0
+  };
+  auto pos = buildClosedShort(s);
+
+  SECTION("Short MFE uses the lowest post-entry low")
+  {
+    REQUIRE(approxEqual(pos->getMaxFavorableExcursion(), D(5.0)));
+  }
+  SECTION("Short MAE uses the highest post-entry high")
+  {
+    REQUIRE(approxEqual(pos->getMaxAdverseExcursion(), D(3.0)));
+  }
+  SECTION("Short MFE and MAE are non-negative (direction-swap sanity check)")
+  {
+    REQUIRE(pos->getMaxFavorableExcursion() >= DecimalConstants<DecimalType>::DecimalZero);
+    REQUIRE(pos->getMaxAdverseExcursion()  >= DecimalConstants<DecimalType>::DecimalZero);
+  }
+}
+
+TEST_CASE("TradingPositionShort: price only moves up (losing short)",
+          "[trading_position][mfe_mae]")
+{
+  // Price rises steadily: never below entry. MFE must be zero, MAE positive.
+  ShortTradeScript s{
+    date(2024, 4, 1), 100.0, 100.0, 100.0,
+    {
+      std::make_tuple(100.0, 102.0, 100.0, 101.0),
+      std::make_tuple(101.0, 105.0, 101.0, 104.0)
+    },
+    date(2024, 4, 3), 104.0
+  };
+  auto pos = buildClosedShort(s);
+
+  REQUIRE(pos->getMaxFavorableExcursion() == DecimalConstants<DecimalType>::DecimalZero);
+  REQUIRE(approxEqual(pos->getMaxAdverseExcursion(), D(5.0)));
+}
+
+
+// ============================================================================
+// 3. ExcursionTrajectoryPoint value-object invariants
+// ============================================================================
+
+TEST_CASE("ExcursionTrajectoryPoint: valid construction and accessors",
+          "[excursion_trajectory_point]")
+{
+  ptime t(date(2024, 1, 1), getDefaultBarTime());
+  ExcursionTrajectoryPoint<DecimalType> p(3, t, D(2.5), D(1.0));
+  REQUIRE(p.getBarNumber()   == 3);
+  REQUIRE(p.getBarDateTime() == t);
+  REQUIRE(p.getMfe()         == D(2.5));
+  REQUIRE(p.getMae()         == D(1.0));
+}
+
+TEST_CASE("ExcursionTrajectoryPoint: barNumber == 0 throws",
+          "[excursion_trajectory_point]")
+{
+  ptime t(date(2024, 1, 1), getDefaultBarTime());
+  REQUIRE_THROWS_AS(
+      ExcursionTrajectoryPoint<DecimalType>(0, t, D(1.0), D(1.0)),
+      TradingPositionException);
+}
+
+TEST_CASE("ExcursionTrajectoryPoint: negative MFE throws",
+          "[excursion_trajectory_point]")
+{
+  ptime t(date(2024, 1, 1), getDefaultBarTime());
+  REQUIRE_THROWS_AS(
+      ExcursionTrajectoryPoint<DecimalType>(1, t, D(-0.5), D(0.0)),
+      TradingPositionException);
+}
+
+TEST_CASE("ExcursionTrajectoryPoint: negative MAE throws",
+          "[excursion_trajectory_point]")
+{
+  ptime t(date(2024, 1, 1), getDefaultBarTime());
+  REQUIRE_THROWS_AS(
+      ExcursionTrajectoryPoint<DecimalType>(1, t, D(0.0), D(-0.5)),
+      TradingPositionException);
+}
+
+TEST_CASE("ExcursionTrajectoryPoint: zero MFE and MAE are valid",
+          "[excursion_trajectory_point]")
+{
+  ptime t(date(2024, 1, 1), getDefaultBarTime());
+  REQUIRE_NOTHROW(
+      ExcursionTrajectoryPoint<DecimalType>(1, t, D(0.0), D(0.0)));
+}
+
+TEST_CASE("ExcursionTrajectoryPoint: equality and inequality",
+          "[excursion_trajectory_point]")
+{
+  ptime t(date(2024, 1, 1), getDefaultBarTime());
+  ExcursionTrajectoryPoint<DecimalType> a(1, t, D(1.0), D(0.5));
+  ExcursionTrajectoryPoint<DecimalType> b(1, t, D(1.0), D(0.5));
+  ExcursionTrajectoryPoint<DecimalType> c(2, t, D(1.0), D(0.5));
+  REQUIRE(a == b);
+  REQUIRE(a != c);
+}
+
+
+// ============================================================================
+// 4. ExcursionTrajectory construction and access
+// ============================================================================
+
+TEST_CASE("ExcursionTrajectory: long position, bar 1 is zero by purist convention",
+          "[excursion_trajectory]")
+{
+  LongTradeScript s{
+    date(2024, 1, 1), 100.0, 110.0, 90.0,   // wide entry-bar range
+    {
+      std::make_tuple(100.0, 102.0, 99.0, 101.0)
+    },
+    date(2024, 1, 2), 101.0
+  };
+  auto pos = buildClosedLong(s);
+  ExcursionTrajectory<DecimalType> traj(*pos);
+
+  REQUIRE(traj.size() == 2);
+  REQUIRE(traj.atBar(1).getMfe() == DecimalConstants<DecimalType>::DecimalZero);
+  REQUIRE(traj.atBar(1).getMae() == DecimalConstants<DecimalType>::DecimalZero);
+}
+
+TEST_CASE("ExcursionTrajectory: bar-by-bar values for a long position",
+          "[excursion_trajectory]")
+{
+  // Entry 100. Bar 2: H=102, L=99. Bar 3: H=105, L=98. Bar 4: H=104, L=95.
+  // Running HWM: 100 -> 102 -> 105 -> 105
+  // Running LWM: 100 ->  99 ->  98 ->  95
+  // Long MFE at bars 2,3,4: 2.0, 5.0, 5.0
+  // Long MAE at bars 2,3,4: 1.0, 2.0, 5.0
+  LongTradeScript s{
+    date(2024, 1, 1), 100.0, 100.0, 100.0,
+    {
+      std::make_tuple(100.0, 102.0,  99.0, 101.0),
+      std::make_tuple(101.0, 105.0,  98.0, 100.0),
+      std::make_tuple(100.0, 104.0,  95.0,  96.0)
+    },
+    date(2024, 1, 5), 96.0
+  };
+  auto pos = buildClosedLong(s);
+  ExcursionTrajectory<DecimalType> traj(*pos);
+
+  REQUIRE(traj.size() == 4);
+  REQUIRE(approxEqual(traj.atBar(2).getMfe(), D(2.0)));
+  REQUIRE(approxEqual(traj.atBar(2).getMae(), D(1.0)));
+  REQUIRE(approxEqual(traj.atBar(3).getMfe(), D(5.0)));
+  REQUIRE(approxEqual(traj.atBar(3).getMae(), D(2.0)));
+  REQUIRE(approxEqual(traj.atBar(4).getMfe(), D(5.0)));
+  REQUIRE(approxEqual(traj.atBar(4).getMae(), D(5.0)));
+}
+
+TEST_CASE("ExcursionTrajectory: bar-by-bar values for a short position",
+          "[excursion_trajectory]")
+{
+  // Entry 100 short. Bar 2: H=101, L=98. Bar 3: H=103, L=97. Bar 4: H=102, L=94.
+  // Running HWM: 100 -> 101 -> 103 -> 103
+  // Running LWM: 100 ->  98 ->  97 ->  94
+  // Short MFE (distance below entry) at bars 2,3,4: 2.0, 3.0, 6.0
+  // Short MAE (distance above entry) at bars 2,3,4: 1.0, 3.0, 3.0
+  ShortTradeScript s{
+    date(2024, 1, 1), 100.0, 100.0, 100.0,
+    {
+      std::make_tuple(100.0, 101.0,  98.0,  99.0),
+      std::make_tuple( 99.0, 103.0,  97.0, 100.0),
+      std::make_tuple(100.0, 102.0,  94.0,  95.0)
+    },
+    date(2024, 1, 5), 95.0
+  };
+  auto pos = buildClosedShort(s);
+  ExcursionTrajectory<DecimalType> traj(*pos);
+
+  REQUIRE(traj.size() == 4);
+  REQUIRE(approxEqual(traj.atBar(2).getMfe(), D(2.0)));
+  REQUIRE(approxEqual(traj.atBar(2).getMae(), D(1.0)));
+  REQUIRE(approxEqual(traj.atBar(3).getMfe(), D(3.0)));
+  REQUIRE(approxEqual(traj.atBar(3).getMae(), D(3.0)));
+  REQUIRE(approxEqual(traj.atBar(4).getMfe(), D(6.0)));
+  REQUIRE(approxEqual(traj.atBar(4).getMae(), D(3.0)));
+}
+
+TEST_CASE("ExcursionTrajectory: at() and atBar() agree",
+          "[excursion_trajectory]")
+{
+  LongTradeScript s{
+    date(2024, 1, 1), 100.0, 100.0, 100.0,
+    {
+      std::make_tuple(100.0, 101.0, 99.0, 100.0),
+      std::make_tuple(100.0, 103.0, 98.0, 101.0)
+    },
+    date(2024, 1, 3), 101.0
+  };
+  auto pos = buildClosedLong(s);
+  ExcursionTrajectory<DecimalType> traj(*pos);
+
+  for (size_t i = 0; i < traj.size(); ++i)
+  {
+    REQUIRE(traj.at(i) == traj.atBar(static_cast<unsigned int>(i + 1)));
+  }
+}
+
+TEST_CASE("ExcursionTrajectory: at() and atBar() out-of-range throw",
+          "[excursion_trajectory]")
+{
+  LongTradeScript s{
+    date(2024, 1, 1), 100.0, 100.0, 100.0,
+    { std::make_tuple(100.0, 101.0, 99.0, 100.0) },
+    date(2024, 1, 2), 100.0
+  };
+  auto pos = buildClosedLong(s);
+  ExcursionTrajectory<DecimalType> traj(*pos);
+
+  REQUIRE_THROWS_AS(traj.at(traj.size()), std::out_of_range);
+  REQUIRE_THROWS_AS(traj.atBar(0), std::out_of_range);
+  REQUIRE_THROWS_AS(traj.atBar(static_cast<unsigned int>(traj.size() + 1)),
+                    std::out_of_range);
+}
+
+
+// ============================================================================
+// 5. ExcursionTrajectory invariants
+// ============================================================================
+
+TEST_CASE("ExcursionTrajectory: running MFE and MAE are monotonically non-decreasing",
+          "[excursion_trajectory][invariants]")
+{
+  // Deliberately choppy price action to stress the invariant.
+  LongTradeScript s{
+    date(2024, 1, 1), 100.0, 100.0, 100.0,
+    {
+      std::make_tuple(100.0, 101.0,  99.0, 100.0),
+      std::make_tuple(100.0, 104.0,  96.0,  98.0),
+      std::make_tuple( 98.0, 102.0,  97.0, 100.0),   // no new extreme on either side
+      std::make_tuple(100.0, 107.0,  93.0,  94.0),
+      std::make_tuple( 94.0,  96.0,  92.0,  95.0)
+    },
+    date(2024, 1, 7), 95.0
+  };
+  auto pos = buildClosedLong(s);
+  ExcursionTrajectory<DecimalType> traj(*pos);
+
+  REQUIRE(traj.size() >= 2);
+  for (size_t i = 1; i < traj.size(); ++i)
+  {
+    REQUIRE(traj.at(i).getMfe() >= traj.at(i - 1).getMfe());
+    REQUIRE(traj.at(i).getMae() >= traj.at(i - 1).getMae());
+  }
+}
+
+
+// ============================================================================
+// 6. Terminal values agree with TradingPosition accessors
+// ============================================================================
+
+TEST_CASE("ExcursionTrajectory: terminal values agree with TradingPosition accessors",
+          "[excursion_trajectory][agreement]")
+{
+  SECTION("long position")
+  {
+    LongTradeScript s{
+      date(2024, 1, 1), 100.0, 100.0, 100.0,
+      {
+        std::make_tuple(100.0, 105.0, 99.0, 104.0),
+        std::make_tuple(103.0, 103.0, 97.0, 102.0)
+      },
+      date(2024, 1, 3), 102.0
+    };
+    auto pos = buildClosedLong(s);
+    ExcursionTrajectory<DecimalType> traj(*pos);
+
+    REQUIRE(approxEqual(traj.terminalMfe(), pos->getMaxFavorableExcursion()));
+    REQUIRE(approxEqual(traj.terminalMae(), pos->getMaxAdverseExcursion()));
+  }
+
+  SECTION("short position")
+  {
+    ShortTradeScript s{
+      date(2024, 2, 1), 100.0, 100.0, 100.0,
+      {
+        std::make_tuple(100.0, 101.0, 95.0, 96.0),
+        std::make_tuple( 98.0, 103.0, 97.0, 98.0)
+      },
+      date(2024, 2, 3), 98.0
+    };
+    auto pos = buildClosedShort(s);
+    ExcursionTrajectory<DecimalType> traj(*pos);
+
+    REQUIRE(approxEqual(traj.terminalMfe(), pos->getMaxFavorableExcursion()));
+    REQUIRE(approxEqual(traj.terminalMae(), pos->getMaxAdverseExcursion()));
+  }
+}
+
+
+// ============================================================================
+// 7. Threshold queries
+// ============================================================================
+
+TEST_CASE("ExcursionTrajectory: firstBarWhereMfeExceeds semantics",
+          "[excursion_trajectory][threshold]")
+{
+  // MFE trajectory: 0.0, 2.0, 5.0, 5.0 (computed earlier test case).
+  LongTradeScript s{
+    date(2024, 1, 1), 100.0, 100.0, 100.0,
+    {
+      std::make_tuple(100.0, 102.0,  99.0, 101.0),
+      std::make_tuple(101.0, 105.0,  98.0, 100.0),
+      std::make_tuple(100.0, 104.0,  95.0,  96.0)
+    },
+    date(2024, 1, 5), 96.0
+  };
+  auto pos = buildClosedLong(s);
+  ExcursionTrajectory<DecimalType> traj(*pos);
+
+  SECTION("threshold never exceeded returns 0")
+  {
+    REQUIRE(traj.firstBarWhereMfeExceeds(D(10.0)) == 0);
+  }
+  SECTION("strict > semantics: threshold equal to MFE does not count")
+  {
+    // bar 3 MFE == 5.0 exactly; threshold 5.0 should not be considered exceeded
+    REQUIRE(traj.firstBarWhereMfeExceeds(D(5.0)) == 0);
+  }
+  SECTION("threshold below first non-zero MFE returns first such bar")
+  {
+    REQUIRE(traj.firstBarWhereMfeExceeds(D(1.0)) == 2);
+  }
+  SECTION("threshold between bar 2 and bar 3 MFE returns bar 3")
+  {
+    REQUIRE(traj.firstBarWhereMfeExceeds(D(3.0)) == 3);
+  }
+  SECTION("threshold of zero returns the first bar with any MFE")
+  {
+    REQUIRE(traj.firstBarWhereMfeExceeds(DecimalConstants<DecimalType>::DecimalZero) == 2);
+  }
+}
+
+TEST_CASE("ExcursionTrajectory: firstBarWhereMaeExceeds semantics",
+          "[excursion_trajectory][threshold]")
+{
+  // MAE trajectory: 0.0, 1.0, 2.0, 5.0.
+  LongTradeScript s{
+    date(2024, 1, 1), 100.0, 100.0, 100.0,
+    {
+      std::make_tuple(100.0, 102.0,  99.0, 101.0),
+      std::make_tuple(101.0, 105.0,  98.0, 100.0),
+      std::make_tuple(100.0, 104.0,  95.0,  96.0)
+    },
+    date(2024, 1, 5), 96.0
+  };
+  auto pos = buildClosedLong(s);
+  ExcursionTrajectory<DecimalType> traj(*pos);
+
+  REQUIRE(traj.firstBarWhereMaeExceeds(D(10.0)) == 0);
+  REQUIRE(traj.firstBarWhereMaeExceeds(D(5.0))  == 0); // strict
+  REQUIRE(traj.firstBarWhereMaeExceeds(D(0.5))  == 2);
+  REQUIRE(traj.firstBarWhereMaeExceeds(D(1.5))  == 3);
+  REQUIRE(traj.firstBarWhereMaeExceeds(D(4.0))  == 4);
+}
+
+
+// ============================================================================
+// 8. Trajectory on an open (not yet closed) position
+// ============================================================================
+
+TEST_CASE("ExcursionTrajectory: can be built from an open position",
+          "[excursion_trajectory][open_position]")
+{
+  // The MFE-conditional exit-rule extension (Phase 2, if adopted) needs
+  // trajectory access during a trade, not only after close. Verify that
+  // the capability works before ClosePosition is called.
+  auto entryBar = makeBar(date(2024, 1, 1), 100.0, 100.0, 100.0, 100.0);
+  auto pos = std::make_shared<TradingPositionLong<DecimalType>>(
+      std::string("TEST"), D(100.0), entryBar, oneShare());
+  pos->addBar(makeBar(date(2024, 1, 2), 100.0, 102.0, 99.0, 101.0));
+  pos->addBar(makeBar(date(2024, 1, 3), 101.0, 105.0, 98.0, 104.0));
+
+  REQUIRE(pos->isPositionOpen());
+
+  ExcursionTrajectory<DecimalType> traj(*pos);
+  REQUIRE(traj.size() == 3);
+  REQUIRE(approxEqual(traj.atBar(3).getMfe(), D(5.0)));
+  REQUIRE(approxEqual(traj.atBar(3).getMae(), D(2.0)));
+  REQUIRE(approxEqual(traj.terminalMfe(), pos->getMaxFavorableExcursion()));
+  REQUIRE(approxEqual(traj.terminalMae(), pos->getMaxAdverseExcursion()));
+}


### PR DESCRIPTION
Add MFE/MAE Tracking
 
## Summary
 
This PR adds first-class **Maximum Favorable Excursion (MFE)** and **Maximum Adverse Excursion (MAE)** tracking to the `TradingPosition` class hierarchy in `libs/backtesting`, plus a supporting `ExcursionTrajectory` capability for per-bar trajectory analysis. It also introduces a comprehensive Catch2 test suite covering the new functionality.
 
This is **Phase 1 of 2** for the holding period optimization initiative. Phase 1 delivers a reusable library capability with no behavioral changes to existing code paths. Phase 2 (separate PR, not yet open) will use this capability to derive an empirically-validated holding period recommendation for the metastrategy.
 
## Motivation
 
Our short-term anomaly-based strategies have a default maximum holding period of 8 bars, but 85–90% of trades exit via profit target or stop loss within the first 2–3 bars. The remaining 10–15% — trades that neither confirm nor invalidate within the typical resolution window — are heterogeneous: some are slow winners that would reach the profit target with more time, while others are dying signals that bleed toward the stop loss. A fixed holding period of 8 treats both cases identically.
 
To distinguish between these populations and recommend a better holding period, we need bar-by-bar MFE and MAE for every trade. The `TradingPosition` class already preserves the OHLC bar history of every position via `OpenPositionHistory`, so the data is available — but no first-class accessor exposes the running excursions either at terminal or per-bar granularity. This PR adds that.
 
MFE and MAE are also useful beyond the holding period study: any future analysis, risk report, or strategy diagnostic can now consume them through the standard position interface.
 
## Design Approach
 
The design was developed through iterative review and is documented in full at `docs/holding_period_optimization_design.md` (added in this PR or a sibling, depending on team preference). Key design decisions reflected in the code:
 
### Integrated tracking, not post-hoc reconstruction
 
Two implementation paths were considered:
 
1. **Post-hoc analyzer** — write a utility that iterates `OpenPositionHistory` after the fact and computes MFE/MAE.
2. **Integrated incremental tracking** — add water-mark members on `OpenPosition` updated in `addBar`.
Path 2 was chosen because MFE/MAE are fundamental trade-level metrics that conceptually belong on the position alongside entry price, exit price, and R-multiple — and because any future state-dependent exit rule (a Phase 2 extension under consideration) requires O(1) in-trade access that a post-hoc approach cannot provide. The hot-path cost is two `Decimal` comparisons per bar, which is negligible against the existing per-bar work.
 
### Purist first-bar convention
 
Water marks are initialized to the entry price rather than to the entry bar's High/Low. The rationale is that an entry filling at a limit price mid-bar cannot have participated in the entry bar's pre-entry price action; starting from the entry price means only post-entry bars contribute to MFE/MAE. This is a conservative bias (slightly understates MFE/MAE in the rare case where a trade resolves on the entry bar itself) and is documented in the header comments.
 
### Direction-specific interpretation in the state hierarchy
 
`OpenPosition` stores direction-agnostic raw price extremes (`mHighWaterMark`, `mLowWaterMark`). The favorable/adverse interpretation is implemented in the long/short specializations — `OpenLongPosition` treats high water mark as favorable, `OpenShortPosition` treats low water mark as favorable — following the same pattern used elsewhere in the file (e.g., `getTradeReturn`).
 
### Separate header for trajectory analysis
 
`ExcursionTrajectoryPoint` and `ExcursionTrajectory` live in a new header (`ExcursionTrajectory.h`) rather than being added to `TradingPosition.h`. Reasons: keeps the already-large `TradingPosition.h` from growing further, lets callers who only need terminal MFE/MAE avoid the include, and isolates the trajectory analytics behind a single import for callers that want them.
 
### Strict greater-than semantics for threshold queries
 
`firstBarWhereMfeExceeds` and `firstBarWhereMaeExceeds` use strict `>`, not `>=`. A threshold equal to a trajectory value is not considered exceeded. This is documented in the header and pinned by tests.
 
## What Changed
 
### `libs/backtesting/TradingPosition.h` (modified)
 
All edits are additive. No existing public method was removed or had its signature changed.
 
**`TradingPositionState<Decimal>`** — two new pure virtual methods:
```cpp
virtual Decimal getMaxFavorableExcursion() const = 0;
virtual Decimal getMaxAdverseExcursion()  const = 0;
```
 
**`OpenPosition<Decimal>`** — two new private members initialized to the entry price; two new public const accessors; `addBar` updated to maintain water marks:
```cpp
Decimal mHighWaterMark;
Decimal mLowWaterMark;
const Decimal& getHighWaterMark() const;
const Decimal& getLowWaterMark()  const;
```
 
**`OpenLongPosition<Decimal>`** and **`OpenShortPosition<Decimal>`** — each implements `getMaxFavorableExcursion` and `getMaxAdverseExcursion` with direction-appropriate water mark and percent-of-entry calculation. Returns are non-negative (zero when no favorable/adverse move has occurred).
 
**`ClosedPosition<Decimal>`** — adds both methods, delegating to `mOpenPosition->getMaxFavorableExcursion()` / `getMaxAdverseExcursion()`. Direction is resolved polymorphically through the stored open-position state.
 
**`TradingPosition<Decimal>`** — adds public forwarding methods:
```cpp
Decimal getMaxFavorableExcursion() const;
Decimal getMaxAdverseExcursion()  const;
```
 
### `libs/backtesting/ExcursionTrajectory.h` (new)
 
Two cooperating classes in the `mkc_timeseries` namespace:
 
**`ExcursionTrajectoryPoint<Decimal>`** — immutable value object carrying `(barNumber, barDateTime, mfe, mae)`. Construction validates `barNumber >= 1` and non-negative MFE/MAE; violations throw `TradingPositionException`. Defaulted copy/move semantics; equality and inequality operators following the project's `OpenPositionBar` pattern.
 
**`ExcursionTrajectory<Decimal>`** — eagerly constructed from a `TradingPosition` by iterating its bar history. Construction is O(N) in bar count; queries are O(1) for indexed access and O(N) for threshold scans. Works for both open and closed positions, since the underlying bar history is preserved across the open→closed transition. API:
 
- Structural access: `size()`, `empty()`, `begin()`, `end()`
- Indexed access: `at(index)` (0-indexed) and `atBar(barNumber)` (1-indexed); both throw `std::out_of_range` on invalid input
- Terminal values: `terminalMfe()`, `terminalMae()` — agree with the position's own accessors
- Threshold queries: `firstBarWhereMfeExceeds(threshold)`, `firstBarWhereMaeExceeds(threshold)` — return the bar number of the first point strictly exceeding the threshold, or 0 if never exceeded
Running MFE and MAE are monotonically non-decreasing across the trajectory by construction. Under the purist convention, the trajectory point at bar 1 always has `MFE = MAE = 0`.
 
### `libs/backtesting/test/ExcursionTest.cpp` (new)
 
Comprehensive Catch2 test suite covering:
 
- Terminal MFE/MAE on long winning and losing trades, short winning and losing trades, the "dip first then rally" case (verifies MAE captures the dip even though the trade closes winning), and the close-on-entry-bar case (verifies the purist convention produces zero MFE and MAE).
- `ExcursionTrajectoryPoint` construction validation: rejects `barNumber == 0`, rejects negative MFE, rejects negative MAE; accepts zero values; equality and inequality operators.
- `ExcursionTrajectory` bar-by-bar values for both long and short positions with hand-computed expected values; agreement of `at` and `atBar`; out-of-range throws; monotonicity invariant under choppy price action; agreement between `terminalMfe`/`terminalMae` and the position's own accessors; threshold query semantics including the strict `>` boundary case; construction from an open (not yet closed) position.
A small `ADAPTATION NOTE` block at the top of the test file isolates the project-specific helpers (`D(double)` for decimal construction via `num::fromString`, `makeBar(...)` for `OHLCTimeSeriesEntry` construction, `oneShare()` for `TradingVolume`).
 
## Performance Impact
 
Hot-path cost added: two `Decimal` comparisons and up to two assignments per `addBar` call. This is negligible against the existing per-bar work (map insertion, counter updates, return recalculation).
 
The new `ExcursionTrajectory` class is invoked only on demand by analysis code; it has no impact on the backtester loop unless a caller explicitly constructs it.
 
## Backward Compatibility
 
Source-level ABI compatible for all existing callers. The public interface of `TradingPosition`, `OpenPosition`, and the closed/open state classes gains new methods but loses none. Serialization, persistence, copy/move semantics, and external callers are unaffected. Existing unit tests pass without modification.
 
## Testing
 
- All new unit tests pass locally.
- Existing backtester unit test suite passes without modification.
- Hand-traced expected values for every bar-by-bar test against the water-mark update rules and the direction-specific interpretation.
## Files Changed
 
| File | Status | Notes |
|------|--------|-------|
| `libs/backtesting/TradingPosition.h` | Modified | Additive: water marks, MFE/MAE accessors, virtual methods |
| `libs/backtesting/ExcursionTrajectory.h` | New | Trajectory point and trajectory classes |
| `libs/backtesting/test/ExcursionTest.cpp` | New | Catch2 unit tests |
 
## Phase 2 Preview
 
Phase 2 (separate PR) will use the capabilities delivered here to:
 
1. Replay all 7000+ data-miner candidate patterns on in-sample data with an unconstrained holding period and dump per-bar MFE/MAE trajectories.
2. Pool trajectories across patterns and compute conditional expected terminal PnL by bar — the signal-decay curve.
3. Recommend a global holding period (the bar where marginal expected PnL crosses zero) as a drop-in replacement for the current default of 8.
4. Validate the recommendation by re-running the metastrategy on out-of-sample data of the 50–100 surviving patterns under both the new HP and the baseline of 8, with block-bootstrap confidence intervals.
The full design rationale, including the IS/OOS contamination analysis, the rationale for using all 7000+ candidates rather than only survivors, and the discussion of how this preserves the framework's "no free parameters per pattern" property, is documented in the design document referenced above.